### PR TITLE
 Add objects for representing autosar specifics

### DIFF
--- a/cantools/database/can/database.py
+++ b/cantools/database/can/database.py
@@ -31,6 +31,7 @@ class Database(object):
                  buses=None,
                  version=None,
                  dbc_specifics=None,
+                 autosar_specifics=None,
                  frame_id_mask=None,
                  strict=True):
         self._messages = messages if messages else []
@@ -40,6 +41,7 @@ class Database(object):
         self._frame_id_to_message = {}
         self._version = version
         self._dbc = dbc_specifics
+        self._autosar = autosar_specifics
 
         if frame_id_mask is None:
             frame_id_mask = 0xffffffff
@@ -100,6 +102,18 @@ class Database(object):
     def dbc(self, value):
         self._dbc = value
 
+    @property
+    def autosar(self):
+        """An object containing AUTOSAR specific properties like e.g. attributes.
+
+        """
+
+        return self._autosar
+
+    @autosar.setter
+    def autosar(self, value):
+        self._autosar = value
+
     def add_arxml(self, fp):
         """Read and parse ARXML data from given file-like object and add the
         parsed data to the database.
@@ -132,6 +146,7 @@ class Database(object):
         self._buses = database.buses
         self._version = database.version
         self._dbc = database.dbc
+        self._autosar = database.autosar
         self.refresh()
 
     def add_dbc(self, fp):

--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -31,7 +31,18 @@ class AutosarMessageSpecifics(object):
     """
 
     def __init__(self):
-        pass
+        self._pdu_paths = []
+
+    @property
+    def pdu_paths(self):
+        """The ARXML paths of all PDUs featured by this message.
+
+        For the vast majority of messages, this list only has a single
+        entry. Messages with multiplexers and container frames are
+        different, though.
+        """
+        return self._pdu_paths
+
 
 
 def parse_int_string(in_string):
@@ -261,14 +272,17 @@ class SystemLoader(object):
 
         # ToDo: senders
 
-        # For "sane" bus systems like CAN or LIN, there ought to be
-        # only a single PDU per frame. AUTOSAR also supports "insane"
-        # bus systems like flexray, though...
+        # Usually, a CAN message contains only a single PDU, but for
+        # things like multiplexed and container messages, this is not
+        # the case...
         pdu = self._get_pdu(can_frame)
         assert pdu is not None
+        pdu_path = self._get_pdu_path(can_frame)
+        autosar_specifics._pdu_paths.append(pdu_path)
 
-        _, _, signals, cycle_time = \
+        _, _, signals, cycle_time, child_pdu_paths = \
             self._load_pdu(pdu, name, 1)
