### PR TITLE
fix the tester test for newer python can versions

### DIFF
--- a/cantools/tester.py
+++ b/cantools/tester.py
@@ -192,7 +192,7 @@ class Message(UserDict, object):
                                     self.scaling,
                                     self.padding)
         self._can_message = can.Message(arbitration_id=arbitration_id,
-                                        extended_id=extended_id,
+                                        is_extended_id=extended_id,
                                         data=data)
 
         if self._periodic_task is not None:

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -13,7 +13,7 @@ except ImportError:
 import cantools
 
 
-class CanBus(object):
+class CanBus(can.BusABC):
 
     def __init__(self):
         self.channel_info = None


### PR DESCRIPTION
also, specify the minimum required python-can version. this was motivated by https://github.com/cantools/cantools/pull/399#issuecomment-1046026905 but is probably unrelated to #399.