### PR TITLE
ARXML: Use floats to represent the minimum and maximum of data types featuring linear segments

### DIFF
--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -1622,8 +1622,8 @@ class SystemLoader(object):
         factor, offset = \
             self._load_linear_factor_and_offset(compu_scale, decimal)
 
-        factor = 1 if factor is None else factor
-        offset = 0 if offset is None else offset
+        factor = 1.0 if factor is None else factor
+        offset = 0.0 if offset is None else offset
 
         # range of the physical values
         minimum = None if minimum_int is None else minimum_int*factor + offset
@@ -1671,12 +1671,12 @@ class SystemLoader(object):
             if factor_scale is not None:
                 factor = factor_scale
             else:
-                factor_scale = 1
+                factor_scale = 1.0
 
             if offset_scale is not None:
                 offset = offset_scale
             else:
-                offset_scale = 0
+                offset_scale = 0.0
 
             # range of the physical values of the scale.
             if minimum is None:

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -312,7 +312,7 @@ Message1:
       Unit: wp
       Initial value: False
       Is signed: False
-      Minimum: 0
+      Minimum: 0.0
       Maximum: 0.1
       Offset: 0.0
       Scaling factor: 0.1


### PR DESCRIPTION
Conceptually, values that represent quantities from the physical world are always floating point values. In practice, this should not matter too much because such tables often exhibit a scaling factor of 1 and an offset of 0. It does not hurt to also handle the corner cases, though...

Andreas Lauser &lt;<andreas.lauser@daimler.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)