+        autosar_specifics._pdu_paths.extend(child_pdu_paths)
 
         return Message(frame_id=frame_id,
                        is_extended_frame=is_extended_frame,
@@ -285,8 +299,9 @@ class SystemLoader(object):
 
 
     def _load_pdu(self, pdu, frame_name, next_selector_idx):
-        # Find all signals in this PDU.
+        # load all data associated with this PDU.
         signals = []
+        child_pdu_paths = []
 
         bit_length = self._get_unique_arxml_child(pdu, 'LENGTH')
         if bit_length is not None:
@@ -322,17 +337,20 @@ class SystemLoader(object):
 
         if pdu.tag == f'{{{self.xml_namespace}}}MULTIPLEXED-I-PDU':
             # multiplexed signals
-            signals.extend(self._load_pdu_multiplexed_parts(pdu,
-                                                            frame_name,
-                                                            next_selector_idx))
+            pdu_signals, child_pdu_paths = \
+                self._load_multiplexed_pdu(pdu, frame_name, next_selector_idx)
+            signals.extend(pdu_signals)
 
         return \
             next_selector_idx, \
             bit_length, \
             signals, \
-            cycle_time
+            cycle_time, \
+            child_pdu_paths
 
-    def _load_pdu_multiplexed_parts(self, pdu, frame_name, next_selector_idx):
+    def _load_multiplexed_pdu(self, pdu, frame_name, next_selector_idx):
+        child_pdu_paths = []
+
         selector_pos = \
             self._get_unique_arxml_child(pdu, 'SELECTOR-FIELD-START-POSITION')
         selector_pos = parse_int_string(selector_pos.text)
@@ -383,12 +401,20 @@ class SystemLoader(object):
                 self._get_unique_arxml_child(dynalt, 'SELECTOR-FIELD-CODE')
             dynalt_selector_value = parse_int_string(dynalt_selector_value.text)
             dynalt_pdu = self._get_unique_arxml_child(dynalt, '&I-PDU')
+            dynalt_pdu_ref = self._get_unique_arxml_child(dynalt, 'I-PDU-REF')
+            dynalt_pdu_ref = \
+                self._get_absolute_arxml_path(dynalt,
+                                              dynalt_pdu_ref.text,
+                                              dynalt_pdu_ref.attrib.get('BASE'))
+            child_pdu_paths.append(dynalt_pdu_ref)
 
             next_selector_idx, \
                 dynalt_bit_length, \
                 dynalt_signals, \
-                dynalt_cycle_time \
+                dynalt_cycle_time, \
+                dynalt_child_pdu_paths \
                 = self._load_pdu(dynalt_pdu, frame_name, next_selector_idx)
+            child_pdu_paths.extend(dynalt_child_pdu_paths)
 
             is_initial = \
                 self._get_unique_arxml_child(dynalt, 'INITIAL-DYNAMIC-PART')
@@ -426,31 +452,46 @@ class SystemLoader(object):
             signals.extend(dynalt_signals)
 
             # TODO: the cycle time of the multiplexers can be
-            # specified indepently. how should this be handled?
+            # specified indepently of that of the message. how should
+            # this be handled?
 
         # the static part of the multiplexed PDU
         if self.autosar_version_newer(4):
-            static_pdus_spec = [
+            static_pdu_refs_spec = [
                 'STATIC-PARTS',
                 '*STATIC-PART',
-                '&I-PDU',
+                'I-PDU-REF',
             ]
         else:
-            static_pdus_spec = [
+            static_pdu_refs_spec = [
                 'STATIC-PART',
-                '&I-PDU',
+                'I-PDU-REF',
             ]
 
-        for static_pdu in self._get_arxml_children(pdu, static_pdus_spec):
+        for static_pdu_ref in self._get_arxml_children(pdu,
+                                                       static_pdu_refs_spec):
+            static_pdu_path = \
+                self._get_absolute_arxml_path(pdu,
+                                              static_pdu_ref.text,
+                                              static_pdu_ref.attrib.get('BASE'))
+            child_pdu_paths.append(static_pdu_path)
+
+            static_pdu = self._follow_arxml_reference(
+                base_elem=pdu,
+                arxml_path=static_pdu_path,
+                dest_tag_name=static_pdu_ref.attrib.get('DEST'))
+
             next_selector_idx, \
                 bit_length, \
                 static_signals, \
-                _ \
+                _, \
+                static_child_pdu_paths \
                 = self._load_pdu(static_pdu, frame_name, next_selector_idx)
 
+            child_pdu_paths.extend(static_child_pdu_paths)
             signals.extend(static_signals)
 
-        return signals
+        return signals, child_pdu_paths
 
     def _load_pdu_signals(self, pdu):
         signals = []
@@ -1041,6 +1082,68 @@ class SystemLoader(object):
 
         return is_signed, is_float
 
+    def _get_absolute_arxml_path(self,
+                                 base_elem,
+                                 arxml_path,
+                                 refbase_name=None):
+        """Return the absolute ARXML path of a reference
+
+        Relative ARXML paths are converted into absolute ones.
+        """
+
+        if arxml_path.startswith('/'):
+            # path is already absolute
+            return arxml_path
+
+        base_path = self._node_to_arxml_path[base_elem]
+        base_path_atoms = base_path.split("/")
+
+        # Find the absolute path specified by the applicable
+        # reference base. The spec says the matching reference
+        # base for the "closest" package should be used, so we
+        # traverse the ARXML path of the base element in reverse
+        # to find the first package with a matching reference
+        # base.
+        refbase_path = None
+        for i in range(len(base_path_atoms), 0, -1):
+            test_path = '/'.join(base_path_atoms[0:i])
+            test_node = self._arxml_path_to_node.get(test_path)
+            if test_node is not None \
+               and test_node.tag  != f'{{{self.xml_namespace}}}AR-PACKAGE':
+                # the referenced XML node does not represent a
+                # package
+                continue
+
+            if refbase_name is None:
+                # the caller did not specify a BASE attribute,
+                # i.e., we ought to use the closest default
+                # reference base
+                refbase_path = \
+                    self._package_default_refbase_path.get(test_path)
+                if refbase_path is None:
+                    # bad luck: this package does not specify a
+                    # default reference base
+                    continue
+                else:
+                    break
+
+            # the caller specifies a BASE attribute
+            refbase_path = \
+                self._package_refbase_paths.get(test_path, {}) \
+                                           .get(refbase_name)
+            if refbase_path is None:
+                # bad luck: this package does not specify a
+                # reference base with the specified name
+                continue
+            else:
+                break
+
+        if refbase_path is None:
+            raise ValueError(f"Unknown reference base '{refbase_name}' "
+                             f"for relative ARXML reference '{arxml_path}'")
+
+        return f'{refbase_path}/{arxml_path}'
+
     def _follow_arxml_reference(self,
                                 base_elem,
                                 arxml_path,
@@ -1053,56 +1156,10 @@ class SystemLoader(object):
         exists, a None object is returned.
         """
 
-        # Handle relative references by converting them into absolute
-        # ones
-        if not arxml_path.startswith("/"):
-            base_path = self._node_to_arxml_path[base_elem].split("/")
+        arxml_path = self._get_absolute_arxml_path(base_elem,
+                                                   arxml_path,
+                                                   refbase_name)
 
-            # Find the absolute path specified by the applicable
-            # reference base. The spec says the matching reference
-            # base for the "closest" package should be used, so we
-            # traverse the ARXML path of the base element in reverse
-            # to find the first package with a matching reference
-            # base.
-            refbase_path = None
-            for i in range(len(base_path), 0, -1):
-                test_path = '/'.join(base_path[0:i])
-                test_node = self._arxml_path_to_node.get(test_path)
-                if test_node is not None \
-                   and test_node.tag  != f'{{{self.xml_namespace}}}AR-PACKAGE':
-                    # the referenced XML node does not represent a
-                    # package
-                    continue
-
-                if refbase_name is None:
-                    # the caller did not specify a BASE attribute,
-                    # i.e., we ought to use the closest default
-                    # reference base
-                    refbase_path = \
-                        self._package_default_refbase_path.get(test_path)
-                    if refbase_path is None:
-                        # bad luck: this package does not specify a
-                        # default reference base
-                        continue
-                    else:
-                        break
-
-                # the caller specifies a BASE attribute
-                refbase_path = \
-                    self._package_refbase_paths.get(test_path, {}) \
-                                               .get(refbase_name)
-                if refbase_path is None:
-                    # bad luck: this package does not specify a
-                    # reference base with the specified name
-                    continue
-                else:
-                    break
-
-            if refbase_path is None:
-                raise ValueError(f"Unknown reference base '{refbase_name}' "
-                                 f"for relative ARXML reference '{arxml_path}'")
-
-            arxml_path = f'{refbase_path}/{arxml_path}'
 
         # resolve the absolute reference: This is simple because we
         # have a path -> XML node dictionary!
@@ -1343,6 +1400,20 @@ class SystemLoader(object):
                                                 '&PDU-TO-FRAME-MAPPING',
                                                 '&PDU'
                                             ])
+
+    def _get_pdu_path(self, can_frame):
+        pdu_ref = self._get_unique_arxml_child(can_frame,
+                                               [
+                                                   'PDU-TO-FRAME-MAPPINGS',
+                                                   '&PDU-TO-FRAME-MAPPING',
+                                                   'PDU-REF'
+                                               ])
+        if pdu_ref is not None:
+            pdu_ref = self._get_absolute_arxml_path(pdu_ref,
+                                                    pdu_ref.text,
+                                                    pdu_ref.attrib.get('BASE'))
+
+        return pdu_ref
 
     def _get_compu_method(self, system_signal):
         if self.autosar_version_newer(4):

--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -13,9 +13,29 @@ from ..internal_database import InternalDatabase
 
 LOGGER = logging.getLogger(__name__)
 
+class AutosarDatabaseSpecifics(object):
+    """This class collects the AUTOSAR specific information of a system
+
+    Message-specific AUTOSAR information is represented by the
+    AutosarMessageSpecifics.
+
+    """
+    def __init__(self):
+        pass
+
+class AutosarMessageSpecifics(object):
+    """This class collects all AUTOSAR specific information of a CAN message
+
+    This means useful information about CAN messages which is provided
+    by ARXML files, but is specific to AUTOSAR.
+    """
+
+    def __init__(self):
+        pass
+
+
 def parse_int_string(in_string):
     in_string = in_string.strip()
-
     if not in_string:
         return 0
     elif in_string[0] == '0' and in_string[1:2].isdigit():
@@ -136,6 +156,7 @@ class SystemLoader(object):
         buses = []
         messages = []
         version = None
+        autosar_specifics = AutosarDatabaseSpecifics()
 
         # recursively extract all CAN clusters of all AUTOSAR packages
         # in the XML tree
@@ -172,7 +193,8 @@ class SystemLoader(object):
         return InternalDatabase(messages,
                                 [],
                                 buses,
-                                version)
+                                version,
+                                autosar_specifics=autosar_specifics)
 
     def _load_package_contents(self, package_elem, messages):
         """This code extracts the information about CAN clusters of an
@@ -225,6 +247,7 @@ class SystemLoader(object):
         # Default values.
         cycle_time = None
         senders = []
+        autosar_specifics = AutosarMessageSpecifics()
 
         can_frame = self._get_can_frame(can_frame_triggering)
 
@@ -257,6 +280,7 @@ class SystemLoader(object):
                        signals=signals,
                        comment=comments,
                        bus_name=None,
+                       autosar_specifics=autosar_specifics,
                        strict=self._strict)
 
 

--- a/cantools/database/can/internal_database.py
+++ b/cantools/database/can/internal_database.py
@@ -10,9 +10,11 @@ class InternalDatabase(object):
                  nodes,
                  buses,
                  version,
-                 dbc_specifics=None):
+                 dbc_specifics=None,
+                 autosar_specifics=None):
         self.messages = messages
         self.nodes = nodes
         self.buses = buses
         self.version = version
         self.dbc = dbc_specifics
+        self.autosar = autosar_specifics

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -34,6 +34,7 @@ class Message(object):
                  send_type=None,
                  cycle_time=None,
                  dbc_specifics=None,
+                 autosar_specifics=None,
                  is_extended_frame=False,
                  bus_name=None,
                  signal_groups=None,
@@ -74,6 +75,7 @@ class Message(object):
         self._send_type = send_type
         self._cycle_time = cycle_time
         self._dbc = dbc_specifics
+        self._autosar = autosar_specifics
         self._bus_name = bus_name
         self._signal_groups = signal_groups
         self._codecs = None
@@ -295,6 +297,20 @@ class Message(object):
     @dbc.setter
     def dbc(self, value):
         self._dbc = value
+
+    @property
+    def autosar(self):
+        """An object containing AUTOsar specific properties
+
+        e.g. auxiliary data required to implement CRCs, secure on-board
+        communication (secOC) or container messages.
+        """
+
+        return self._autosar
+
+    @autosar.setter
+    def autosar(self, value):
+        self._autosar = value
 
     @property
     def bus_name(self):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4060,8 +4060,6 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertTrue(db.dbc is None)
 
         mux_message = db.messages[0]
-        self.assertTrue(mux_message.autosar is not None)
-        self.assertTrue(mux_message.dbc is None)
         self.assertEqual(mux_message.frame_id, 4)
         self.assertEqual(mux_message.is_extended_frame, False)
         self.assertEqual(mux_message.name, 'Multiplexed')
@@ -4072,6 +4070,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(mux_message.signals), 6)
         self.assertEqual(mux_message.comments, None)
         self.assertEqual(mux_message.bus_name, None)
