### PR TITLE
Add support for BU_BO_REL_ in dbc files

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -282,7 +282,7 @@ class Parser(textparser.Parser):
 
         attribute_definition_rel = Sequence(
             'BA_DEF_REL_',
-            Optional('BU_SG_REL_'),
+            Optional(choice('BU_SG_REL_', 'BU_BO_REL_')),
             'STRING',
             'WORD',
             choice(DelimitedList('STRING'), OneOrMore('NUMBER')),
@@ -291,9 +291,13 @@ class Parser(textparser.Parser):
         attribute_definition_default_rel = Sequence(
             'BA_DEF_DEF_REL_', 'STRING', choice('NUMBER', 'STRING'), ';')
 
-        attribute_rel = Sequence(
+        attribute_rel_sg = Sequence(
             'BA_REL_', 'STRING', 'BU_SG_REL_', 'WORD', 'SG_', 'NUMBER',
             'WORD', choice('NUMBER', 'STRING'), ';')
+
+        attribute_rel_bo = Sequence(
+            'BA_REL_', 'STRING', 'BU_BO_REL_', 'WORD', 'NUMBER',
+            choice('NUMBER', 'STRING'), ';')
 
         choice_ = Sequence(
             'VAL_',
@@ -330,7 +334,8 @@ class Parser(textparser.Parser):
                 value_table,
                 choice_,
                 attribute,
-                attribute_rel,
+                attribute_rel_sg,
+                attribute_rel_bo,
                 attribute_definition_rel,
                 attribute_definition_default,
                 attribute_definition_default_rel,

--- a/tests/files/dbc/BU_BO_REL_.dbc
+++ b/tests/files/dbc/BU_BO_REL_.dbc
@@ -1,0 +1,55 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: COM
+
+
+BO_ 1 CONTROL: 7 COM
+ SG_ state : 0|8@1+ (1,0) [0|100] "%" Vector__XXX
+
+
+
+
+
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 65535;
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_DEF_REL_ BU_BO_REL_  "MsgProject" ENUM  "A","B","C";
+BA_DEF_DEF_REL_ "MsgProject" "A";
+BA_REL_ "MsgProject" BU_BO_REL_ COM 1 2;
+
+VAL_ 1 state 255 "Invalid" ;
+
+
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -5361,6 +5361,11 @@ class CanToolsDatabaseTest(unittest.TestCase):
             db,
             'tests/files/dbc/issue_184_extended_mux_multiple_values_dumped.dbc')
 
+    def test_dbc_BU_BO_REL(self):
+        # Loading the file should not generate an exception
+        db = cantools.database.load_file(
+            'tests/files/dbc/BU_BO_REL_.dbc')
+
     def test_issue_184_independent_multiplexors(self):
         db = cantools.database.load_file(
             'tests/files/dbc/issue_184_extended_mux_independent_multiplexors.dbc')


### PR DESCRIPTION
This fixed some issues we had when parsing DBC files generated with CANdb++.

This is also mentioned here: https://github.com/cantools/cantools/issues/22#issuecomment-737739571