### PR TITLE
ARXML: always pretend to be version 4.0 for AR4

### DIFF
--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -522,10 +522,11 @@ class SystemLoader(object):
                 return None
 
             literal_spec = \
-                self._follow_arxml_reference(base_elem=signal_elem,
-                                             arxml_path=ref_elem.text,
-                                             dest_tag_name=ref_elem.attrib.get('DEST'),
-                                             refbase_name=ref_elem.attrib.get('BASE'))
+                self._follow_arxml_reference(
+                    base_elem=signal_elem,
+                    arxml_path=ref_elem.text,
+                    dest_tag_name=ref_elem.attrib.get('DEST'),
+                    refbase_name=ref_elem.attrib.get('BASE'))
             if literal_spec is None:
                 # dangling reference...
                 return None
@@ -817,7 +818,11 @@ class SystemLoader(object):
 
         return is_signed, is_float
 
-    def _follow_arxml_reference(self, base_elem, arxml_path, dest_tag_name=None, refbase_name=None):
+    def _follow_arxml_reference(self,
+                                base_elem,
+                                arxml_path,
+                                dest_tag_name=None,
+                                refbase_name=None):
         """Resolve an ARXML reference
 
         It returns the ElementTree node which corresponds to the given
@@ -840,7 +845,8 @@ class SystemLoader(object):
             for i in range(len(base_path), 0, -1):
                 test_path = '/'.join(base_path[0:i])
                 test_node = self._arxml_path_to_node.get(test_path)
-                if test_node is not None and test_node.tag  != f'{{{self.xml_namespace}}}AR-PACKAGE':
+                if test_node is not None \
+                   and test_node.tag  != f'{{{self.xml_namespace}}}AR-PACKAGE':
                     # the referenced XML node does not represent a
                     # package
                     continue
@@ -849,7 +855,8 @@ class SystemLoader(object):
                     # the caller did not specify a BASE attribute,
                     # i.e., we ought to use the closest default
                     # reference base
-                    refbase_path = self._package_default_refbase_path.get(test_path)
+                    refbase_path = \
+                        self._package_default_refbase_path.get(test_path)
                     if refbase_path is None:
                         # bad luck: this package does not specify a
                         # default reference base
@@ -858,7 +865,9 @@ class SystemLoader(object):
                         break
 
                 # the caller specifies a BASE attribute
-                refbase_path = self._package_refbase_paths.get(test_path, {}).get(refbase_name)
+                refbase_path = \
+                    self._package_refbase_paths.get(test_path, {}) \
+                                               .get(refbase_name)
                 if refbase_path is None:
                     # bad luck: this package does not specify a
                     # reference base with the specified name
@@ -867,7 +876,8 @@ class SystemLoader(object):
                     break
 
             if refbase_path is None:
-                raise ValueError(f"Unknown reference base '{refbase_name}' for relative ARXML reference '{arxml_path}'")
+                raise ValueError(f"Unknown reference base '{refbase_name}' "
+                                 f"for relative ARXML reference '{arxml_path}'")
 
             arxml_path = f'{refbase_path}/{arxml_path}'
 
@@ -927,18 +937,26 @@ class SystemLoader(object):
                                          self._xml_namespaces).text.strip()
 
                 is_default = elem.find('./ns:IS-DEFAULT', self._xml_namespaces)
+
                 if is_default is not None:
                     is_default = (is_default.text.strip().lower() == "true")
-                if is_default and self._package_default_refbase_path.get(cur_package_path) is not None:
-                    raise ValueError(f'Multiple default reference bases bases '
-                                     f'specified for package "{cur_package_path}".')
-                elif is_default:
-                    self._package_default_refbase_path[cur_package_path] = refbase_path
 
+                current_default_refbase_path = \
+                    self._package_default_refbase_path.get(cur_package_path)
+
+                if is_default and current_default_refbase_path is not None:
+                    raise ValueError(f'Multiple default reference bases bases '
+                                     f'specified for package '
+                                     f'"{cur_package_path}".')
+                elif is_default:
+                    self._package_default_refbase_path[cur_package_path] = \
+                        refbase_path
 
                 is_global = elem.find('./ns:IS-GLOBAL', self._xml_namespaces)
+
                 if is_global is not None:
                     is_global = (is_global.text.strip().lower() == "true")
+
                 if is_global:
                     raise ValueError(f'Non-canonical relative references are '
                                      f'not yet supported.')
@@ -946,7 +964,8 @@ class SystemLoader(object):
                 # ensure that a dictionary for the refbases of the package exists
                 if cur_package_path not in self._package_refbase_paths:
                     self._package_refbase_paths[cur_package_path] = {}
-                elif refbase_name in self._package_refbase_paths[cur_package_path]:
+                elif refbase_name in \
+                     self._package_refbase_paths[cur_package_path]:
                     raise ValueError(f'Package "{cur_package_path}" specifies '
                                      f'multiple reference bases named '
                                      f'"{refbase_name}".')

--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -45,7 +45,16 @@ class SystemLoader(object):
                      xml_namespace)
 
         if m:
-            # AUTOSAR 4
+            # AUTOSAR 4: For some reason, all AR 4 revisions always
+            # use "http://autosar.org/schema/r4.0" as their XML
+            # namespace. To find out the exact revision used (i.e.,
+            # 4.0, 4.1, 4.2, ...), the "xsi:schemaLocation" attribute
+            # of the root tag needs to be examined. Since this is
+            # pretty fragile (the used naming scheme has changed
+            # during the AR4 journey and with the latest naming scheme
+            # there seems to be no programmatic way to associate the
+            # schemaLocation with the AR revision), we pretend to
+            # always use AR 4.0...
             autosar_version_string = m.group(1)
 
         else:

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<AUTOSAR xsi:schemaLocation="http://autosar.org/schema/r4.2.1 AUTOSAR_00046.xsd" xmlns="http://autosar.org/schema/r4.2.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<AUTOSAR xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00046.xsd" xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <AR-PACKAGES>
     <AR-PACKAGE UUID="4f17ec0cd204bc161e791f669540c652">
       <SHORT-NAME>Cluster</SHORT-NAME>

--- a/tests/files/arxml/system-illegal-namespace-4.2.arxml
+++ b/tests/files/arxml/system-illegal-namespace-4.2.arxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<AUTOSAR xsi:schemaLocation="http://autosar.org/schema/r4.2.1 AUTOSAR_00046.xsd" xmlns="http://autosar.org/schema/argh4.2.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<AUTOSAR xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00046.xsd" xmlns="http://autosar.org/schema/argh4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <AR-PACKAGES>
   </AR-PACKAGES>
 </AUTOSAR>

--- a/tests/files/arxml/system-illegal-root-4.2.arxml
+++ b/tests/files/arxml/system-illegal-root-4.2.arxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<AUTOSARGH xsi:schemaLocation="http://autosar.org/schema/r4.2.1 AUTOSAR_00046.xsd" xmlns="http://autosar.org/schema/r4.2.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<AUTOSARGH xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00046.xsd" xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <AR-PACKAGES>
   </AR-PACKAGES>
 </AUTOSARGH>

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4000,7 +4000,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         self.assertEqual(
             str(cm.exception),
-            'ARXML: "Unrecognized XML namespace \'http://autosar.org/schema/argh4.2.1\'"')
+            'ARXML: "Unrecognized XML namespace \'http://autosar.org/schema/argh4.0\'"')
 
         root = ElementTree.parse('tests/files/arxml/system-illegal-namespace-4.2.arxml').getroot()
         with self.assertRaises(ValueError) as cm:
@@ -4008,7 +4008,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         self.assertEqual(
             str(cm.exception),
-            'Unrecognized AUTOSAR XML namespace \'http://autosar.org/schema/argh4.2.1\'')
+            'Unrecognized AUTOSAR XML namespace \'http://autosar.org/schema/argh4.0\'')
 
     def test_illegal_root(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
@@ -4016,7 +4016,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         self.assertEqual(
             str(cm.exception),
-            'ARXML: "No XML namespace specified or illegal root tag name \'{http://autosar.org/schema/r4.2.1}AUTOSARGH\'"')
+            'ARXML: "No XML namespace specified or illegal root tag name \'{http://autosar.org/schema/r4.0}AUTOSARGH\'"')
 
         root = ElementTree.parse('tests/files/arxml/system-illegal-root-4.2.arxml').getroot()
         with self.assertRaises(ValueError) as cm:
@@ -4024,7 +4024,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         self.assertEqual(
             str(cm.exception),
-            'No XML namespace specified or illegal root tag name \'{http://autosar.org/schema/r4.2.1}AUTOSARGH\'')
+            'No XML namespace specified or illegal root tag name \'{http://autosar.org/schema/r4.0}AUTOSARGH\'')
 
     def test_illegal_version(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
@@ -4042,13 +4042,11 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(loader.autosar_version_newer(4), True)
         self.assertEqual(loader.autosar_version_newer(5), False)
 
-        self.assertEqual(loader.autosar_version_newer(4, 1), True)
-        self.assertEqual(loader.autosar_version_newer(4, 2), True)
+        # for AUTOSAR 4, we always pretend to be version 4.0
+        self.assertEqual(loader.autosar_version_newer(4, 0), True)
+        self.assertEqual(loader.autosar_version_newer(4, 1), False)
+        self.assertEqual(loader.autosar_version_newer(4, 2), False)
         self.assertEqual(loader.autosar_version_newer(4, 3), False)
-
-        self.assertEqual(loader.autosar_version_newer(4, 2, 0), True)
-        self.assertEqual(loader.autosar_version_newer(4, 2, 1), True)
-        self.assertEqual(loader.autosar_version_newer(4, 2, 2), False)
 
     def test_DAI_namespace(self):
         db = cantools.db.load_file('tests/files/arxml/system-DAI-3.1.2.arxml')


### PR DESCRIPTION
For some reason, all AR 4 revisions always use "http://autosar.org/schema/r4.0" as their XML namespace. To find out the exact AUTOSAR revision (i.e., 4.0, 4.1, 4.2, ...), the "xsi:schemaLocation" attribute of the root tag needs to be examined. Since this is pretty fragile (the used naming scheme has changed during the AR4 journey and with the latest naming scheme there seems to be no programmatic way to associate the value of schemaLocation with the AR revision), we pretend to always use AR 4.0. If incompatible changes between AR4 revisions are encountered in the future, it can be supported by implementing all posibilities and backtracking if necessary.

Andreas Lauser &lt;<andreas.lauser@daimler.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)