### PR TITLE
monitor, dump: Improve/implement handling of container messages

### DIFF
--- a/cantools/subparsers/monitor.py
+++ b/cantools/subparsers/monitor.py
@@ -365,7 +365,13 @@ class Monitor(can.Listener):
             self._try_update_container(message, timestamp, data)
             return
 
-        if len(data) != message.length:
+        if len(data) < message.length:
+            formatted = [
+                f'{timestamp:12.3f} {message.name} '
+                f'( undecoded, {message.length - len(data)} bytes '
+                f'too short: 0x{data.hex()} )'
+            ]
+            self._update_formatted_message(message.name, formatted)
             self._discarded += 1
             return
 

--- a/cantools/subparsers/monitor.py
+++ b/cantools/subparsers/monitor.py
@@ -434,7 +434,7 @@ class Monitor(can.Listener):
         contained_names = []
         for cmsg, _ in decoded:
             if isinstance(cmsg, int):
-                tmp = dbmsg.get_contained_message_by_header_id(cmsg) # type: ignore
+                tmp = dbmsg.get_contained_message_by_header_id(cmsg)
                 cmsg_name = f'0x{cmsg:x}' if tmp is None else tmp.name
             else:
                 cmsg_name = cmsg.name
@@ -461,7 +461,7 @@ class Monitor(can.Listener):
         # by '.'
         for cmsg, cdata in decoded:
             if isinstance(cmsg, int):
-                tmp = dbmsg.get_contained_message_by_header_id(cmsg) # type: ignore
+                tmp = dbmsg.get_contained_message_by_header_id(cmsg)
                 cmsg_name = f'0x{cmsg:x}' if tmp is None else tmp.name
                 full_name = f'{dbmsg.name} :: {cmsg_name}'
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -741,11 +741,11 @@ BATTERY_VT(
 
   ------------------------------------------------------------------------
 
-  Name:       ExampleMessage
-  Id:         0x1f0
-  Length:     8 bytes
-  Cycle time: - ms
-  Senders:    PCM1
+  Name:           ExampleMessage
+  Id:             0x1f0
+  Length:         8 bytes
+  Cycle time:     - ms
+  Senders:        PCM1
   Layout:
 
                           Bit
@@ -812,11 +812,11 @@ BATTERY_VT(
 
   ------------------------------------------------------------------------
 
-  Name:       ExampleMessage
-  Id:         0x1f0
-  Length:     8 bytes
-  Cycle time: - ms
-  Senders:    PCM1
+  Name:           ExampleMessage
+  Id:             0x1f0
+  Length:         8 bytes
+  Cycle time:     - ms
+  Senders:        PCM1
   Layout:
 
                           Bit
@@ -885,16 +885,16 @@ BATTERY_VT(
 
   ------------------------------------------------------------------------
 
-  Name:       Message1
-  Id:         0x123456
+  Name:           Message1
+  Id:             0x123456
       Priority:       0
       PGN:            0x01200
       Source:         0x56
       Destination:    0x34
       Format:         PDU 1
-  Length:     8 bytes
-  Cycle time: - ms
-  Senders:    -
+  Length:         8 bytes
+  Cycle time:     - ms
+  Senders:        -
   Layout:
 
                           Bit
@@ -985,11 +985,11 @@ BATTERY_VT(
 
   ------------------------------------------------------------------------
 
-  Name:       Foo
-  Id:         0x1d8
-  Length:     1 bytes
-  Cycle time: - ms
-  Senders:    -
+  Name:           Foo
+  Id:             0x1d8
+  Length:         1 bytes
+  Cycle time:     - ms
+  Senders:        -
   Layout:
 
                           Bit
@@ -1030,11 +1030,11 @@ BATTERY_VT(
 
   ------------------------------------------------------------------------
 
-  Name:       Message0
-  Id:         0x400
-  Length:     8 bytes
-  Cycle time: - ms
-  Senders:    Node0
+  Name:           Message0
+  Id:             0x400
+  Length:         8 bytes
+  Cycle time:     - ms
+  Senders:        Node0
   Layout:
 
                           Bit
@@ -1108,16 +1108,16 @@ BATTERY_VT(
 
   ------------------------------------------------------------------------
 
-  Name:       Message1
-  Id:         0x15340201
+  Name:           Message1
+  Id:             0x15340201
       Priority:       5
       PGN:            0x13400
       Source:         0x01
       Destination:    0x02
       Format:         PDU 1
-  Length:     8 bytes
-  Cycle time: - ms
-  Senders:    Node1
+  Length:         8 bytes
+  Cycle time:     - ms
+  Senders:        Node1
   Layout:
 
                           Bit
@@ -1150,16 +1150,16 @@ BATTERY_VT(
 
   ------------------------------------------------------------------------
 
-  Name:       Message2
-  Id:         0x15f01002
+  Name:           Message2
+  Id:             0x15f01002
       Priority:       5
       PGN:            0x1f010
       Source:         0x02
       Destination:    All
       Format:         PDU 2
-  Length:     8 bytes
-  Cycle time: - ms
-  Senders:    Node2
+  Length:         8 bytes
+  Cycle time:     - ms
+  Senders:        Node2
   Layout:
 
                           Bit

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -281,14 +281,9 @@ class CanToolsMonitorTest(unittest.TestCase):
             stdscr.addstr,
             [
                 call(0, 0, 'Received: 1, Discarded: 1, Errors: 0'),
-                call(1,
-                     0,
-                     '   TIMESTAMP  MESSAGE                                           ',
-                     'green'),
-                call(29,
-                     0,
-                     'q: Quit, f: Filter, p: Play/Pause, r: Reset                     ',
-                     'cyan')
+                call(1, 0, '   TIMESTAMP  MESSAGE                                           ', 'green'),
+                call(2, 0, '       0.000 BATTERY_VT ( undecoded: 0x240098980b00 )'),
+                call(29, 0, 'q: Quit, f: Filter, p: Play/Pause, r: Reset                     ', 'cyan')
             ])
 
     @patch('can.Notifier')


### PR DESCRIPTION
With this PR, the `dump` subparser gains support for container messages, and `monitor` becomes useful for scenarios involving containers. The general idea is the same: For the container messages themselves, only a "table of contents" is printed, while the actual child messages are printed as separate messages named `{container.name} :: {child.name}`.

Besides this, the `monitor` subparser now only increases the number of lines used to display a given message, i.e., the "display real estate" used for a message never gets smaller. This significantly reduces the jittering of the screen contents if messages that require a variable number of lines -- like containers and multiplexer messages -- are involved. (IMO, the `monitor` subparser only has a very limited amount of value with the current behaviour in this scenario.)

Andreas Lauser &lt;<andreas.lauser@daimler.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)