### PR TITLE
ARXML: extract bus information

### DIFF
--- a/cantools/database/can/bus.py
+++ b/cantools/database/can/bus.py
@@ -8,10 +8,24 @@ class Bus(object):
     def __init__(self,
                  name,
                  comment=None,
-                 baudrate=None):
+                 baudrate=None,
+                 fd_baudrate=None):
         self._name = name
-        self._comment = comment
+
+        # If the 'comment' argument is a string, we assume that is an
+        # English comment. This is slightly hacky, because the
+        # function's behavior depends on the type of the passed
+        # argument, but it is quite convenient...
+        if isinstance(comment, str):
+            # use the first comment in the dictionary as "The" comment
+            self._comments = { None: comment }
+        else:
+            # assume that we have either no comment at all or a
+            # multi-lingual dictionary
+            self._comments = comment
+
         self._baudrate = baudrate
+        self._fd_baudrate = fd_baudrate
 
     @property
     def name(self):
@@ -23,11 +37,28 @@ class Bus(object):
 
     @property
     def comment(self):
-        """The bus comment, or ``None`` if unavailable.
+        """The bus' comment, or ``None`` if unavailable.
+
+        Note that we implicitly try to return the English comment if
+        multiple languages were specified.
 
         """
+        if self._comments is None:
+            return None
+        elif self._comments.get(None) is not None:
+            return self._comments.get(None)
+        elif self._comments.get("FOR-ALL") is not None:
+            return self._comments.get("FOR-ALL")
 
-        return self._comment
+        return self._comments.get('EN')
+
+    @property
+    def comments(self):
+        """The dictionary with the descriptions of the bus in multiple
+        languages. ``None`` if unavailable.
+
+        """
+        return self._comments
 
     @property
     def baudrate(self):
@@ -37,7 +68,16 @@ class Bus(object):
 
         return self._baudrate
 
+    @property
+    def fd_baudrate(self):
+        """The baudrate used for the payload of CAN-FD frames, or ``None`` if
+        unavailable.
+
+        """
+
+        return self._fd_baudrate
+
     def __repr__(self):
         return "bus('{}', {})".format(
             self._name,
-            "'" + self._comment + "'" if self._comment is not None else None)
+            "'" + self.comment + "'" if self.comment is not None else None)

--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -10,6 +10,7 @@ from xml.etree import ElementTree
 from ..signal import Signal, NamedSignalValue
 from ..signal import Decimal as SignalDecimal
 from ..message import Message
+from ..bus import Bus
 from ..internal_database import InternalDatabase
 
 LOGGER = logging.getLogger(__name__)
@@ -187,6 +188,7 @@ class SystemLoader(object):
             root_packages = self._root.find("./ns:TOP-LEVEL-PACKAGES",
                                             self._xml_namespaces)
 
+        buses = self._load_buses(root_packages)
         messages = self._load_messages(root_packages)
 
         arxml_version = \
@@ -197,11 +199,113 @@ class SystemLoader(object):
         autosar_specifics = \
             AutosarDatabaseSpecifics(arxml_version=arxml_version)
 
-        return InternalDatabase(messages,
+        return InternalDatabase(buses=buses,
                                 nodes=[],
-                                buses=[],
+                                messages=messages,
                                 version=None,
                                 autosar_specifics=autosar_specifics)
+
+    def _load_buses(self, package_list):
+        """Recursively extract all buses of all CAN clusters of a list of
+        AUTOSAR packages.
+
+        @return A list of all buses contained in the given list of
+                packages and their sub-packages
+        """
+
+        buses = []
+
+        for package in package_list:
+            can_clusters = \
+                self._get_arxml_children(package,
+                                         [
+                                             'ELEMENTS',
+                                             '*&CAN-CLUSTER',
+                                         ])
+
+            # handle locally-specified clusters
+            for can_cluster in can_clusters:
+                if self.autosar_version_newer(4):
+                    name = \
+                        self._get_unique_arxml_child(can_cluster,
+                                                     'SHORT-NAME').text
+                    comments = self._load_comments(can_cluster)
+                    variants = \
+                        self._get_arxml_children(can_cluster,
+                                                 [
+                                                     '*CAN-CLUSTER-VARIANTS',
+                                                     'CAN-CLUSTER-CONDITIONAL',
+                                                 ])
+
+                    if variants is None or len(variants) == 0:
+                        # WTH?
+                        continue
+                    elif len(variants) > 1:
+                        LOGGER.warning(f'Multiple variants specified for CAN '
+                                       f'cluster "{name}". Using first one.')
+
+                    variant = variants[0]
+
+                    # version of the CAN standard
+                    proto_version = \
+                        self._get_unique_arxml_child(variant, 'PROTOCOL-VERSION')
+                    if proto_version is not None:
+                        proto_version = proto_version.text
+
+                    # base signaling rate
+                    baudrate = self._get_unique_arxml_child(variant, 'BAUDRATE')
+                    if baudrate is not None:
+                        baudrate = parse_int_string(baudrate.text)
+
+                    # baudrate for the payload of CAN-FD frames. (None if
+                    # this bus does not use CAN-FD.)
+                    fd_baudrate = \
+                        self._get_unique_arxml_child(variant, 'CAN-FD-BAUDRATE')
+                    if fd_baudrate is not None:
+                        fd_baudrate = parse_int_string(fd_baudrate.text)
+
+                    buses.append(Bus(name=name,
+                                     comment=comments,
+                                     baudrate=baudrate,
+                                     fd_baudrate=fd_baudrate))
+                else: # AUTOSAR 3
+                    name = \
+                        self._get_unique_arxml_child(can_cluster,
+                                                     'SHORT-NAME').text
+                    comments = self._load_comments(can_cluster)
+
+                    # version of the CAN standard
+                    proto_version = \
+                        self._get_unique_arxml_child(can_cluster, 'PROTOCOL-VERSION')
+                    if proto_version is not None:
+                        proto_version = proto_version.text
+
+                    # base signaling rate
+                    baudrate = self._get_unique_arxml_child(can_cluster, 'SPEED')
+                    if baudrate is not None:
+                        baudrate = parse_int_string(baudrate.text)
+
+                    # AUTOSAR 3 does not support CAN-FD
+                    fd_baudrate = None
+
+                    buses.append(Bus(name=name,
+                                     comment=comments,
+                                     baudrate=baudrate,
+                                     fd_baudrate=fd_baudrate))
+
+            # handle all sub-packages
+            if self.autosar_version_newer(4):
+                sub_package_list = package.find('./ns:AR-PACKAGES',
+                                                self._xml_namespaces)
+
+            else:
+                sub_package_list = package.find('./ns:SUB-PACKAGES',
+                                                self._xml_namespaces)
+
+            if sub_package_list is not None:
+                buses.extend(self._load_buses(sub_package_list))
+
+        return buses
 
     def _load_messages(self, package_list):
         """Recursively extract all messages of all CAN clusters of a list of
