### PR TITLE
DBC: Add support for STRING type in GenMsgSendType

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -1386,8 +1386,11 @@ def _load_messages(tokens,
 
         try:
             result = message_attributes['GenMsgSendType'].value
-            # Resolve ENUM index to ENUM text
-            result = definitions['GenMsgSendType'].choices[int(result)]
+            
+            # if definitions is enum (otherwise above value is maintained) -> Prevents ValueError
+            if definitions['GenMsgSendType'].choices != None:
+                # Resolve ENUM index to ENUM text
+                result = definitions['GenMsgSendType'].choices[int(result)]
         except (KeyError, TypeError):
             try:
                 result = definitions['GenMsgSendType'].default_value

--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -1388,9 +1388,7 @@ def _load_messages(tokens,
             result = message_attributes['GenMsgSendType'].value
             
             # if definitions is enum (otherwise above value is maintained) -> Prevents ValueError
-            if definitions['GenMsgSendType'].choices is not None and \
-
-                int(result) in definitions['GenMsgSendType'].choices:
+            if definitions['GenMsgSendType'].choices != None:
                 # Resolve ENUM index to ENUM text
                 result = definitions['GenMsgSendType'].choices[int(result)]
         except (KeyError, TypeError):

--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -1388,7 +1388,9 @@ def _load_messages(tokens,
             result = message_attributes['GenMsgSendType'].value
             
             # if definitions is enum (otherwise above value is maintained) -> Prevents ValueError
-            if definitions['GenMsgSendType'].choices != None:
+            if definitions['GenMsgSendType'].choices is not None and \
+
+                int(result) in definitions['GenMsgSendType'].choices:
                 # Resolve ENUM index to ENUM text
                 result = definitions['GenMsgSendType'].choices[int(result)]
         except (KeyError, TypeError):

--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -1389,6 +1389,7 @@ def _load_messages(tokens,
             
             # if definitions is enum (otherwise above value is maintained) -> Prevents ValueError
             if definitions['GenMsgSendType'].choices is not None and \
+
                 int(result) in definitions['GenMsgSendType'].choices:
                 # Resolve ENUM index to ENUM text
                 result = definitions['GenMsgSendType'].choices[int(result)]

--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -1389,7 +1389,6 @@ def _load_messages(tokens,
             
             # if definitions is enum (otherwise above value is maintained) -> Prevents ValueError
             if definitions['GenMsgSendType'].choices is not None and \
-
                 int(result) in definitions['GenMsgSendType'].choices:
                 # Resolve ENUM index to ENUM text
                 result = definitions['GenMsgSendType'].choices[int(result)]

--- a/tests/files/dbc/attribute_Event.dbc
+++ b/tests/files/dbc/attribute_Event.dbc
@@ -1,0 +1,50 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: TheNode
+
+
+
+BO_ 1234 INV2EventMsg1: 8 Inv2
+ SG_ TheSignal : 0|8@1- (1,0) [0|0] "" Vector__XXX
+
+
+BA_DEF_ BO_  "GenMsgSendType" STRING ;
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 100;
+BA_ "GenMsgSendType" BO_ 1234 "Event";
+BA_ "GenMsgCycleTime" BO_ 1234 0;
+
+
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3043,7 +3043,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         self.assertEqual(reg_id_msg.is_extended_frame, False)
         self.assertEqual(ext_id_msg.is_extended_frame, True)
-
+ 
+    def test_event_attributes(self):
+        db = cantools.db.load_file('tests/files/dbc/attribute_Event.dbc')
+        
+        self.assertEqual(db.messages[0].send_type, 'Event')
+        self.assertEqual(db.messages[0].frame_id, 1234)
+        self.assertEqual( db.messages[0].name, 'INV2EventMsg1')
+        
     def test_attributes(self):
         filename = 'tests/files/dbc/attributes.dbc'
 


### PR DESCRIPTION
BUG fixing: 
---------------------
Prevents ValueError in case of  result = message_attributes['GenMsgSendType'].value is a String value.

Necessary in case of Evnet-based sending like in that dbc attribute expression:

BA_ "GenMsgSendType" BO_ 1373 "Event";
BA_ "GenMsgCycleTime" BO_ 1373 0;

in Vector CANdb++ generated dbcs.

Greetings Maurice