### PR TITLE
Enforce python 3.6 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,11 @@
 
 from setuptools import setup
 from setuptools import find_packages
+import sys
 import re
 
+if sys.version_info < (3, 6):
+    sys.exit('Sorry, Python < 3.6 is not supported')
 
 def find_version():
     return re.search(r"^__version__ = '(.*)'$",
@@ -12,6 +15,7 @@ def find_version():
 
 
 setup(name='cantools',
+      python_requires='>3.6.0',
       version=find_version(),
       description='CAN BUS tools.',
       long_description=open('README.rst', 'r').read(),


### PR DESCRIPTION
This PR adds some checks and an error message to `setup.py` to help users identify packaging problems if they are using Ubuntu Xenial (defaults to 3.5.2).

Without this error message, users on xenial will get syntax errors from `argparse-addons` with no clear indication that `cantools` is actually the problem.

The most elegant solution would be simply the addition of `python_requires`. Unfortunately, `python3-pip` also pins to version 8.1.1, so `python_requires` is also not supported by the xenial `pip`.  Therefore, I also had to add the somewhat ugly`sys` error mechanism.

I tested this with a `ubuntu:16.04` docker image and also on ubuntu 20.04.  Attempts to install `cantools` on 16.04 results in a much better error message, while the 20.04 installation succeeds as usual.