@@ -241,45 +345,51 @@ class SystemLoader(object):
         """
 
         messages = []
-        if self.autosar_version_newer(4):
-            frame_triggerings_spec = \
-                [
-                    'ELEMENTS',
-                    '*&CAN-CLUSTER',
-                    'CAN-CLUSTER-VARIANTS',
-                    '*&CAN-CLUSTER-CONDITIONAL',
-                    'PHYSICAL-CHANNELS',
-                    '*&CAN-PHYSICAL-CHANNEL',
-                    'FRAME-TRIGGERINGS',
-                    '*&CAN-FRAME-TRIGGERING'
-                ]
 
-        # AUTOSAR 3
-        else:
-            frame_triggerings_spec = \
-                [
-                    'ELEMENTS',
-                    '*&CAN-CLUSTER',
-                    'PHYSICAL-CHANNELS',
-                    '*&PHYSICAL-CHANNEL',
+        can_clusters = self._get_arxml_children(package_elem,
+                                                [
+                                                    'ELEMENTS',
+                                                    '*&CAN-CLUSTER',
+                                                ])
+        for can_cluster in can_clusters:
+            bus_name = self._get_unique_arxml_child(can_cluster,
+                                                    'SHORT-NAME').text
+            if self.autosar_version_newer(4):
+                frame_triggerings_spec = \
+                    [
+                        'CAN-CLUSTER-VARIANTS',
+                        '*&CAN-CLUSTER-CONDITIONAL',
+                        'PHYSICAL-CHANNELS',
+                        '*&CAN-PHYSICAL-CHANNEL',
+                        'FRAME-TRIGGERINGS',
+                        '*&CAN-FRAME-TRIGGERING'
+                    ]
 
-                    # ATTENTION! The trailig 'S' here is in purpose:
-                    # It appears in the AUTOSAR 3.2 XSD, but it still
-                    # seems to be a typo in the spec...
-                    'FRAME-TRIGGERINGSS',
+            # AUTOSAR 3
+            else:
+                frame_triggerings_spec = \
+                    [
+                        'PHYSICAL-CHANNELS',
+                        '*&PHYSICAL-CHANNEL',
 
-                    '*&CAN-FRAME-TRIGGERING'
-                ]
+                        # ATTENTION! The trailig 'S' here is in purpose:
+                        # It appears in the AUTOSAR 3.2 XSD, but it still
+                        # seems to be a typo in the spec...
+                        'FRAME-TRIGGERINGSS',
 
-        can_frame_triggerings = \
-            self._get_arxml_children(package_elem, frame_triggerings_spec)
+                        '*&CAN-FRAME-TRIGGERING'
+                    ]
 
-        for can_frame_triggering in can_frame_triggerings:
-            messages.append(self._load_message(can_frame_triggering))
+            can_frame_triggerings = \
+                self._get_arxml_children(can_cluster, frame_triggerings_spec)
+
+            for can_frame_triggering in can_frame_triggerings:
+                messages.append(self._load_message(bus_name,
+                                                   can_frame_triggering))
 
         return messages
 
-    def _load_message(self, can_frame_triggering):
+    def _load_message(self, bus_name, can_frame_triggering):
         """Load given message and return a message object.
 
         """
@@ -313,7 +423,8 @@ class SystemLoader(object):
             self._load_pdu(pdu, name, 1)
         autosar_specifics._pdu_paths.extend(child_pdu_paths)
 
-        return Message(frame_id=frame_id,
+        return Message(bus_name=bus_name,
+                       frame_id=frame_id,
                        is_extended_frame=is_extended_frame,
                        name=name,
                        length=length,
@@ -322,10 +433,8 @@ class SystemLoader(object):
                        cycle_time=cycle_time,
                        signals=signals,
                        comment=comments,
-                       bus_name=None,
                        autosar_specifics=autosar_specifics,
                        strict=self._strict)
-
 
     def _load_pdu(self, pdu, frame_name, next_selector_idx):
         # load all data associated with this PDU.

--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -21,8 +21,19 @@ class AutosarDatabaseSpecifics(object):
     AutosarMessageSpecifics.
 
     """