+        self.assertTrue(mux_message.dbc is None)
+        self.assertTrue(mux_message.autosar is not None)
+        self.assertEqual(mux_message.autosar.pdu_paths, [
+            '/Network/CanCluster/CAN/PDUs/Multiplexed',
+            '/Network/CanCluster/CAN/PDUs/Multiplexed_0',
+            '/Network/CanCluster/CAN/PDUs/Multiplexed_1',
+            '/Network/CanCluster/CAN/PDUs/Multiplexed_Static',
+        ])
 
         mux_signal_selector = mux_message.signals[0]
         self.assertEqual(mux_signal_selector.name, 'Multiplexed_selector1')
@@ -4194,8 +4200,6 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(mux_signal_world1.multiplexer_ids, [1])
 
         message_1 = db.messages[1]
-        self.assertTrue(message_1.autosar is not None)
-        self.assertTrue(message_1.dbc is None)
         self.assertEqual(message_1.frame_id, 123)
         self.assertEqual(message_1.is_extended_frame, False)
         self.assertEqual(message_1.name, 'Status')
@@ -4206,6 +4210,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(message_1.signals), 4)
         self.assertEqual(message_1.comments["EN"], 'The lonely frame description')
         self.assertEqual(message_1.bus_name, None)
+        self.assertTrue(message_1.dbc is None)
+        self.assertTrue(message_1.autosar is not None)
+        self.assertEqual(message_1.autosar.pdu_paths, [ '/Network/CanCluster/CAN/PDUs/Status' ])
 
         signal_1 = message_1.signals[0]
         self.assertEqual(signal_1.name, 'Alive')
