### PR TITLE
Add option to get single precision floating point (float) in the generated code, instead of double.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,6 +298,14 @@ file names are also changed by this option.
 See `my_database_name.h`_ and `my_database_name.c`_ for the contents
 of the generated files.
 
+In this example we use ``--single-precision-floating-point`` so floating point numbers in the generated
+code are single precision (float) instead of double precision (double).
+
+.. code-block:: text
+
+   $ python3 -m cantools generate_c_source --single-precision-floating-point tests/files/dbc/motohawk.dbc
+   Successfully generated motohawk.h and motohawk.c.
+
 In the last example we use ``--no-floating-point-numbers`` to generate
 code without floating point types, i.e. ``float`` and ``double``.
 

--- a/cantools/subparsers/generate_c_source.py
+++ b/cantools/subparsers/generate_c_source.py
@@ -31,6 +31,7 @@ def _do_generate_c_source(args):
         filename_c,
         fuzzer_filename_c,
         not args.no_floating_point_numbers,
+        args.single_precision_floating_point,
         args.bit_fields)
 
     os.makedirs(args.output_directory, exist_ok=True)
@@ -80,6 +81,11 @@ def add_subparser(subparsers):
         '--no-floating-point-numbers',
         action='store_true',
         help='No floating point numbers in the generated code.')