-    def __init__(self):
-        pass
+    def __init__(self,
+                 arxml_version):
+        self._arxml_version = arxml_version
+
+    @property
+    def arxml_version(self):
+        """The used version of ARXML file format
+
+        Note that due to technical reasons we always return version
+        "4.0.0" for AUTOSAR 4.X.
+        """
+        return self._arxml_version
+
 
 class AutosarMessageSpecifics(object):
     """This class collects all AUTOSAR specific information of a CAN message
@@ -166,7 +177,6 @@ class SystemLoader(object):
 
     def load(self):
         messages = []
-        autosar_specifics = AutosarDatabaseSpecifics()
 
         if self.autosar_version_newer(4):
             root_packages = self._root.find("./ns:AR-PACKAGES",
@@ -178,6 +188,14 @@ class SystemLoader(object):
                                             self._xml_namespaces)
 
         messages = self._load_messages(root_packages)
+
+        arxml_version = \
+            f'{self.autosar_version_major}.' \
+            f'{self.autosar_version_minor}.' \
+            f'{self.autosar_version_patch}'
+
+        autosar_specifics = \
+            AutosarDatabaseSpecifics(arxml_version=arxml_version)
 
         return InternalDatabase(messages,
                                 nodes=[],

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -236,20 +236,23 @@ class Message(object):
     def comment(self):
         """The message comment, or ``None`` if unavailable.
 
-        Note that we implicitly try to return the comment's language
-        to be English comment if multiple languages were specified.
+        Note that we implicitly try to return the English comment if
+        multiple languages were specified.
 
         """
         if self._comments is None:
             return None
         elif self._comments.get(None) is not None:
             return self._comments.get(None)
+        elif self._comments.get("FOR-ALL") is not None:
+            return self._comments.get("FOR-ALL")
 
-        return self._comments.get('EN', None)
+        return self._comments.get('EN')
 
     @property
     def comments(self):
-        """The dictionary with the descriptions of the message in multiple languages. ``None`` if unavailable.
+        """The dictionary with the descriptions of the message in multiple
+        languages. ``None`` if unavailable.
 
         """
         return self._comments