@@ -4309,8 +4316,6 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         # multiplexed message
         mux_message = db.messages[0]
-        self.assertTrue(mux_message.autosar is not None)
-        self.assertTrue(mux_message.dbc is None)
         self.assertEqual(mux_message.frame_id, 4)
         self.assertEqual(mux_message.is_extended_frame, False)
         self.assertEqual(mux_message.name, 'MultiplexedMessage')
@@ -4322,6 +4327,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(mux_message.bus_name, None)
         self.assertEqual(mux_message.comments, None)
         self.assertEqual(mux_message.comment, None)
+        self.assertTrue(mux_message.dbc is None)
+        self.assertTrue(mux_message.autosar is not None)
+        self.assertEqual(mux_message.autosar.pdu_paths, [
+            '/MultiplexedIPdu/multiplexed_message',
+            '/ISignalIPdu/multiplexed_message_0',
+            '/ISignalIPdu/multiplexed_message_1',
+            '/ISignalIPdu/multiplexed_message_static',
+        ])
 
         mux_signal_static = mux_message.signals[0]
         self.assertEqual(mux_signal_static.name, 'MultiplexedStatic')
@@ -4423,8 +4436,6 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(mux_signal_world1.multiplexer_ids, [ 1 ])
 
         message_1 = db.messages[1]
