### PR TITLE
Modularize the 'strict' mode for encoding messages

### DIFF
--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -78,8 +78,8 @@ class Message(object):
                  senders: Optional[List[str]] = None,
                  send_type: Optional[str] = None,
                  cycle_time: Optional[int] = None,
-                 dbc_specifics: Optional["DbcSpecifics"] = None,
-                 autosar_specifics: Optional["AutosarMessageSpecifics"] = None,
+                 dbc_specifics: Optional['DbcSpecifics'] = None,
+                 autosar_specifics: Optional['AutosarMessageSpecifics'] = None,
                  is_extended_frame: bool = False,
                  is_fd: bool = False,
                  bus_name: Optional[str] = None,
@@ -382,8 +382,8 @@ class Message(object):
             return None
         elif self._comments.get(None) is not None:
             return self._comments.get(None)
-        elif self._comments.get("FOR-ALL") is not None:
-            return self._comments.get("FOR-ALL")
+        elif self._comments.get('FOR-ALL') is not None:
+            return self._comments.get('FOR-ALL')
 
         return self._comments.get('EN')
 
@@ -431,7 +431,7 @@ class Message(object):
         return self._cycle_time
 
     @property
-    def dbc(self) -> Optional["DbcSpecifics"]:
+    def dbc(self) -> Optional['DbcSpecifics']:
         """An object containing dbc specific properties like e.g. attributes.
 
         """
@@ -439,11 +439,11 @@ class Message(object):
         return self._dbc
 
     @dbc.setter
-    def dbc(self, value: Optional["DbcSpecifics"]) -> None:
+    def dbc(self, value: Optional['DbcSpecifics']) -> None:
         self._dbc = value
 
     @property
-    def autosar(self) -> Optional["AutosarMessageSpecifics"]:
+    def autosar(self) -> Optional['AutosarMessageSpecifics']:
         """An object containing AUTOSAR specific properties
 
         e.g. auxiliary data required to implement CRCs, secure on-board
@@ -453,7 +453,7 @@ class Message(object):
         return self._autosar
 
     @autosar.setter
-    def autosar(self, value: Optional["AutosarMessageSpecifics"]) -> None:
+    def autosar(self, value: Optional['AutosarMessageSpecifics']) -> None:
         self._autosar = value
 
     @property
@@ -518,8 +518,8 @@ class Message(object):
         for signal in node['signals']:
             val = input_data.get(signal.name)
             if val is None:
-                raise EncodeError(f"The signal '{signal.name}' is "
-                                  f"required for encoding.")
+                raise EncodeError(f'The signal "{signal.name}" is '
+                                  f'required for encoding.')
             result[signal.name] = val
 
         for mux_signal_name, mux_nodes in node['multiplexers'].items():
@@ -1058,7 +1058,7 @@ class Message(object):
                                   f'decode_containers parameter to True')
 
         if self._codecs is None:
-            raise ValueError("Codec is not initialized.")
+            raise ValueError('Codec is not initialized.')
 
         data = data[:self._length]
 
@@ -1116,7 +1116,7 @@ class Message(object):
 
         """
         if self._codecs is None:
-            raise ValueError("Codec is not initialized.")
+            raise ValueError('Codec is not initialized.')
 
         return bool(self._codecs['multiplexers'])
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -63,7 +63,7 @@ class CanToolsConvertFullTest(unittest.TestCase):
                     #print("    "+f"sig.{a}".ljust(30) + str(getattr(sig1, a)).ljust(10) + " == %s" % getattr(sig2, a))
                     self.assertEqual(getattr(sig1, a), getattr(sig2, a), "%s does not match for signal %s in message %s" % (a, sig1.name, msg1.name))
 
-                print()
+                #print()
 
     def remove_out_file(self, fn_out):
         path = os.path.split(fn_out)[0]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -714,38 +714,38 @@ class CanToolsDatabaseTest(unittest.TestCase):
             (
                 'Message1',
                 0,
-                "Expected signal 'Signal1' value greater than or equal to 1 in "
-                "message 'Message1', but got 0."
+                'Expected signal "Signal1" value greater than or equal to 1 in '
+                'message "Message1", but got 0.'
             ),
             (
                 'Message1',
                 3,
-                "Expected signal 'Signal1' value less than or equal to 2 in "
-                "message 'Message1', but got 3."
+                'Expected signal "Signal1" value less than or equal to 2 in '
+                'message "Message1", but got 3.'
             ),
             (
                 'Message2',
                 0,
-                "Expected signal 'Signal1' value greater than or equal to 1 in "
-                "message 'Message2', but got 0."
+                'Expected signal "Signal1" value greater than or equal to 1 in '
+                'message "Message2", but got 0.'
             ),
             (
                 'Message3',
                 3,
-                "Expected signal 'Signal1' value less than or equal to 2 in "
-                "message 'Message3', but got 3."
+                'Expected signal "Signal1" value less than or equal to 2 in '
+                'message "Message3", but got 3.'
             ),
             (
                 'Message4',
                 1.9,
-                "Expected signal 'Signal1' value greater than or equal to 2 in "
-                "message 'Message4', but got 1.9."
+                'Expected signal "Signal1" value greater than or equal to 2 in '
+                'message "Message4", but got 1.9.'
             ),
             (
                 'Message4',
                 8.1,
-                "Expected signal 'Signal1' value less than or equal to 8 in "
-                "message 'Message4', but got 8.1."
+                'Expected signal "Signal1" value less than or equal to 8 in '
+                'message "Message4", but got 8.1.'
             )
         ]
 
@@ -772,7 +772,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         self.assertEqual(
             str(cm.exception),
-            "The signal 'Signal1' is required for encoding.")
+            'The signal "Signal1" is required for encoding.')
 
         # Missing value, but checks disabled.
         with self.assertRaises(KeyError):


### PR DESCRIPTION
Passing `strict=True` to `message.encode()` is now just a shortcut for calling `message.assert_{signals,container}_encodable()` before `message.encode()`. Thus, if `strict=False` is passed, the calling code can decide which checks (if any) to apply.

Besides this, `Message.gather_signals()` is added. Given a dictionary containing a superset of all required signals, this method produces a dictionary with only the signal values that are required to encode the message. (The `Message.gather_container()` method serves the same purpose for container messages.) This is quite useful if the application's state is kept in a global dictionary, but one wants to use strict mode when encoding messages during development to avoid mistakes.

This should close [#358](https://github.com/cantools/cantools/issues/358).

Andreas Lauser &lt;<andreas.lauser@daimler.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)