--- a/cantools/database/can/signal.py
+++ b/cantools/database/can/signal.py
@@ -423,16 +423,18 @@ class Signal(object):
     def comment(self):
         """The signal comment, or ``None`` if unavailable.
 
-        Note that we implicitly try to return the comment's language
-        to be English comment if multiple languages were specified.
-    
+        Note that we implicitly try to return the English comment if
+        multiple languages were specified.
+
         """
         if self._comments is None:
             return None
         elif self._comments.get(None) is not None:
             return self._comments.get(None)
+        elif self._comments.get("FOR-ALL") is not None:
+            return self._comments.get("FOR-ALL")
 
-        return self._comments.get('EN', None)
+        return self._comments.get('EN')
 
     @property
     def comments(self):

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -6,6 +6,9 @@
       <ELEMENTS>
         <CAN-CLUSTER UUID="3cd9c2f3aada9a66711bbe3efb74a27c">
           <SHORT-NAME>Cluster0</SHORT-NAME>
+	  <DESC>
+	    <L-2 L="FOR-ALL">The great CAN cluster</L-2>
+	  </DESC>
           <CAN-CLUSTER-VARIANTS>
             <CAN-CLUSTER-CONDITIONAL>
               <BAUDRATE>500000</BAUDRATE>
@@ -46,6 +49,8 @@
                   </FRAME-TRIGGERINGS>
                 </CAN-PHYSICAL-CHANNEL>
               </PHYSICAL-CHANNELS>
+	      <PROTOCOL-VERSION>can2.0b</PROTOCOL-VERSION>
+	      <CAN-FD-BAUDRATE>2000000</CAN-FD-BAUDRATE>
             </CAN-CLUSTER-CONDITIONAL>
           </CAN-CLUSTER-VARIANTS>
         </CAN-CLUSTER>

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4058,6 +4058,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(db.messages), 2)
         self.assertTrue(db.autosar is not None)
         self.assertTrue(db.dbc is None)
+        self.assertEqual(db.autosar.arxml_version, "3.2.3")
 
         mux_message = db.messages[0]
         self.assertEqual(mux_message.frame_id, 4)
@@ -4313,6 +4314,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(db.messages), 5)
         self.assertTrue(db.autosar is not None)
         self.assertTrue(db.dbc is None)
+        self.assertEqual(db.autosar.arxml_version, "4.0.0")
 
         # multiplexed message
         mux_message = db.messages[0]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4054,6 +4054,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_system_3_arxml(self):
         db = cantools.db.load_file('tests/files/arxml/system-3.2.3.arxml')
 
+        self.assertEqual(len(db.buses), 1)
+        bus = db.buses[0]
+        self.assertEqual(bus.name, 'Network')
+        self.assertEqual(bus.comment, None)
+        self.assertEqual(bus.comments, None)
+        self.assertEqual(bus.baudrate, 250000)
+        self.assertEqual(bus.fd_baudrate, None)
+
         self.assertEqual(len(db.nodes), 0)
         self.assertEqual(len(db.messages), 2)
         self.assertTrue(db.autosar is not None)
@@ -4070,7 +4078,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(mux_message.cycle_time, None)
         self.assertEqual(len(mux_message.signals), 6)
         self.assertEqual(mux_message.comments, None)