-        self.assertTrue(message_1.autosar is not None)
-        self.assertTrue(message_1.dbc is None)
         self.assertEqual(message_1.frame_id, 5)
         self.assertEqual(message_1.is_extended_frame, False)
         self.assertEqual(message_1.name, 'Message1')
@@ -4443,6 +4454,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
                              'DE': 'Kommentar eins',
                              'EN': 'Comment one'
                          })
+        self.assertTrue(message_1.dbc is None)
+        self.assertTrue(message_1.autosar is not None)
+        self.assertEqual(message_1.autosar.pdu_paths, [ '/ISignalIPdu/message1' ])
 
         signal_1 = message_1.signals[0]
         self.assertEqual(signal_1.name, 'signal6')
@@ -4523,8 +4537,6 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_3.multiplexer_ids, None)
 
         message_2 = db.messages[2]
-        self.assertTrue(message_2.autosar is not None)
-        self.assertTrue(message_2.dbc is None)
         self.assertEqual(message_2.frame_id, 6)
         self.assertEqual(message_2.is_extended_frame, True)
         self.assertEqual(message_2.name, 'Message2')
@@ -4535,6 +4547,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(message_2.signals), 3)
         self.assertEqual(message_2.comment, None)
         self.assertEqual(message_2.bus_name, None)
+        self.assertTrue(message_2.dbc is None)
+        self.assertTrue(message_2.autosar is not None)
+        self.assertEqual(message_2.autosar.pdu_paths, [ '/ISignalIPdu/message2' ])
 
         signal_1 = message_2.signals[0]
         self.assertEqual(signal_1.name, 'signal3')
@@ -4605,8 +4620,6 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_3.multiplexer_ids, None)
 
         message_3 = db.messages[3]
-        self.assertTrue(message_3.autosar is not None)
-        self.assertTrue(message_3.dbc is None)
         self.assertEqual(message_3.frame_id, 100)
         self.assertEqual(message_3.is_extended_frame, False)
         self.assertEqual(message_3.name, 'Message3')
@@ -4617,11 +4630,12 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(message_3.signals), 0)
         self.assertEqual(message_3.comment, None)
         self.assertEqual(message_3.bus_name, None)
+        self.assertTrue(message_3.dbc is None)
+        self.assertTrue(message_3.autosar is not None)
+        self.assertEqual(message_3.autosar.pdu_paths, [ '/ISignalIPdu/message3' ])
 
         # message 4 tests different base encodings
         message_4 = db.messages[4]
