### PR TITLE
Fix #384

### DIFF
--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -5,7 +5,8 @@ import os.path
 import re
 from decimal import Decimal
 from typing import Dict, Union, List, Callable
-from ..typechecking import Literal, Final
+
+from typing_extensions import Literal, Final
 
 from cantools.database.can.signal import NamedSignalValue, Signal
 from cantools.typechecking import Formats

--- a/cantools/typechecking.py
+++ b/cantools/typechecking.py
@@ -1,7 +1,6 @@
 import typing
 
 import typing_extensions
-from typing_extensions import Literal, Final
 from bitstruct import CompiledFormatDict
 
 if typing.TYPE_CHECKING:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ nala; python_version >= '3.6'
 argparse_addons
 matplotlib
 parameterized
-mypy==0.931
-typing_extensions>=3.10.0.0
+mypy>=0.931

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(name='cantools',
           'textparser>=0.21.1',
           'diskcache',
           'argparse_addons',
+          'typing_extensions>=3.10.0.0',
       ],
       extras_require=dict(
           plot=['matplotlib'],


### PR DESCRIPTION
Closes #384 

Currently the CI installs the dependencies with `pip install -r requirements.txt` and ignores the dependencies in `setup.py`.
This wouldn't have happened if cantools used tox. Tox actually tests the packaged and installed code.