-        self.assertEqual(mux_message.bus_name, None)
+        self.assertEqual(mux_message.bus_name, 'Network')
         self.assertTrue(mux_message.dbc is None)
         self.assertTrue(mux_message.autosar is not None)
         self.assertEqual(mux_message.autosar.pdu_paths, [
@@ -4210,7 +4218,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_1.cycle_time, 500)
         self.assertEqual(len(message_1.signals), 4)
         self.assertEqual(message_1.comments["EN"], 'The lonely frame description')
-        self.assertEqual(message_1.bus_name, None)
+        self.assertEqual(message_1.bus_name, 'Network')
         self.assertTrue(message_1.dbc is None)
         self.assertTrue(message_1.autosar is not None)
         self.assertEqual(message_1.autosar.pdu_paths, [ '/Network/CanCluster/CAN/PDUs/Status' ])
@@ -4310,6 +4318,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_system_4_arxml(self):
         db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
 
+        self.assertEqual(len(db.buses), 1)
+        bus = db.buses[0]
+        self.assertEqual(bus.name, 'Cluster0')
+        self.assertEqual(bus.comment, 'The great CAN cluster')
+        self.assertEqual(bus.comments, { 'FOR-ALL': 'The great CAN cluster' })
+        self.assertEqual(bus.baudrate, 500000)
+        self.assertEqual(bus.fd_baudrate, 2000000)
+
         self.assertEqual(len(db.nodes), 0)
         self.assertEqual(len(db.messages), 5)
         self.assertTrue(db.autosar is not None)
@@ -4326,7 +4342,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(mux_message.send_type, None)
         self.assertEqual(mux_message.cycle_time, None)
         self.assertEqual(len(mux_message.signals), 6)
-        self.assertEqual(mux_message.bus_name, None)
+        self.assertEqual(mux_message.bus_name, 'Cluster0')
         self.assertEqual(mux_message.comments, None)
         self.assertEqual(mux_message.comment, None)
         self.assertTrue(mux_message.dbc is None)
@@ -4448,7 +4464,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(message_1.signals), 3)
         self.assertEqual(message_1.comments["DE"], 'Kommentar1')
         self.assertEqual(message_1.comments["EN"], 'Comment1')
-        self.assertEqual(message_1.bus_name, None)
+        self.assertEqual(message_1.bus_name, 'Cluster0')
         self.assertEqual(message_1.comment, 'Comment1')
         message_1.comments = {'DE': 'Kommentar eins', 'EN': 'Comment one'}
         self.assertEqual(message_1.comments,
@@ -4548,7 +4564,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_2.cycle_time, 200)
         self.assertEqual(len(message_2.signals), 3)
         self.assertEqual(message_2.comment, None)
-        self.assertEqual(message_2.bus_name, None)
+        self.assertEqual(message_2.bus_name, 'Cluster0')
         self.assertTrue(message_2.dbc is None)
         self.assertTrue(message_2.autosar is not None)
         self.assertEqual(message_2.autosar.pdu_paths, [ '/ISignalIPdu/message2' ])
@@ -4631,7 +4647,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_3.cycle_time, None)
         self.assertEqual(len(message_3.signals), 0)
         self.assertEqual(message_3.comment, None)
-        self.assertEqual(message_3.bus_name, None)
+        self.assertEqual(message_3.bus_name, 'Cluster0')
         self.assertTrue(message_3.dbc is None)
         self.assertTrue(message_3.autosar is not None)
         self.assertEqual(message_3.autosar.pdu_paths, [ '/ISignalIPdu/message3' ])
@@ -4647,7 +4663,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_4.cycle_time, None)
         self.assertEqual(len(message_4.signals), 3)
         self.assertEqual(message_4.comment, None)
-        self.assertEqual(message_4.bus_name, None)
+        self.assertEqual(message_4.bus_name, 'Cluster0')
         self.assertTrue(message_4.dbc is None)
         self.assertTrue(message_4.autosar is not None)
         self.assertEqual(message_4.autosar.pdu_paths, [ '/ISignalIPdu/message4' ])
@@ -4720,6 +4736,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_no_compu_method_category_arxml(self):
         db = cantools.db.load_file('tests/files/arxml/compu_method_no_category.arxml')
 
+        self.assertEqual(len(db.buses), 1)
+        bus = db.buses[0]
+        self.assertEqual(bus.name, 'MY_CLUSTER')
+        self.assertEqual(bus.comment, None)
+        self.assertEqual(bus.comments, None)
+        self.assertEqual(bus.baudrate, 500000)
+        self.assertEqual(bus.fd_baudrate, None)
+
         self.assertEqual(len(db.nodes), 0)
 
         self.assertEqual(len(db.messages), 1)
@@ -4734,16 +4758,16 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_1.send_type, None)
         self.assertEqual(message_1.cycle_time, 200)
         self.assertEqual(message_1.comments, None)
-        self.assertEqual(message_1.bus_name, None)
+        self.assertEqual(message_1.bus_name, 'MY_CLUSTER')
         self.assertEqual(len(message_1.signals), 1)
 
         # signal
         signal_1 = message_1.signals[0]