-        self.assertTrue(message_4.autosar is not None)
-        self.assertTrue(message_4.dbc is None)
         self.assertEqual(message_4.frame_id, 101)
         self.assertEqual(message_4.is_extended_frame, False)
         self.assertEqual(message_4.name, 'Message4')
@@ -4632,6 +4646,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(message_4.signals), 3)
         self.assertEqual(message_4.comment, None)
         self.assertEqual(message_4.bus_name, None)
+        self.assertTrue(message_4.dbc is None)
+        self.assertTrue(message_4.autosar is not None)
+        self.assertEqual(message_4.autosar.pdu_paths, [ '/ISignalIPdu/message4' ])
 
         signal_2 = message_4.signals[0]
         self.assertEqual(signal_2.name, 'signal2')

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4055,10 +4055,13 @@ class CanToolsDatabaseTest(unittest.TestCase):
         db = cantools.db.load_file('tests/files/arxml/system-3.2.3.arxml')
 
         self.assertEqual(len(db.nodes), 0)
-
         self.assertEqual(len(db.messages), 2)
+        self.assertTrue(db.autosar is not None)
+        self.assertTrue(db.dbc is None)
 
         mux_message = db.messages[0]
+        self.assertTrue(mux_message.autosar is not None)
+        self.assertTrue(mux_message.dbc is None)
         self.assertEqual(mux_message.frame_id, 4)
         self.assertEqual(mux_message.is_extended_frame, False)
         self.assertEqual(mux_message.name, 'Multiplexed')
@@ -4191,6 +4194,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(mux_signal_world1.multiplexer_ids, [1])
 
         message_1 = db.messages[1]
+        self.assertTrue(message_1.autosar is not None)
+        self.assertTrue(message_1.dbc is None)
         self.assertEqual(message_1.frame_id, 123)
         self.assertEqual(message_1.is_extended_frame, False)
         self.assertEqual(message_1.name, 'Status')
@@ -4298,11 +4303,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
         db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
 
         self.assertEqual(len(db.nodes), 0)
-
         self.assertEqual(len(db.messages), 5)
+        self.assertTrue(db.autosar is not None)
+        self.assertTrue(db.dbc is None)
 
         # multiplexed message
         mux_message = db.messages[0]
+        self.assertTrue(mux_message.autosar is not None)
+        self.assertTrue(mux_message.dbc is None)
         self.assertEqual(mux_message.frame_id, 4)
         self.assertEqual(mux_message.is_extended_frame, False)
         self.assertEqual(mux_message.name, 'MultiplexedMessage')
@@ -4415,6 +4423,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(mux_signal_world1.multiplexer_ids, [ 1 ])
 
         message_1 = db.messages[1]
+        self.assertTrue(message_1.autosar is not None)
+        self.assertTrue(message_1.dbc is None)
         self.assertEqual(message_1.frame_id, 5)
         self.assertEqual(message_1.is_extended_frame, False)
         self.assertEqual(message_1.name, 'Message1')
@@ -4513,6 +4523,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_3.multiplexer_ids, None)
 
         message_2 = db.messages[2]
+        self.assertTrue(message_2.autosar is not None)
+        self.assertTrue(message_2.dbc is None)
         self.assertEqual(message_2.frame_id, 6)
         self.assertEqual(message_2.is_extended_frame, True)
         self.assertEqual(message_2.name, 'Message2')
@@ -4593,6 +4605,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_3.multiplexer_ids, None)
 
         message_3 = db.messages[3]
+        self.assertTrue(message_3.autosar is not None)
+        self.assertTrue(message_3.dbc is None)
         self.assertEqual(message_3.frame_id, 100)
         self.assertEqual(message_3.is_extended_frame, False)
         self.assertEqual(message_3.name, 'Message3')
@@ -4606,6 +4620,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         # message 4 tests different base encodings
         message_4 = db.messages[4]
+        self.assertTrue(message_4.autosar is not None)
+        self.assertTrue(message_4.dbc is None)
         self.assertEqual(message_4.frame_id, 101)
         self.assertEqual(message_4.is_extended_frame, False)
         self.assertEqual(message_4.name, 'Message4')


### PR DESCRIPTION
this is completely analogous to the handling of dbc specifics. These objects currently only contain a list of the ARXML paths of all PDUs which are featured in a given message, but this will be extended in the future.

Andreas Lauser &lt;<andreas.lauser@daimler.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)