### PR TITLE
Prune signal choices

### DIFF
--- a/cantools/database/__init__.py
+++ b/cantools/database/__init__.py
@@ -5,6 +5,7 @@ from .errors import Error
 from ..compat import fopen
 from . import can
 from . import diagnostics
+from . import utils
 import textparser
 import diskcache
 
@@ -96,6 +97,7 @@ def load_file(filename,
               database_format=None,
               encoding=None,
               frame_id_mask=None,
+              prune_choices=True,
               strict=True,
               cache_dir=None):
     """Open, read and parse given database file and return a
@@ -177,6 +179,7 @@ def load_file(filename,
             return load(fin,
                         database_format,
                         frame_id_mask,
+                        prune_choices,
                         strict)
     else:
         return _load_file_cache(filename,
@@ -228,6 +231,7 @@ def dump_file(database,
 def load(fp,
          database_format=None,
          frame_id_mask=None,
+         prune_choices=True,
          strict=True):
     """Read and parse given database file-like object and return a
     :class:`can.Database<.can.Database>` or
@@ -252,12 +256,14 @@ def load(fp,
     return load_string(fp.read(),
                        database_format,
                        frame_id_mask,
+                       prune_choices,
                        strict)
 
 
 def load_string(string,
                 database_format=None,
                 frame_id_mask=None,
+                prune_choices=True,
                 strict=True):
     """Parse given database string and return a
     :class:`can.Database<.can.Database>` or
@@ -306,6 +312,9 @@ def load_string(string,
             db.add_kcd_string(string)
         elif fmt == 'sym':
             db.add_sym_string(string)
+
+        if prune_choices:
+            utils.prune_database_choices(db)
 
         return db
 

--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -87,7 +87,7 @@ class SystemLoader(object):
         self._root = root
         self._strict = strict
 
-        m = re.match('^\\{(.*)\\}AUTOSAR$', self._root.tag)
+        m = re.match(r'^\{(.*)\}AUTOSAR$', self._root.tag)
 
         if not m:
             raise ValueError(f"No XML namespace specified or illegal root tag "
@@ -97,7 +97,7 @@ class SystemLoader(object):
         self.xml_namespace = xml_namespace
         self._xml_namespaces = { 'ns': xml_namespace }
 
-        m = re.match('^http://autosar\.org/schema/r(4\.[0-9.]*)$',
+        m = re.match(r'^http://autosar\.org/schema/r(4\.[0-9.]*)$',
                      xml_namespace)
 
         if m:
@@ -114,14 +114,14 @@ class SystemLoader(object):
             autosar_version_string = m.group(1)
 
         else:
-            m = re.match('^http://autosar\.org/(3\.[0-9.]*)$', xml_namespace)
+            m = re.match(r'^http://autosar\.org/(3\.[0-9.]*)$', xml_namespace)
 
             if m:
                 # AUTOSAR 3
                 autosar_version_string = m.group(1)
 
             else:
-                m = re.match('^http://autosar\.org/([0-9.]*)\.DAI\.[0-9]$',
+                m = re.match(r'^http://autosar\.org/([0-9.]*)\.DAI\.[0-9]$',
                              xml_namespace)
 
                 if m:
@@ -132,7 +132,7 @@ class SystemLoader(object):
                     raise ValueError(f"Unrecognized AUTOSAR XML namespace "
                                      f"'{xml_namespace}'")
 
-        m = re.match('^([0-9]*)(\.[0-9]*)?(\.[0-9]*)?$', autosar_version_string)
+        m = re.match(r'^([0-9]*)(\.[0-9]*)?(\.[0-9]*)?$', autosar_version_string)
 
         if not m:
             raise ValueError(f"Could not parse AUTOSAR version "
@@ -2084,16 +2084,16 @@ def load_string(string, strict=True):
 
     root = ElementTree.fromstring(string)
 
-    m = re.match("{(.*)}AUTOSAR", root.tag)
+    m = re.match(r'{(.*)}AUTOSAR', root.tag)
     if not m:
         raise ValueError(f"No XML namespace specified or illegal root tag name '{root.tag}'")
     xml_namespace = m.group(1)
 
     # Should be replaced with a validation using the XSD file.
     recognized_namespace = False
-    if re.match("http://autosar.org/schema/r(4.*)", xml_namespace) \
-       or re.match("http://autosar.org/(3.*)", xml_namespace) \
-       or re.match("http://autosar.org/(.*)\.DAI\.[0-9]", xml_namespace):
+    if re.match(r'http://autosar.org/schema/r(4.*)', xml_namespace) \
+       or re.match(r'http://autosar.org/(3.*)', xml_namespace) \
+       or re.match(r'http://autosar.org/(.*)\.DAI\.[0-9]', xml_namespace):
         recognized_namespace = True
 
     if not recognized_namespace:

--- a/cantools/subparsers/convert.py
+++ b/cantools/subparsers/convert.py
@@ -6,6 +6,7 @@ from .. import database
 def _do_convert(args):
     dbase = database.load_file(args.infile,
                                encoding=args.encoding,
+                               prune_choices=args.prune,
                                strict=not args.no_strict)
 
     database.dump_file(dbase,
@@ -22,6 +23,14 @@ def add_subparser(subparsers):
     convert_parser.add_argument(
         '-e', '--encoding',
         help='File encoding.')
+    # the result of the convert operation should represent the
+    # original file as closely as possible so -- in contrast to the
+    # other subparsers -- we do not prune the names of signal values
+    # by default
+    convert_parser.add_argument(
+        '--prune',
+        action='store_true',
+        help='Shorten the named signal values.')
     convert_parser.add_argument(
         '--no-strict',
         action='store_true',

--- a/cantools/subparsers/decode.py
+++ b/cantools/subparsers/decode.py
@@ -10,6 +10,7 @@ def _do_decode(args):
     dbase = database.load_file(args.database,
                                encoding=args.encoding,
                                frame_id_mask=args.frame_id_mask,
+                               prune_choices=not args.no_prune,
                                strict=not args.no_strict)
     decode_choices = not args.no_decode_choices
     parser = logreader.Parser(sys.stdin)
@@ -42,6 +43,10 @@ def add_subparser(subparsers):
     decode_parser.add_argument(
         '-e', '--encoding',
         help='File encoding.')
+    decode_parser.add_argument(
+        '--no-prune',
+        action='store_true',
+        help='Refrain from shortening the names of named signal values.')
     decode_parser.add_argument(
         '--no-strict',
         action='store_true',

--- a/cantools/subparsers/dump/__init__.py
+++ b/cantools/subparsers/dump/__init__.py
@@ -124,6 +124,7 @@ def _dump_diagnostics_database(dbase):
 def _do_dump(args):
     dbase = database.load_file(args.database,
                                encoding=args.encoding,
+                               prune_choices=not args.no_prune,
                                strict=not args.no_strict)
 
     if isinstance(dbase, CanDatabase):
@@ -142,6 +143,10 @@ def add_subparser(subparsers):
     dump_parser.add_argument(
         '-e', '--encoding',
         help='File encoding.')
+    dump_parser.add_argument(
+        '--no-prune',
+        action='store_true',
+        help='Refrain from shortening the names of named signal values.')
     dump_parser.add_argument(
         '--no-strict',
         action='store_true',

--- a/cantools/subparsers/generate_c_source.py
+++ b/cantools/subparsers/generate_c_source.py
@@ -10,6 +10,7 @@ from ..database.can.c_source import camel_to_snake_case
 def _do_generate_c_source(args):
     dbase = database.load_file(args.infile,
                                encoding=args.encoding,
+                               prune_choices=not args.no_prune,
                                strict=not args.no_strict)
 
     if args.database_name is None:
@@ -87,6 +88,10 @@ def add_subparser(subparsers):
     generate_c_source_parser.add_argument(
         '-e', '--encoding',
         help='File encoding.')
+    generate_c_source_parser.add_argument(
+        '--no-prune',
+        action='store_true',
+        help='Refrain from shortening the names of named signal values.')
     generate_c_source_parser.add_argument(
         '--no-strict',
         action='store_true',

--- a/cantools/subparsers/list.py
+++ b/cantools/subparsers/list.py
@@ -118,11 +118,14 @@ def _print_bus(bus):
 
 def _do_list(args):
     input_file_name = args.file[0]
+    no_prune=args.no_prune
     no_strict=args.no_strict
     print_buses=args.print_buses
     print_nodes=args.print_nodes
 
-    can_db = cantools.database.load_file(input_file_name, strict=not no_strict)
+    can_db = cantools.database.load_file(input_file_name,
+                                         prune_choices=not no_prune,
+                                         strict=not no_strict)
 
     if print_buses:
         _do_list_buses(can_db, args)
@@ -245,6 +248,10 @@ def add_subparser(subparsers):
         const=True,
         required=False,
         help='Print information about the CAN nodes described by the input file.')
+    list_parser.add_argument(
+        '--no-prune',
+        action='store_true',
+        help='Refrain from shortening the names of named signal values.')
     list_parser.add_argument(
         '--no-strict',
         action='store_true',

--- a/cantools/subparsers/monitor.py
+++ b/cantools/subparsers/monitor.py
@@ -24,6 +24,7 @@ class Monitor(can.Listener):
         self._dbase = database.load_file(args.database,
                                          encoding=args.encoding,
                                          frame_id_mask=args.frame_id_mask,
+                                         prune_choices=not args.no_prune,
                                          strict=not args.no_strict)
         self._single_line = args.single_line
         self._filtered_sorted_message_names = []
@@ -460,10 +461,6 @@ def add_subparser(subparsers):
         '-e', '--encoding',
         help='File encoding.')
     monitor_parser.add_argument(
-        '--no-strict',
-        action='store_true',
-        help='Skip database consistency checks.')
-    monitor_parser.add_argument(
         '-m', '--frame-id-mask',
         type=Integer(0),
         help=('Only compare selected frame id bits to find the message in the '
@@ -484,6 +481,14 @@ def add_subparser(subparsers):
         '-f', '--fd',
         action='store_true',
         help='Python CAN CAN-FD bus.')
+    monitor_parser.add_argument(
+        '--no-prune',
+        action='store_true',
+        help='Refrain from shortening the names of named signal values.')
+    monitor_parser.add_argument(
+        '--no-strict',
+        action='store_true',
+        help='Skip database consistency checks.')
     monitor_parser.add_argument(
         'database',
         help='Database file.')

--- a/cantools/subparsers/plot.py
+++ b/cantools/subparsers/plot.py
@@ -331,6 +331,7 @@ def _do_decode(args):
     dbase = database.load_file(args.database,
                                encoding=args.encoding,
                                frame_id_mask=args.frame_id_mask,
+                               prune_choices=not args.no_prune,
                                strict=not args.no_strict)
     re_format = None
     timestamp_parser = TimestampParser(args)
@@ -799,36 +800,32 @@ def add_subparser(subparsers):
     It adds the options for this subprogram to the argparse parser.
     It sets the entry point for this subprogram by setting a default values for func.
     '''
-    decode_parser = subparsers.add_parser(
+    plot_parser = subparsers.add_parser(
         'plot',
         description=__doc__,
         formatter_class=RawDescriptionArgumentDefaultsHelpFormatter)
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-c', '--no-decode-choices',
         action='store_true',
         help='Do not convert scaled values to choice strings.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-e', '--encoding',
         help='File encoding of dbc file.')
-    decode_parser.add_argument(
-        '--no-strict',
-        action='store_true',
-        help='Skip database consistency checks.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-m', '--frame-id-mask',
         type=Integer(0),
         help=('Only compare selected frame id bits to find the message in the '
               'database. By default the candump and database frame ids must '
               'be equal for a match.'))
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-I', '--case-sensitive',
         action='store_true',
         help='Match the signal names case sensitive.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-l', '--line-numbers',
         action='store_true',
         help='Use line numbers instead of time stamps on the horizontal axis (useful with `candump -td`).')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-t', '--break-time',
         default=100,
         type=float,
@@ -837,75 +834,83 @@ def add_subparser(subparsers):
               '(if timestamps are used) or input lines (if line numbers are used). '
               '-1 means infinite. '))
 
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '--show-invalid-syntax',
         action='store_true',
         help='Show a marker for lines which could not be parsed. This implies -l.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '--show-unknown-frames',
         action='store_true',
         help='Show a marker for messages which are not contained in the database file.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '--show-invalid-data',
         action='store_true',
         help='Show a marker for messages with data which could not be parsed.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-s', '--show-errors',
         action='store_true',
         help='Show all error messages in the plot. This is an abbreviation for all --show-* options. This implies -l.')
 
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '--ignore-invalid-syntax',
         action='store_true',
         help='Don\'t print an error message for lines which could not be parsed.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '--ignore-unknown-frames',
         action='store_true',
         help='Don\'t print an error message for messages which are not contained in the database file.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '--ignore-invalid-data',
         action='store_true',
         help='Don\'t print an error message for messages with data which could not be parsed.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-q', '--quiet',
         action='store_true',
         help='Don\'t print any error messages. This is an abbreviation for all --ignore-* options.')
 
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-o', '--output-file',
         help='A file to write the plot to instead of displaying it in a window.')
 
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-ss', '--start',
         help='A start time or line number. Everything before is ignored. '
              'This filters the lines/messages to be processed. It does *not* set the minimum value of the x-axis.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-to', '--stop',
         help='An end time or line number. Everything after is ignored. '
              'This filters the lines/messages to be processed. It does *not* set the maximum value of the x-axis.')
 
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '--style',
         help='The matplotlib style to be used.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '--list-styles',
         action='store_true',
         help='Print all available matplotlib styles without drawing a plot.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         '-ac', '--auto-color-ylabels',
         action='store_true',
         help='This is equivalent to applying --color C0 to the first y-axis, --color C1 to the second and so on.')
+    plot_parser.add_argument(
+        '--no-prune',
+        action='store_true',
+        help='Refrain from shortening the names of named signal values.')
+    plot_parser.add_argument(
+        '--no-strict',
+        action='store_true',
+        help='Skip database consistency checks.')
 
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         'database',
         help='Database file.')
-    decode_parser.add_argument(
+    plot_parser.add_argument(
         'signals',
         nargs='*',
         help='The signals to be plotted.')
-    decode_parser.set_defaults(func=_do_decode)
+    plot_parser.set_defaults(func=_do_decode)
 
-    subplot_arggroup = decode_parser.add_argument_group('subplot arguments',
+    subplot_arggroup = plot_parser.add_argument_group('subplot arguments',
         '''\
 The following options can be used to configure the subplots/axes.
 If they shall apply to a specific subplot/axis they must be placed among the signals for that subplot/axis and a -- must mark the end of the global optional arguments.

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -104,7 +104,7 @@ DRIVER_HEARTBEAT(
   vcan0  1F4   [4]  01 02 03 04 ::
 IO_DEBUG(
     IO_DEBUG_test_unsigned: 1,
-    IO_DEBUG_test_enum: 'IO_DEBUG_test2_enum_two',
+    IO_DEBUG_test_enum: 'two',
     IO_DEBUG_test_signed: 3,
     IO_DEBUG_test_float: 2.0
 )
@@ -146,7 +146,7 @@ DRIVER_HEARTBEAT(
  (2020-12-19 12:04:56.805087)  vcan0  1F4   [4]  01 02 03 04 ::
 IO_DEBUG(
     IO_DEBUG_test_unsigned: 1,
-    IO_DEBUG_test_enum: 'IO_DEBUG_test2_enum_two',
+    IO_DEBUG_test_enum: 'two',
     IO_DEBUG_test_signed: 3,
     IO_DEBUG_test_float: 2.0
 )
@@ -188,7 +188,7 @@ DRIVER_HEARTBEAT(
  (012.831664)  vcan0  1F4   [4]  01 02 03 04 ::
 IO_DEBUG(
     IO_DEBUG_test_unsigned: 1,
-    IO_DEBUG_test_enum: 'IO_DEBUG_test2_enum_two',
+    IO_DEBUG_test_enum: 'two',
     IO_DEBUG_test_signed: 3,
     IO_DEBUG_test_float: 2.0
 )
@@ -261,7 +261,7 @@ DRIVER_HEARTBEAT(
 (1594172462.356874) vcan0 1F4#01020304 ::
 IO_DEBUG(
     IO_DEBUG_test_unsigned: 1,
-    IO_DEBUG_test_enum: 'IO_DEBUG_test2_enum_two',
+    IO_DEBUG_test_enum: 'two',
     IO_DEBUG_test_signed: 3,
     IO_DEBUG_test_float: 2.0
 )
@@ -299,7 +299,7 @@ IO_DEBUG(
   vcan0  064   [10]  F0 01 FF FF FF FF FF FF FF FF :: DRIVER_HEARTBEAT(DRIVER_HEARTBEAT_cmd: 240)
   vcan0  ERROR
 
-  vcan0  1F4   [4]  01 02 03 04 :: IO_DEBUG(IO_DEBUG_test_unsigned: 1, IO_DEBUG_test_enum: 'IO_DEBUG_test2_enum_two', IO_DEBUG_test_signed: 3, IO_DEBUG_test_float: 2.0)
+  vcan0  1F4   [4]  01 02 03 04 :: IO_DEBUG(IO_DEBUG_test_unsigned: 1, IO_DEBUG_test_enum: 'two', IO_DEBUG_test_signed: 3, IO_DEBUG_test_float: 2.0)
   vcan0  1F3   [3]  01 02 03 :: Unknown frame id 499 (0x1f3)
 """
 
@@ -334,7 +334,7 @@ IO_DEBUG(
 (1594172462.126542) vcan0 064#F001FFFFFFFFFFFFFFFF :: DRIVER_HEARTBEAT(DRIVER_HEARTBEAT_cmd: 240)
 (1594172462.127684) vcan0 ERROR
 
-(1594172462.356874) vcan0 1F4#01020304 :: IO_DEBUG(IO_DEBUG_test_unsigned: 1, IO_DEBUG_test_enum: 'IO_DEBUG_test2_enum_two', IO_DEBUG_test_signed: 3, IO_DEBUG_test_float: 2.0)
+(1594172462.356874) vcan0 1F4#01020304 :: IO_DEBUG(IO_DEBUG_test_unsigned: 1, IO_DEBUG_test_enum: 'two', IO_DEBUG_test_signed: 3, IO_DEBUG_test_float: 2.0)
 (1594172462.688432) vcan0 1F3#010203 :: Unknown frame id 499 (0x1f3)
 """
 
@@ -1056,20 +1056,20 @@ BATTERY_VT(
   Signal choices:
 
     FooSignal
-        0 FOO_A
-        1 FOO_B
-        2 FOO_C
-        3 FOO_D
+        0 A
+        1 B
+        2 C
+        3 D
 
     BarSignal
-        0 BAR_A
-        1 BAR_B
-        2 BAR_C
-        3 BAR_D
-        4 BAR_E
-        5 BAR_F
-        6 BAR_G
-        7 BAR_H
+        0 A
+        1 B
+        2 C
+        3 D
+        4 E
+        5 F
+        6 G
+        7 H
 
   ------------------------------------------------------------------------
 """

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2398,7 +2398,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assert_dbc_dump(db, 'tests/files/dbc/multiplex_dumped.dbc')
 
     def test_multiplex_choices(self):
-        db = cantools.db.load_file('tests/files/dbc/multiplex_choices.dbc')
+        db = cantools.db.load_file('tests/files/dbc/multiplex_choices.dbc',
+                                   prune_choices=False)
 
         # With Multiplexor and BIT_L as strings.
         decoded_message = {
@@ -2897,7 +2898,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.load_file('tests/files/dbc/multiplex_choices.dbc')
+        db = cantools.db.load_file('tests/files/dbc/multiplex_choices.dbc',
+                                   prune_choices=True)
 
         decoded_message = {
             'Multiplexor': 'MULTIPLEXOR_8',
@@ -2922,7 +2924,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.load_file('tests/files/dbc/multiplex_choices.dbc')
+        db = cantools.db.load_file('tests/files/dbc/multiplex_choices.dbc',
+                                   prune_choices=False)
 
         message_1 = db.messages[0]
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -25,6 +25,7 @@ class Args(object):
         self.exclude_extended = False
         self.print_all = False
         self.no_strict = False
+        self.no_prune = False
         self.file = (database, )
         self.print_buses = False
         self.print_nodes = False

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -23,6 +23,7 @@ class Args(object):
         self.database = database
         self.encoding = None
         self.frame_id_mask = None
+        self.no_prune = False
         self.no_strict = False
         self.single_line = single_line
         self.bit_rate = None


### PR DESCRIPTION
This gets rid if redundant prefixes of the named values of signals thus reducing visual noise when decoding such signals considerably while still guaranteeing the uniqueness and validity of the new names.

On one hand, this requires minor modifications for some of the user scripts (sorry in advance to all affected users), but on the other hand, I think that it improves usability considerably enough to enable it by default.

Andreas Lauser &lt;<andreas.lauser@daimler.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)