+    generate_c_source_parser.add_argument(
+        '--single-precision-floating-point',
+        action='store_true',
+        help=('Use single precision floating point numbers in the generated '
+              'code (use float instead double).'))
     generate_c_source_parser.add_argument(
         '--bit-fields',
         action='store_true',

--- a/tests/files/c_source/motohawk_single_floating_point_numbers.c
+++ b/tests/files/c_source/motohawk_single_floating_point_numbers.c
@@ -1,0 +1,175 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018-2019 Erik Moqvist
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+
+ */
+
+#include <string.h>
+
+#include "motohawk.h"
+
+static inline uint8_t pack_left_shift_u8(
+    uint8_t value,
+    uint8_t shift,
+    uint8_t mask)
+{
+    return (uint8_t)((uint8_t)(value << shift) & mask);
+}
+
+static inline uint8_t pack_left_shift_u16(
+    uint16_t value,
+    uint8_t shift,
+    uint8_t mask)
+{
+    return (uint8_t)((uint8_t)(value << shift) & mask);
+}
+
+static inline uint8_t pack_right_shift_u16(
+    uint16_t value,
+    uint8_t shift,
+    uint8_t mask)
+{
+    return (uint8_t)((uint8_t)(value >> shift) & mask);
+}
+
+static inline uint16_t unpack_left_shift_u16(
+    uint8_t value,
+    uint8_t shift,
+    uint8_t mask)
+{
+    return (uint16_t)((uint16_t)(value & mask) << shift);
+}
+
+static inline uint8_t unpack_right_shift_u8(
+    uint8_t value,
+    uint8_t shift,
+    uint8_t mask)
+{
+    return (uint8_t)((uint8_t)(value & mask) >> shift);
+}
+
+static inline uint16_t unpack_right_shift_u16(
+    uint8_t value,
+    uint8_t shift,
+    uint8_t mask)
+{
+    return (uint16_t)((uint16_t)(value & mask) >> shift);
+}
+
+int motohawk_example_message_pack(
+    uint8_t *dst_p,
+    const struct motohawk_example_message_t *src_p,
+    size_t size)
+{
+    uint16_t temperature;
+
+    if (size < 8u) {
+        return (-EINVAL);
+    }
+
+    memset(&dst_p[0], 0, 8);
+
+    dst_p[0] |= pack_left_shift_u8(src_p->enable, 7u, 0x80u);
+    dst_p[0] |= pack_left_shift_u8(src_p->average_radius, 1u, 0x7eu);
+    temperature = (uint16_t)src_p->temperature;
+    dst_p[0] |= pack_right_shift_u16(temperature, 11u, 0x01u);
+    dst_p[1] |= pack_right_shift_u16(temperature, 3u, 0xffu);
+    dst_p[2] |= pack_left_shift_u16(temperature, 5u, 0xe0u);
+
+    return (8);
+}
+
+int motohawk_example_message_unpack(
+    struct motohawk_example_message_t *dst_p,
+    const uint8_t *src_p,
+    size_t size)
+{
+    uint16_t temperature;
+
+    if (size < 8u) {
+        return (-EINVAL);
+    }
+
+    dst_p->enable = unpack_right_shift_u8(src_p[0], 7u, 0x80u);
+    dst_p->average_radius = unpack_right_shift_u8(src_p[0], 1u, 0x7eu);
+    temperature = unpack_left_shift_u16(src_p[0], 11u, 0x01u);
+    temperature |= unpack_left_shift_u16(src_p[1], 3u, 0xffu);
+    temperature |= unpack_right_shift_u16(src_p[2], 5u, 0xe0u);
+
+    if ((temperature & (1u << 11)) != 0u) {
+        temperature |= 0xf000u;
+    }
+
+    dst_p->temperature = (int16_t)temperature;
+
+    return (0);
+}
+
+uint8_t motohawk_example_message_enable_encode(float value)
+{
+    return (uint8_t)(value);
+}
+
+float motohawk_example_message_enable_decode(uint8_t value)
+{
+    return ((float)value);
+}
+
+bool motohawk_example_message_enable_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t motohawk_example_message_average_radius_encode(float value)
+{
+    return (uint8_t)(value / 0.1);
+}
+
+float motohawk_example_message_average_radius_decode(uint8_t value)
+{
+    return ((float)value * 0.1);
+}
+
+bool motohawk_example_message_average_radius_is_in_range(uint8_t value)
+{
+    return (value <= 50u);
+}
+
+int16_t motohawk_example_message_temperature_encode(float value)
+{
+    return (int16_t)((value - 250.0) / 0.01);
+}
+
+float motohawk_example_message_temperature_decode(int16_t value)
+{
+    return (((float)value * 0.01) + 250.0);
+}
+
+bool motohawk_example_message_temperature_is_in_range(int16_t value)
+{
+    return ((value >= -2048) && (value <= 2047));
+}

--- a/tests/files/c_source/motohawk_single_floating_point_numbers.h
+++ b/tests/files/c_source/motohawk_single_floating_point_numbers.h
@@ -1,0 +1,206 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018-2019 Erik Moqvist
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+
+ */
+
+#ifndef MOTOHAWK_H
+#define MOTOHAWK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifndef EINVAL
+#    define EINVAL 22
+#endif
+
+/* Frame ids. */
+#define MOTOHAWK_EXAMPLE_MESSAGE_FRAME_ID (0x1f0u)
+
+/* Frame lengths in bytes. */
+#define MOTOHAWK_EXAMPLE_MESSAGE_LENGTH (8u)
+
+/* Extended or standard frame types. */
+#define MOTOHAWK_EXAMPLE_MESSAGE_IS_EXTENDED (0)
+
+/* Frame cycle times in milliseconds. */
+
+
+/* Signal choices. */
+#define MOTOHAWK_EXAMPLE_MESSAGE_ENABLE_DISABLED_CHOICE (0u)
+#define MOTOHAWK_EXAMPLE_MESSAGE_ENABLE_ENABLED_CHOICE (1u)
+
+/**
+ * Signals in message ExampleMessage.
+ *
+ * Example message used as template in MotoHawk models.
+ *
+ * All signal values are as on the CAN bus.
+ */
+struct motohawk_example_message_t {
+    /**
+     * Range: -
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t enable;
+
+    /**
+     * Range: 0..50 (0..5 m)
+     * Scale: 0.1
+     * Offset: 0
+     */
+    uint8_t average_radius;
+
+    /**
+     * Range: -2048..2047 (229.52..270.47 degK)
+     * Scale: 0.01
+     * Offset: 250
+     */
+    int16_t temperature;
+};
+
+/**
+ * Pack message ExampleMessage.
+ *
+ * @param[out] dst_p Buffer to pack the message into.
+ * @param[in] src_p Data to pack.
+ * @param[in] size Size of dst_p.
+ *
+ * @return Size of packed data, or negative error code.
+ */
+int motohawk_example_message_pack(
+    uint8_t *dst_p,
+    const struct motohawk_example_message_t *src_p,
+    size_t size);
+
+/**
+ * Unpack message ExampleMessage.
+ *
+ * @param[out] dst_p Object to unpack the message into.
+ * @param[in] src_p Message to unpack.
+ * @param[in] size Size of src_p.
+ *
+ * @return zero(0) or negative error code.
+ */
+int motohawk_example_message_unpack(
+    struct motohawk_example_message_t *dst_p,
+    const uint8_t *src_p,
+    size_t size);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t motohawk_example_message_enable_encode(float value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+float motohawk_example_message_enable_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool motohawk_example_message_enable_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t motohawk_example_message_average_radius_encode(float value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+float motohawk_example_message_average_radius_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool motohawk_example_message_average_radius_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+int16_t motohawk_example_message_temperature_encode(float value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+float motohawk_example_message_temperature_decode(int16_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool motohawk_example_message_temperature_is_in_range(int16_t value);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1473,6 +1473,40 @@ BATTERY_VT(
             self.assertFalse(os.path.exists(fuzzer_c))
             self.assertFalse(os.path.exists(fuzzer_mk))
 
+    def test_generate_c_source_single_floating_point_numbers(self):
+        databases = [
+            'motohawk',
+        ]
+
+        for database in databases:
+            argv = [
+                'cantools',
+                'generate_c_source',
+                '--single-precision-floating-point',
+                'tests/files/dbc/{}.dbc'.format(database)
+            ]
+
+            database_h = database + '.h'
+            database_c = database + '.c'
+            expected_database_h = database + '_no_floating_point_numbers.h'
+            expected_database_c = database + '_no_floating_point_numbers.c'
+
+            if os.path.exists(database_h):
+                os.remove(database_h)
+
+            if os.path.exists(database_c):
+                os.remove(database_c)
+
+            with patch('sys.argv', argv):
+                cantools._main()
+
+            if sys.version_info[0] > 2:
+                self.assert_files_equal(
+                    database_h,
+                    'tests/files/c_source/' + expected_database_h)
+                self.assert_files_equal(
+                    database_c,
+                    'tests/files/c_source/' + expected_database_c)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For targets having single precision as native type for floating point numbers, ability to generate C code with float type instead double is welcome.
This pull request implements this possibility by adding the CLI option "--single-precision-floating-point":

- If specified, "float" is used in the generated C code.
- If not specified, "double" is used in the generated C code (the default behavior is then not modified).

A test has been added but not run due to difficulties with my Linux Ubuntu 16.04 (I work mainly under Windows). I'm not able to install Python 3.6  and lack time to setup another linux.