-        self.assertEqual(signal_1.name, "MY_SIGNAL_XIX_MY_MESSAGE_XIX_MY_CLUSTER")
+        self.assertEqual(signal_1.name, 'MY_SIGNAL_XIX_MY_MESSAGE_XIX_MY_CLUSTER')
         self.assertEqual(signal_1.start, 15)
         self.assertEqual(signal_1.length, 1)
         self.assertEqual(signal_1.receivers, [])
-        self.assertEqual(signal_1.byte_order, "little_endian")
+        self.assertEqual(signal_1.byte_order, 'little_endian')
         self.assertEqual(signal_1.initial, 0)
         self.assertEqual(signal_1.is_signed, False)
         self.assertEqual(signal_1.is_float, False)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -26,7 +26,8 @@ class Args(object):
         self.print_all = False
         self.no_strict = False
         self.file = (database, )
-        self.messages = []
+        self.print_buses = False
+        self.items = []
 
 class CanToolsListTest(unittest.TestCase):
     def test_dbc(self):
@@ -97,10 +98,29 @@ ExampleMessage:
             actual_output = stdout.getvalue()
             self.assertEqual(actual_output, expected_output)
 
+    def test_arxml3(self):
+        args = Args('tests/files/arxml/system-3.2.3.arxml')
+        args.print_buses = True
+
+        stdout = StringIO()
+        with patch('sys.stdout', stdout):
+            # Run the main function of the subparser
+            list_module._do_list(args)
+
+            # check make sure it behaves as expected
+            expected_output = """\
+Network:
+  Baudrate: 250000
+  CAN-FD enabled: False
+"""
+
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
+
     def test_arxml4(self):
         # Prepare mocks.
         args = Args('tests/files/arxml/system-4.2.arxml')
-        args.messages = ["Message2"]
+        args.items = ["Message2"]
 
         stdout = StringIO()
         with patch('sys.stdout', stdout):
@@ -110,6 +130,7 @@ ExampleMessage:
             # check make sure it behaves as expected
             expected_output = """\
 Message2:
+  Bus: Cluster0
   Frame ID: 0x6 (6)
   Size: 7 bytes
   Is extended frame: True
@@ -177,7 +198,7 @@ MultiplexedMessage
             self.assertEqual(actual_output, expected_output)
 
         args = Args('tests/files/arxml/system-4.2.arxml')
-        args.messages = [ "IAmAGhost" ]
+        args.items = [ "IAmAGhost" ]
 
         stdout = StringIO()
         with patch('sys.stdout', stdout):
@@ -193,7 +214,7 @@ No message named "IAmAGhost" has been found in input file.
             self.assertEqual(actual_output, expected_output)
 
         args = Args('tests/files/arxml/system-4.2.arxml')
-        args.messages = [ "Message1" ]
+        args.items = [ "Message1" ]
 
         stdout = StringIO()
         with patch('sys.stdout', stdout):
@@ -205,6 +226,7 @@ No message named "IAmAGhost" has been found in input file.
 Message1:
   Comment[EN]: Comment1
   Comment[DE]: Kommentar1
+  Bus: Cluster0
   Frame ID: 0x5 (5)
   Size: 6 bytes
   Is extended frame: False
@@ -246,6 +268,27 @@ Message1:
 
             actual_output = stdout.getvalue()
             self.assertEqual(actual_output, expected_output)
+
+        args = Args('tests/files/arxml/system-4.2.arxml')
+        args.print_buses = True
+
+        stdout = StringIO()
+        with patch('sys.stdout', stdout):
+            # Run the main function of the subparser
+            list_module._do_list(args)
+
+            # check make sure it behaves as expected
+            expected_output = """\
+Cluster0:
+  Comment[FOR-ALL]: The great CAN cluster
+  Baudrate: 500000
+  CAN-FD enabled: True
+  FD Baudrate: 2000000
+"""
+
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
+
 
     def test_kcd(self):
         # Prepare mocks.


### PR DESCRIPTION
This internalizes the information about the CAN buses which can be provided by ARXML files. most of the infrastructure was already present, the exception is the FD baudrate which was not around, supposedly because the base DBC file format (probably) does not support CAN-FD.

Besides this, I added the file format version of the input file to the autosar specifics of the database and cleaned up the message loading code slightly (to avoid using nested functions).

Andreas Lauser &lt;<andreas.lauser@daimler.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)