### PR TITLE
Implement AUTOSAR end-to-end protection

### DIFF
--- a/cantools/autosar/__init__.py
+++ b/cantools/autosar/__init__.py
@@ -1,0 +1,3 @@
+# a collection of AUTOSAR specific functionality
+
+from .end_to_end import *

--- a/cantools/autosar/end_to_end.py
+++ b/cantools/autosar/end_to_end.py
@@ -1,0 +1,182 @@
+# Utilities for calculating the CRC of the AUTOSAR end-to-end
+# protection specification
+
+import crccheck # type: ignore
+
+from ..database.can.message import Message
+
+from typing import Union, List, Optional
+
+def compute_profile2_crc(payload : Union[bytes, bytearray],
+                         msg_or_data_id: Union[int, Message]) -> Optional[int]:
+    """Compute the CRC checksum for profile 2 of the AUTOSAR end-to-end
+    protection specification.
+
+    data_id is the data ID to be used. If it is unspecified, it is
+    determined from the message's ``autosar.e2e.data_ids`` attribute.
+    """
+
+    if len(payload) < 2:
+        # Profile 2 E2E protection requires at least 2 bytes
+        return None
+
+    data_id = None
+    secured_len = len(payload)
+    if isinstance(msg_or_data_id, Message):
+        msg = msg_or_data_id
+        if msg.autosar is None or \
+           msg.autosar.e2e is None or \
+           msg.autosar.e2e.data_ids is None or \
+           len(msg.autosar.e2e.data_ids) != 16:
+            # message is not end-to-end protected using profile 2
+            return None
+
+        assert msg.autosar is not None
+        assert msg.autosar.e2e is not None
+        assert msg.autosar.e2e.data_ids is not None
+
+        seq_counter = (payload[1]&0xf0) >> 4
+        data_id = msg.autosar.e2e.data_ids[seq_counter]
+
+        if msg.autosar.is_secured:
+            secured_len = msg.autosar.secured_payload_length
+    else:
+        data_id = msg_or_data_id
+
+    # create the data to be checksumed
+    crc_data = bytearray(payload[1:secured_len])
+
+    # append data id
+    crc_data += bytearray([ data_id ])
+
+    # do the actual work
+    return int(crccheck.crc.Crc8Autosar().calc(crc_data))
+
+def apply_profile2_crc(payload : Union[bytes, bytearray],
+                       msg_or_data_id: Union[int, Message]) \
+  -> Optional[bytearray]:
+    """Compute the CRC checksum for profile 2 of the AUTOSAR end-to-end
+    protection specification and apply it to an encoded payload.
+
+    If the message is passed, this function also takes care of special
+    cases like the message not being end-to-end protected or being a
+    secured frame.
+    """
+
+    crc = compute_profile2_crc(payload, msg_or_data_id)
+
+    if crc is None:
+        return None
+
+    result = bytearray(payload)
+    result[0] = crc
+    return result
+
+
+def check_profile2_crc(payload : Union[bytes, bytearray],
+                       msg_or_data_id: Union[int, Message]) -> bool:
+    """Check if the AUTOSAR E2E checksum for profile 2 of the AUTOSAR
+    end-to-end protection specification is correct.
+
+    If a message is not end-to-end protected by profile 2, ``False`` is
+    returned.
+    """
+
+    crc = compute_profile2_crc(payload, msg_or_data_id)
+
+    if crc is None:
+        return False
+
+    crc2 = payload[0]
+
+    return crc == crc2
+
+def compute_profile5_crc(payload : Union[bytes, bytearray],
+                         msg_or_data_id: Union[int, Message]) -> Optional[int]:
+    """Compute the CRC checksum for profile 5 of the AUTOSAR end-to-end
+    protection specification.
+
+    data_id is the data ID to be used. If it is unspecified, it is
+    determined from the message's ``autosar.e2e.data_ids`` attribute.
+    """
+
+    if len(payload) < 4:
+        # Profile 5 E2E protection requires at least 4 bytes
+        return None
+
+    data_id = None
+    secured_len = len(payload)
+    if isinstance(msg_or_data_id, Message):
+        msg = msg_or_data_id
+        if msg_or_data_id.autosar is None or \
+           msg_or_data_id.autosar.e2e is None or \
+           msg_or_data_id.autosar.e2e.data_ids is None or \
+           len(msg_or_data_id.autosar.e2e.data_ids) != 1:
+            # message is not end-to-end protected using profile 5
+            return None
+
+        assert msg.autosar is not None
+        assert msg.autosar.e2e is not None
+        assert msg.autosar.e2e.data_ids is not None
+
+        data_id = msg.autosar.e2e.data_ids[0]
+
+        if msg.autosar.is_secured:
+            secured_len = msg.autosar.secured_payload_length
+    else:
+        data_id = msg_or_data_id
+
+    # we assume that the "offset" parameter given in the specification
+    # is always 0...
+    result = crccheck.crc.Crc16Autosar().calc(payload[2:secured_len],
+                                              initvalue=0xffff)
+
+    # deal with the data id
+    result = crccheck.crc.Crc16Autosar().calc(bytearray([data_id&0xff]),
+                                              initvalue=result)
+    result = crccheck.crc.Crc16Autosar().calc(bytearray([(data_id>>8)&0xff]),
+                                              initvalue=result)
+
+    return int(result)
+
+def apply_profile5_crc(payload : Union[bytes, bytearray],
+                       msg_or_data_id: Union[int, Message]) \
+  -> Optional[bytearray]:
+    """Compute the AUTOSAR E2E checksum for profile 5 of the AUTOSAR
+    end-to-end protection specification and apply it to an encoded
+    payload.
+
+    If the message is passed, this function also takes care of special
+    cases like the message not being end-to-end protected or being a
+    secured frame.
+
+    """
+
+    crc = compute_profile5_crc(payload, msg_or_data_id)
+
+    if crc is None:
+        return None
+
+    result = bytearray(payload)
+    result[0] = crc&0xff
+    result[1] = (crc>>8)&0xff
+
+    return result
+
+def check_profile5_crc(payload : Union[bytes, bytearray],
+                       msg_or_data_id: Union[int, Message]) -> bool:
+    """Check if the AUTOSAR E2E checksum for profile 5 of the AUTOSAR
+    end-to-end protection specification is correct.
+
+    If a message is not end-to-end protected by profile 5, ``False`` is
+    returned.
+    """
+
+    crc = compute_profile5_crc(payload, msg_or_data_id)
+
+    if crc is None:
+        return False
+
+    crc2 = payload[0] + (payload[1]<<8)
+
+    return crc == crc2

--- a/cantools/subparsers/list.py
+++ b/cantools/subparsers/list.py
@@ -31,6 +31,10 @@ def _print_message(message, indent=''):
     if message.cycle_time is not None:
         print(f'{indent}  Cycle time: {message.cycle_time} ms')
 
+    if message.autosar and message.autosar.e2e:
+        print(f'{indent}  End-to-end category: {message.autosar.e2e.category}')
+        print(f'{indent}  Data IDs: {message.autosar.e2e.data_ids}')
+
     if message.signals:
         print(f'{indent}  Signal tree:')
         st = signal_tree_string(message, console_width=1000*1000)

--- a/cantools/subparsers/list.py
+++ b/cantools/subparsers/list.py
@@ -35,6 +35,17 @@ def _print_message(message, indent=''):
         print(f'{indent}  End-to-end category: {message.autosar.e2e.category}')
         print(f'{indent}  Data IDs: {message.autosar.e2e.data_ids}')
 
+    is_secured = False
+    if message.autosar and \
+       message.autosar.is_secured:
+        is_secured = True
+
+    print(f'{indent}  Is secured: {is_secured}')
+
+    if is_secured:
+        print(f'{indent}  Secured payload size: '
+              f'{message.autosar.secured_payload_length}')
+
     if message.signals:
         print(f'{indent}  Signal tree:')
         st = signal_tree_string(message, console_width=1000*1000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 bitstruct >= 8.12.1
+crccheck
 codespell
 mock
 python-can

--- a/tests/files/arxml/system-3.2.3.arxml
+++ b/tests/files/arxml/system-3.2.3.arxml
@@ -153,6 +153,24 @@
           <DATA-TYPE-REF DEST="INTEGER-TYPE">/DataTypes/MultiplexSelector</DATA-TYPE-REF>
           <LENGTH>2</LENGTH>
         </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/Checksum -->
+        <SYSTEM-SIGNAL UUID="7531a1caf3df44ada375af1713eeb6c2">
+          <SHORT-NAME>Checksum</SHORT-NAME>
+          <DESC>
+            <L-2 L="EN">AUTOSAR end-to-end protection CRC according to profile 2</L-2>
+          </DESC>
+          <DATA-TYPE-REF DEST="INTEGER-TYPE">/DataTypes/Integer</DATA-TYPE-REF>
+          <LENGTH>8</LENGTH>
+        </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/SequenceCounter -->
+        <SYSTEM-SIGNAL UUID="456b676d0744498cb9fbf8e6ec03ba7f">
+          <SHORT-NAME>SequenceCounter</SHORT-NAME>
+          <DESC>
+            <L-2 L="EN">AUTOSAR end-to-end protection sequence counter according to profile 2</L-2>
+          </DESC>
+          <DATA-TYPE-REF DEST="INTEGER-TYPE">/DataTypes/Integer</DATA-TYPE-REF>
+          <LENGTH>4</LENGTH>
+        </SYSTEM-SIGNAL>
         <!-- /SystemSignals/IsAlive -->
         <SYSTEM-SIGNAL UUID="d81e9932feaf514c0b04bfd10d259013">
           <SHORT-NAME>IsAlive</SHORT-NAME>
@@ -426,7 +444,7 @@
                     <!-- /Network/CanCluster/CAN/PDUs/Status -->
                     <SIGNAL-I-PDU UUID="02a323c0ebfeeb13c5ac0f42488d767d">
                       <SHORT-NAME>Status</SHORT-NAME>
-                      <LENGTH>1</LENGTH>
+                      <LENGTH>3</LENGTH>
                       <I-PDU-TIMING-SPECIFICATION>
                         <CYCLIC-TIMING>
                           <REPEATING-TIME>
@@ -439,33 +457,47 @@
                         <MINIMUM-DELAY>0.01</MINIMUM-DELAY>
                       </I-PDU-TIMING-SPECIFICATION>
                       <SIGNAL-TO-PDU-MAPPINGS>
+                        <!-- /Network/CanCluster/CAN/PDUs/ChecksumMapping -->
+                        <I-SIGNAL-TO-I-PDU-MAPPING UUID="445b106734604db694900910b6e8ed04">
+                          <SHORT-NAME>ChecksumMapping</SHORT-NAME>
+                          <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
+                          <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Status/Checksum</SIGNAL-REF>
+                          <START-POSITION>0</START-POSITION>
+                        </I-SIGNAL-TO-I-PDU-MAPPING>
+                        <!-- /Network/CanCluster/CAN/PDUs/SequenceCounterMapping -->
+                        <I-SIGNAL-TO-I-PDU-MAPPING UUID="dc7db079d14c45c99df2ec21977974dd">
+                          <SHORT-NAME>SequenceCounterMapping</SHORT-NAME>
+                          <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
+                          <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Status/SequenceCounter</SIGNAL-REF>
+                          <START-POSITION>12</START-POSITION>
+                        </I-SIGNAL-TO-I-PDU-MAPPING>
                         <!-- /Network/CanCluster/CAN/PDUs/AliveMapping -->
                         <I-SIGNAL-TO-I-PDU-MAPPING UUID="193a3a3d59ef551a4007497ed778baeb">
                           <SHORT-NAME>AliveMapping</SHORT-NAME>
                           <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
                           <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Status/Alive</SIGNAL-REF>
-                          <START-POSITION>0</START-POSITION>
+                          <START-POSITION>16</START-POSITION>
                         </I-SIGNAL-TO-I-PDU-MAPPING>
                         <!-- /Network/CanCluster/CAN/PDUs/SleepMapping -->
                         <I-SIGNAL-TO-I-PDU-MAPPING UUID="193a3a3d59ef551a4007497ed778baeb">
                           <SHORT-NAME>SleepMapping</SHORT-NAME>
                           <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
                           <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Status/Sleeps</SIGNAL-REF>
-                          <START-POSITION>1</START-POSITION>
+                          <START-POSITION>17</START-POSITION>
                         </I-SIGNAL-TO-I-PDU-MAPPING>
                         <!-- /Network/CanCluster/CAN/PDUs/PositionMapping -->
                         <I-SIGNAL-TO-I-PDU-MAPPING UUID="8662b1aff79c78cca00b319a89f42fd7">
                           <SHORT-NAME>PositionMapping</SHORT-NAME>
                           <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
                           <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Status/Position</SIGNAL-REF>
-                          <START-POSITION>3</START-POSITION>
+                          <START-POSITION>19</START-POSITION>
                         </I-SIGNAL-TO-I-PDU-MAPPING>
                         <!-- /Network/CanCluster/CAN/PDUs/MovementMapping -->
                         <I-SIGNAL-TO-I-PDU-MAPPING UUID="1af43965e283bd5921b9832d183832c1">
                           <SHORT-NAME>MovementMapping</SHORT-NAME>
                           <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
                           <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Status/Movement</SIGNAL-REF>
-                          <START-POSITION>5</START-POSITION>
+                          <START-POSITION>21</START-POSITION>
                         </I-SIGNAL-TO-I-PDU-MAPPING>
                         <!-- /Network/CanCluster/CAN/PDUs/PositionMovementGroupMapping -->
                         <I-SIGNAL-TO-I-PDU-MAPPING UUID="ae3fc5e7d33ace46bb8db8ef9d1b32f3">
@@ -521,6 +553,16 @@
                     <AR-PACKAGE UUID="d092f91b9733319fe3599c2d991c1c80">
                       <SHORT-NAME>Status</SHORT-NAME>
                       <ELEMENTS>
+                        <!-- /Network/CanCluster/CAN/ISignals/Status/Checksum -->
+                        <I-SIGNAL UUID="dc7db079d14c45c99df2ec21977974dd">
+			  <SHORT-NAME>Checksum</SHORT-NAME>
+                          <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/Checksum</SYSTEM-SIGNAL-REF>
+                        </I-SIGNAL>
+                        <!-- /Network/CanCluster/CAN/ISignals/Status/SequenceCounter -->
+                        <I-SIGNAL UUID="e05d9b2e0e164799856f79b60dd10d7c">
+			  <SHORT-NAME>SequenceCounter</SHORT-NAME>
+                          <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/SequenceCounter</SYSTEM-SIGNAL-REF>
+                        </I-SIGNAL>
                         <!-- /Network/CanCluster/CAN/ISignals/Status/Alive -->
                         <I-SIGNAL UUID="8889d143c798e7d0bd8cc6b91c0de364">
                           <SHORT-NAME>Alive</SHORT-NAME>
@@ -577,7 +619,7 @@
                       <DESC>
                         <L-2>The lonely frame description</L-2>
                       </DESC>
-                      <FRAME-LENGTH>1</FRAME-LENGTH>
+                      <FRAME-LENGTH>3</FRAME-LENGTH>
                       <PDU-TO-FRAME-MAPPINGS>
                         <!-- /Network/CanCluster/CAN/Frames/Status/StatusMapping -->
                         <PDU-TO-FRAME-MAPPING UUID="d95c16e24ffdc90dd424ded01440bc9c">
@@ -595,6 +637,48 @@
           </SUB-PACKAGES>
         </AR-PACKAGE>
       </SUB-PACKAGES>
+    </AR-PACKAGE>
+    <!-- /Network/E2EProtection -->
+    <AR-PACKAGE UUID="ca27093f100845be98fe6094731ab03b">
+      <SHORT-NAME>E2EProtection</SHORT-NAME>
+      <ELEMENTS>
+        <!-- /Network/E2EProtection/pset -->
+        <END-TO-END-PROTECTION-SET UUID="6313352860c346f698251c94394e1254">
+          <SHORT-NAME>pset</SHORT-NAME>
+          <END-TO-END-PROTECTIONS>
+            <!-- /Network/E2EProtection/pset/protectmeplenty -->
+            <END-TO-END-PROTECTION UUID="17359182ebae411bb303f0b5d8aa106a">
+              <SHORT-NAME>protectmeplenty</SHORT-NAME>
+              <END-TO-END-PROFILE>
+                <CATEGORY>p2</CATEGORY> <!-- AUTOSAR profile 2 -->
+                <DATA-IDS>
+                  <DATA-ID>0</DATA-ID>
+                  <DATA-ID>1</DATA-ID>
+                  <DATA-ID>2</DATA-ID>
+                  <DATA-ID>3</DATA-ID>
+                  <DATA-ID>4</DATA-ID>
+                  <DATA-ID>5</DATA-ID>
+                  <DATA-ID>6</DATA-ID>
+                  <DATA-ID>7</DATA-ID>
+                  <DATA-ID>8</DATA-ID>
+                  <DATA-ID>9</DATA-ID>
+                  <DATA-ID>10</DATA-ID>
+                  <DATA-ID>11</DATA-ID>
+                  <DATA-ID>12</DATA-ID>
+                  <DATA-ID>13</DATA-ID>
+                  <DATA-ID>14</DATA-ID>
+                  <DATA-ID>15</DATA-ID>
+                </DATA-IDS>
+              </END-TO-END-PROFILE>
+              <END-TO-END-PROTECTION-I-SIGNAL-I-PDUS>
+                <END-TO-END-PROTECTION-I-SIGNAL-I-PDU>
+                  <I-SIGNAL-I-PDU-REF DEST="SIGNAL-I-PDU">/Network/CanCluster/CAN/PDUs/Status</I-SIGNAL-I-PDU-REF>
+                </END-TO-END-PROTECTION-I-SIGNAL-I-PDU>
+              </END-TO-END-PROTECTION-I-SIGNAL-I-PDUS>
+            </END-TO-END-PROTECTION>
+          </END-TO-END-PROTECTIONS>
+        </END-TO-END-PROTECTION-SET>
+      </ELEMENTS>
     </AR-PACKAGE>
   </TOP-LEVEL-PACKAGES>
 </AUTOSAR>

--- a/tests/files/arxml/system-3.2.3.arxml
+++ b/tests/files/arxml/system-3.2.3.arxml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AUTOSAR xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://autosar.org/3.2.3">
   <TOP-LEVEL-PACKAGES>
+    <!-- /DataTypes -->
     <AR-PACKAGE UUID="596d57028f777bc4cc548334060522b4">
       <SHORT-NAME>DataTypes</SHORT-NAME>
       <ELEMENTS>
+        <!-- /DataTypes/Movement -->
         <INTEGER-TYPE UUID="030d7ec5203a69b9454cb2777e64e329">
           <SHORT-NAME>Movement</SHORT-NAME>
           <SW-DATA-DEF-PROPS>
@@ -12,6 +14,7 @@
           <LOWER-LIMIT INTERVAL-TYPE="CLOSED">0</LOWER-LIMIT>
           <UPPER-LIMIT INTERVAL-TYPE="CLOSED">3</UPPER-LIMIT>
         </INTEGER-TYPE>
+        <!-- /DataTypes/Position -->
         <INTEGER-TYPE UUID="1fa3dab3cf6ac721b9994a6a2a56cf07">
           <SHORT-NAME>Position</SHORT-NAME>
           <SW-DATA-DEF-PROPS>
@@ -20,32 +23,38 @@
           <LOWER-LIMIT INTERVAL-TYPE="CLOSED">0</LOWER-LIMIT>
           <UPPER-LIMIT INTERVAL-TYPE="CLOSED">7</UPPER-LIMIT>
         </INTEGER-TYPE>
-	<INTEGER-TYPE UUID="201e91bc35814ab9a3bed09645011cdf">
-	  <SHORT-NAME>MultiplexSelector</SHORT-NAME>
+        <!-- /DataTypes/MultiplexSelector -->
+        <INTEGER-TYPE UUID="201e91bc35814ab9a3bed09645011cdf">
+          <SHORT-NAME>MultiplexSelector</SHORT-NAME>
           <SW-DATA-DEF-PROPS>
             <COMPU-METHOD-REF DEST="COMPU-METHOD">/CompuMethods/Identical</COMPU-METHOD-REF>
-	    <INVALID-VALUE>
-	      <INTEGER-LITERAL UUID="791ff33619ca4a649b6affbf23014578">
-		<SHORT-NAME>Invalid</SHORT-NAME>
-		<VALUE>3</VALUE>
-	      </INTEGER-LITERAL>
-	    </INVALID-VALUE>
+            <INVALID-VALUE>
+              <!-- /DataTypes/MultiplexSelector/Invalid -->
+              <INTEGER-LITERAL UUID="791ff33619ca4a649b6affbf23014578">
+                <SHORT-NAME>Invalid</SHORT-NAME>
+                <VALUE>3</VALUE>
+              </INTEGER-LITERAL>
+            </INVALID-VALUE>
           </SW-DATA-DEF-PROPS>
-	</INTEGER-TYPE>
+        </INTEGER-TYPE>
+        <!-- /DataTypes/Integer -->
         <INTEGER-TYPE UUID="814eb2db91a343fba2738b9507009317">
           <SHORT-NAME>Integer</SHORT-NAME>
           <SW-DATA-DEF-PROPS>
             <COMPU-METHOD-REF DEST="COMPU-METHOD">/CompuMethods/Identical</COMPU-METHOD-REF>
           </SW-DATA-DEF-PROPS>
         </INTEGER-TYPE>
+        <!-- /DataTypes/Boolean -->
         <BOOLEAN-TYPE UUID="3df650d43ea5b9d6173cbf1922adad77">
           <SHORT-NAME>Boolean</SHORT-NAME>
         </BOOLEAN-TYPE>
       </ELEMENTS>
     </AR-PACKAGE>
+    <!-- /CompuMethods -->
     <AR-PACKAGE UUID="48a80c79345a00b111923d5e52041ca2">
       <SHORT-NAME>CompuMethods</SHORT-NAME>
       <ELEMENTS>
+        <!-- /CompuMethods/Movement -->
         <COMPU-METHOD UUID="0d8ea46e74eb86d0d89f1c629a73ccea">
           <SHORT-NAME>Movement</SHORT-NAME>
           <CATEGORY>LINEAR</CATEGORY>
@@ -62,6 +71,7 @@
             </COMPU-SCALES>
           </COMPU-INTERNAL-TO-PHYS>
         </COMPU-METHOD>
+        <!-- /CompuMethods/Position -->
         <COMPU-METHOD UUID="c5acee518d38ca443f70b09e227849c1">
           <SHORT-NAME>Position</SHORT-NAME>
           <CATEGORY>TEXTTABLE</CATEGORY>
@@ -94,47 +104,56 @@
             </COMPU-SCALES>
           </COMPU-INTERNAL-TO-PHYS>
         </COMPU-METHOD>
+        <!-- /CompuMethods/Identical -->
         <COMPU-METHOD UUID="9bb3f300fe314e21979609e0e75419ff">
           <SHORT-NAME>Identical</SHORT-NAME>
           <CATEGORY>IDENTICAL</CATEGORY>
         </COMPU-METHOD>
       </ELEMENTS>
     </AR-PACKAGE>
+    <!-- /SystemSignals -->
     <AR-PACKAGE UUID="0a2e07bb2ca11243a466a8743ba9774c">
       <SHORT-NAME>SystemSignals</SHORT-NAME>
       <ELEMENTS>
+        <!-- /SystemSignals/MultiplexedStatic -->
         <SYSTEM-SIGNAL UUID="65f9a160cdca4896bd7cfa085033196b">
           <SHORT-NAME>MultiplexedStatic</SHORT-NAME>
           <DATA-TYPE-REF DEST="BOOLEAN-TYPE">/DataTypes/Boolean</DATA-TYPE-REF>
           <INIT-VALUE-REF DEST="BOOLEAN-LITERAL">/Constants/BooleanFalse/literal</INIT-VALUE-REF>
           <LENGTH>3</LENGTH>
         </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/MultiplexedStatic2 -->
         <SYSTEM-SIGNAL UUID="b782eebb07e04418a24e3345bd989526">
           <SHORT-NAME>MultiplexedStatic2</SHORT-NAME>
           <DATA-TYPE-REF DEST="INTEGER-TYPE">/DataTypes/Integer</DATA-TYPE-REF>
           <LENGTH>8</LENGTH>
         </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/MultiplexedHello -->
         <SYSTEM-SIGNAL UUID="e19e0f192d034018bfae433807d70d45">
           <SHORT-NAME>MultiplexedHello</SHORT-NAME>
           <DATA-TYPE-REF DEST="INTEGER-TYPE">/DataTypes/Integer</DATA-TYPE-REF>
           <INIT-VALUE-REF DEST="INTEGER-LITERAL">/Constants/Integer7/literal</INIT-VALUE-REF>
           <LENGTH>3</LENGTH>
         </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/MultiplexedWorld1 -->
         <SYSTEM-SIGNAL UUID="0b48d1f7fee74ee0a66c59d9ffac741a">
           <SHORT-NAME>MultiplexedWorld1</SHORT-NAME>
           <DATA-TYPE-REF DEST="INTEGER-TYPE">/DataTypes/Integer</DATA-TYPE-REF>
           <LENGTH>2</LENGTH>
         </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/MultiplexedWorld2 -->
         <SYSTEM-SIGNAL UUID="4376173f8d8741a190f7da5df3a7909c">
           <SHORT-NAME>MultiplexedWorld2</SHORT-NAME>
           <DATA-TYPE-REF DEST="INTEGER-TYPE">/DataTypes/Integer</DATA-TYPE-REF>
           <LENGTH>1</LENGTH>
         </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/MultiplexedSelector -->
         <SYSTEM-SIGNAL UUID="afe2f8ba2ef04c7cb818894c1ca82412">
           <SHORT-NAME>MultiplexedSelector</SHORT-NAME>
           <DATA-TYPE-REF DEST="INTEGER-TYPE">/DataTypes/MultiplexSelector</DATA-TYPE-REF>
           <LENGTH>2</LENGTH>
         </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/IsAlive -->
         <SYSTEM-SIGNAL UUID="d81e9932feaf514c0b04bfd10d259013">
           <SHORT-NAME>IsAlive</SHORT-NAME>
           <DESC>
@@ -145,12 +164,14 @@
           <INIT-VALUE-REF DEST="BOOLEAN-LITERAL">/Constants/BooleanFalse/literal</INIT-VALUE-REF>
           <LENGTH>1</LENGTH>
         </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/IsAsleep -->
         <SYSTEM-SIGNAL>
           <SHORT-NAME>IsAsleep</SHORT-NAME>
           <DATA-TYPE-REF DEST="BOOLEAN-TYPE">/DataTypes/Boolean</DATA-TYPE-REF>
           <INIT-VALUE-REF DEST="BOOLEAN-LITERAL">/Constants/BooleanTrue/literal</INIT-VALUE-REF>
           <LENGTH>1</LENGTH>
         </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/Movement -->
         <SYSTEM-SIGNAL UUID="8718d38b58c6a81ba299843d9c8bbf99">
           <SHORT-NAME>Movement</SHORT-NAME>
           <DESC>
@@ -160,12 +181,14 @@
           <INIT-VALUE-REF DEST="INTEGER-LITERAL">/Constants/MovementStop/literal</INIT-VALUE-REF>
           <LENGTH>3</LENGTH>
         </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/Position -->
         <SYSTEM-SIGNAL UUID="1e68ee3a71c4fcdb5c1fce9bbdab92ed">
           <SHORT-NAME>Position</SHORT-NAME>
           <DATA-TYPE-REF DEST="INTEGER-TYPE">/DataTypes/Position</DATA-TYPE-REF>
           <INIT-VALUE-REF DEST="INTEGER-LITERAL">/Constants/PositionStandard/literal</INIT-VALUE-REF>
           <LENGTH>2</LENGTH>
         </SYSTEM-SIGNAL>
+        <!-- /SystemSignals/PositionMovementGroup -->
         <SYSTEM-SIGNAL-GROUP UUID="96a9ad1b8db03324b20058c3d8bd2457">
           <SHORT-NAME>PositionMovementGroup</SHORT-NAME>
           <SYSTEM-SIGNAL-REFS>
@@ -175,12 +198,15 @@
         </SYSTEM-SIGNAL-GROUP>
       </ELEMENTS>
     </AR-PACKAGE>
+    <!-- /Constants -->
     <AR-PACKAGE UUID="23e33dc51bcddb0978e855b43f804c88">
       <SHORT-NAME>Constants</SHORT-NAME>
       <ELEMENTS>
-	<CONSTANT-SPECIFICATION UUID="20df4046aeb140cfbca6685393728910">
+        <!-- /Constants/Integer7 -->
+        <CONSTANT-SPECIFICATION UUID="20df4046aeb140cfbca6685393728910">
           <SHORT-NAME>Integer7</SHORT-NAME>
           <VALUE>
+            <!-- /Constants/Integer7/literal -->
             <INTEGER-LITERAL UUID="cd63b372778a475590a10f9fb3d9fa5f">
               <SHORT-NAME>literal</SHORT-NAME>
               <TYPE-TREF DEST="INTEGER-TYPE">/DataTypes/Integer</TYPE-TREF>
@@ -188,9 +214,11 @@
               </INTEGER-LITERAL>
           </VALUE>
         </CONSTANT-SPECIFICATION>
+        <!-- /Constants/BooleanFalse -->
         <CONSTANT-SPECIFICATION UUID="5800a92dce4e046f6e25a7f6fdf567e4">
           <SHORT-NAME>BooleanFalse</SHORT-NAME>
           <VALUE>
+            <!-- /Constants/BooleanFalse/literal -->
             <BOOLEAN-LITERAL UUID="98d4f2c200c31f9b35cde34b2bdd103e">
               <SHORT-NAME>literal</SHORT-NAME>
               <TYPE-TREF DEST="BOOLEAN-TYPE">/DataTypes/Boolean</TYPE-TREF>
@@ -198,9 +226,11 @@
             </BOOLEAN-LITERAL>
           </VALUE>
         </CONSTANT-SPECIFICATION>
+        <!-- /Constants/BooleanTrue -->
         <CONSTANT-SPECIFICATION UUID="3475e8b6c16ba5c357c4daa1e254e1f8">
           <SHORT-NAME>BooleanTrue</SHORT-NAME>
           <VALUE>
+            <!-- /Constants/BooleanTrue/literal -->
             <BOOLEAN-LITERAL UUID="c9f67c6d257f0c287fb5488b15254240">
               <SHORT-NAME>literal</SHORT-NAME>
               <TYPE-TREF DEST="BOOLEAN-TYPE">/DataTypes/Boolean</TYPE-TREF>
@@ -208,9 +238,11 @@
             </BOOLEAN-LITERAL>
           </VALUE>
         </CONSTANT-SPECIFICATION>
+        <!-- /Constants/MovementStop -->
         <CONSTANT-SPECIFICATION UUID="4adffe8ffbafc92fa4063b3fdeb7e55a">
           <SHORT-NAME>MovementStop</SHORT-NAME>
           <VALUE>
+            <!-- /Constants/MovementStop/literal -->
             <INTEGER-LITERAL UUID="78047897ec0b1af63ab7a13cd07330cc">
               <SHORT-NAME>literal</SHORT-NAME>
               <TYPE-TREF DEST="INTEGER-TYPE">/DataTypes/Movement</TYPE-TREF>
@@ -218,9 +250,11 @@
             </INTEGER-LITERAL>
           </VALUE>
         </CONSTANT-SPECIFICATION>
+        <!-- /Constants/PositionStandard -->
         <CONSTANT-SPECIFICATION UUID="0c46789532160be6bd664a53be7a2d4d">
           <SHORT-NAME>PositionStandard</SHORT-NAME>
           <VALUE>
+            <!-- /Constants/PositionStandard/literal -->
             <INTEGER-LITERAL UUID="7d0c6df382887dc8a015d73fd4014cac">
               <SHORT-NAME>literal</SHORT-NAME>
               <TYPE-TREF DEST="INTEGER-TYPE">/DataTypes/Position</TYPE-TREF>
@@ -230,44 +264,53 @@
         </CONSTANT-SPECIFICATION>
       </ELEMENTS>
     </AR-PACKAGE>
+    <!-- /ECUs -->
     <AR-PACKAGE UUID="9855a1cef66a4ce9bf4a77a28001860b">
       <SHORT-NAME>ECUs</SHORT-NAME>
       <ELEMENTS>
-	<ECU-INSTANCE UUID="48ec4fa049f04d5dacd8dd4ee539d302">
-	  <SHORT-NAME>Driver</SHORT-NAME>
-	  <DESC>
-	    <L-2 L="DE">Der rätselhafte Fahrer</L-2>
-	    <L-2 L="EN">The enigmatic driver</L-2>
-	  </DESC>
-	</ECU-INSTANCE>
-	<ECU-INSTANCE UUID="ef19e858820e4c5e8c1ce3ef6fe0a11b">
-	  <SHORT-NAME>Passenger</SHORT-NAME>
-	  <DESC>
-	    <L-2 L="FOR-ALL">A boring passenger</L-2>
-	    <L-2 L="DE">Ein langweiliger Passagier</L-2>
-	  </DESC>
-	</ECU-INSTANCE>
+        <!-- /ECUs/Driver -->
+        <ECU-INSTANCE UUID="48ec4fa049f04d5dacd8dd4ee539d302">
+          <SHORT-NAME>Driver</SHORT-NAME>
+          <DESC>
+            <L-2 L="DE">Der rätselhafte Fahrer</L-2>
+            <L-2 L="EN">The enigmatic driver</L-2>
+          </DESC>
+        </ECU-INSTANCE>
+        <!-- /ECUs/Passenger -->
+        <ECU-INSTANCE UUID="ef19e858820e4c5e8c1ce3ef6fe0a11b">
+          <SHORT-NAME>Passenger</SHORT-NAME>
+          <DESC>
+            <L-2 L="FOR-ALL">A boring passenger</L-2>
+            <L-2 L="DE">Ein langweiliger Passagier</L-2>
+          </DESC>
+        </ECU-INSTANCE>
       </ELEMENTS>
     </AR-PACKAGE>
+    <!-- /Network -->
     <AR-PACKAGE UUID="89a48947c1ebc60fbfd68acf9b5bb63a">
       <SHORT-NAME>Network</SHORT-NAME>
       <SUB-PACKAGES>
+        <!-- /Network/CanCluster -->
         <AR-PACKAGE UUID="8bd55efe25f0d03d0fe19af528366101">
           <SHORT-NAME>CanCluster</SHORT-NAME>
           <ELEMENTS>
+            <!-- /Network/CanCluster/Network -->
             <CAN-CLUSTER UUID="37b6a814c9d49141840f6a238912b103">
               <SHORT-NAME>Network</SHORT-NAME>
               <MAX-FRAME-LENGTH>8</MAX-FRAME-LENGTH>
               <PHYSICAL-CHANNELS>
+                <!-- /Network/CanCluster/Network/Network -->
                 <PHYSICAL-CHANNEL UUID="9f949c1c11494bbffbcda6a8941467d7">
                   <SHORT-NAME>Network</SHORT-NAME>
                   <FRAME-TRIGGERINGSS>
-		    <CAN-FRAME-TRIGGERING UUID="e410c101f94346faa3e2412ae925ac7f">
+                    <!-- /Network/CanCluster/Network/Network/MultiplexedTriggering -->
+                    <CAN-FRAME-TRIGGERING UUID="e410c101f94346faa3e2412ae925ac7f">
                       <SHORT-NAME>MultiplexedTriggering</SHORT-NAME>
                       <FRAME-REF DEST="FRAME">/Network/CanCluster/CAN/Frames/Multiplexed</FRAME-REF>
                       <CAN-ADDRESSING-MODE>STANDARD</CAN-ADDRESSING-MODE>
                       <IDENTIFIER>4</IDENTIFIER>
                     </CAN-FRAME-TRIGGERING>
+                    <!-- /Network/CanCluster/Network/Network/StatusTriggering -->
                     <CAN-FRAME-TRIGGERING UUID="b1b7f42b0cee5f5530f20281823762aa">
                       <SHORT-NAME>StatusTriggering</SHORT-NAME>
                       <FRAME-REF DEST="FRAME">/Network/CanCluster/CAN/Frames/Status</FRAME-REF>
@@ -283,90 +326,104 @@
             </CAN-CLUSTER>
           </ELEMENTS>
           <SUB-PACKAGES>
+            <!-- /Network/CanCluster/CAN -->
             <AR-PACKAGE UUID="6ec93102d5795011e5ca9e32a6d1223c">
               <SHORT-NAME>CAN</SHORT-NAME>
               <SUB-PACKAGES>
+                <!-- /Network/CanCluster/CAN/PDUs -->
                 <AR-PACKAGE UUID="439568a2dd0a71ae803672f4bb077940">
                   <SHORT-NAME>PDUs</SHORT-NAME>
                   <ELEMENTS>
-		    <MULTIPLEXED-I-PDU UUID="c83552efde3c4b149d7142e99549e01e">
-		      <SHORT-NAME>Multiplexed</SHORT-NAME>
-		      <LENGTH>10</LENGTH>
-		      <DYNAMIC-PART>
-			<DYNAMIC-PART-ALTERNATIVES>
-			  <DYNAMIC-PART-ALTERNATIVE>
-			    <I-PDU-REF DEST="SIGNAL-I-PDU">/Network/CanCluster/CAN/PDUs/Multiplexed_0</I-PDU-REF>
-			    <INITIAL-DYNAMIC-PART>true</INITIAL-DYNAMIC-PART>
-			    <SELECTOR-FIELD-CODE>0</SELECTOR-FIELD-CODE>
-			  </DYNAMIC-PART-ALTERNATIVE>
-			  <DYNAMIC-PART-ALTERNATIVE>
-			    <I-PDU-REF DEST="SIGNAL-I-PDU">/Network/CanCluster/CAN/PDUs/Multiplexed_1</I-PDU-REF>
-			    <SELECTOR-FIELD-CODE>1</SELECTOR-FIELD-CODE>
-			  </DYNAMIC-PART-ALTERNATIVE>
-			</DYNAMIC-PART-ALTERNATIVES>
-		      </DYNAMIC-PART>
-		      <SELECTOR-FIELD-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-FIRST</SELECTOR-FIELD-BYTE-ORDER>
-		      <SELECTOR-FIELD-LENGTH>2</SELECTOR-FIELD-LENGTH>
-		      <SELECTOR-FIELD-START-POSITION>7</SELECTOR-FIELD-START-POSITION>
-		      <STATIC-PART>
-			<I-PDU-REF DEST="SIGNAL-I-PDU">/Network/CanCluster/CAN/PDUs/Multiplexed_Static</I-PDU-REF>
-		      </STATIC-PART>
-		    </MULTIPLEXED-I-PDU>
-		    <SIGNAL-I-PDU UUID="c32a836a633e4f99be88d6e96d9581d3">
-		      <SHORT-NAME>Multiplexed_Static</SHORT-NAME>
-		      <LENGTH>8</LENGTH>
-		      <SIGNAL-TO-PDU-MAPPINGS>
-			<I-SIGNAL-TO-I-PDU-MAPPING UUID="fe1853b6a0a64af683cecab9bfcf6590">
-			  <SHORT-NAME>Multiplexed_Static_StaticMapping</SHORT-NAME>
-			  <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/Static</SIGNAL-REF>
-			  <START-POSITION>0</START-POSITION>
-			</I-SIGNAL-TO-I-PDU-MAPPING>
-			<I-SIGNAL-TO-I-PDU-MAPPING UUID="23e6b3d5038e4b6f9e526c01fc804d78">
-			  <SHORT-NAME>Multiplexed_Static_Static2Mapping</SHORT-NAME>
-			  <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/Static2</SIGNAL-REF>
-			  <START-POSITION>8</START-POSITION>
-			</I-SIGNAL-TO-I-PDU-MAPPING>
-		      </SIGNAL-TO-PDU-MAPPINGS>
-		    </SIGNAL-I-PDU>
-		    <SIGNAL-I-PDU UUID="c6a887e9644c4fde97da40d2aa20a318">
-		      <SHORT-NAME>Multiplexed_0</SHORT-NAME>
-		      <LENGTH>8</LENGTH>
-		      <SIGNAL-TO-PDU-MAPPINGS>
-			<I-SIGNAL-TO-I-PDU-MAPPING UUID="508c19ba4f6f43258b69ed0517d250da">
-			  <SHORT-NAME>Multiplexed_0_HelloMapping</SHORT-NAME>
-			  <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/Hello</SIGNAL-REF>
-			  <START-POSITION>3</START-POSITION>
-			</I-SIGNAL-TO-I-PDU-MAPPING>
-			<I-SIGNAL-TO-I-PDU-MAPPING UUID="81898c2a77dd44d6a5b184e48836c093">
-			  <SHORT-NAME>Multiplexed_0_SelectorMapping</SHORT-NAME>
-			  <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-FIRST</PACKING-BYTE-ORDER>
-			  <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/Selector</SIGNAL-REF>
-			  <START-POSITION>7</START-POSITION>
-			</I-SIGNAL-TO-I-PDU-MAPPING>
-		      </SIGNAL-TO-PDU-MAPPINGS>
-		    </SIGNAL-I-PDU>
-		    <SIGNAL-I-PDU UUID="83956540cfc24484942001f169189792">
-		      <SHORT-NAME>Multiplexed_1</SHORT-NAME>
-		      <LENGTH>8</LENGTH>
-		      <SIGNAL-TO-PDU-MAPPINGS>
-			<I-SIGNAL-TO-I-PDU-MAPPING UUID="48d697ab7ac74677b25006a50a79a616">
-			  <SHORT-NAME>Multiplexed_1_World1Mapping</SHORT-NAME>
-			  <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/World1</SIGNAL-REF>
-			  <START-POSITION>4</START-POSITION>
-			</I-SIGNAL-TO-I-PDU-MAPPING>
-			<I-SIGNAL-TO-I-PDU-MAPPING UUID="f3d9badf61ef48a3bf985c41a769d835">
-			  <SHORT-NAME>Multiplexed_1_World2Mapping</SHORT-NAME>
-			  <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/World2</SIGNAL-REF>
-			  <START-POSITION>3</START-POSITION>
-			</I-SIGNAL-TO-I-PDU-MAPPING>
-			<I-SIGNAL-TO-I-PDU-MAPPING UUID="48534de3ef4f49efb18b68d1817b6ee0">
-			  <SHORT-NAME>Multiplexed_1_SelectorMapping</SHORT-NAME>
-			  <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-FIRST</PACKING-BYTE-ORDER>
-			  <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/Selector</SIGNAL-REF>
-			  <START-POSITION>7</START-POSITION>
-			</I-SIGNAL-TO-I-PDU-MAPPING>
-		      </SIGNAL-TO-PDU-MAPPINGS>
-		    </SIGNAL-I-PDU>
+                    <!-- /Network/CanCluster/CAN/PDUs/Multiplexed -->
+                    <MULTIPLEXED-I-PDU UUID="c83552efde3c4b149d7142e99549e01e">
+                      <SHORT-NAME>Multiplexed</SHORT-NAME>
+                      <LENGTH>10</LENGTH>
+                      <DYNAMIC-PART>
+                        <DYNAMIC-PART-ALTERNATIVES>
+                          <DYNAMIC-PART-ALTERNATIVE>
+                            <I-PDU-REF DEST="SIGNAL-I-PDU">/Network/CanCluster/CAN/PDUs/Multiplexed_0</I-PDU-REF>
+                            <INITIAL-DYNAMIC-PART>true</INITIAL-DYNAMIC-PART>
+                            <SELECTOR-FIELD-CODE>0</SELECTOR-FIELD-CODE>
+                          </DYNAMIC-PART-ALTERNATIVE>
+                          <DYNAMIC-PART-ALTERNATIVE>
+                            <I-PDU-REF DEST="SIGNAL-I-PDU">/Network/CanCluster/CAN/PDUs/Multiplexed_1</I-PDU-REF>
+                            <SELECTOR-FIELD-CODE>1</SELECTOR-FIELD-CODE>
+                          </DYNAMIC-PART-ALTERNATIVE>
+                        </DYNAMIC-PART-ALTERNATIVES>
+                      </DYNAMIC-PART>
+                      <SELECTOR-FIELD-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-FIRST</SELECTOR-FIELD-BYTE-ORDER>
+                      <SELECTOR-FIELD-LENGTH>2</SELECTOR-FIELD-LENGTH>
+                      <SELECTOR-FIELD-START-POSITION>7</SELECTOR-FIELD-START-POSITION>
+                      <STATIC-PART>
+                        <I-PDU-REF DEST="SIGNAL-I-PDU">/Network/CanCluster/CAN/PDUs/Multiplexed_Static</I-PDU-REF>
+                      </STATIC-PART>
+                    </MULTIPLEXED-I-PDU>
+                    <!-- /Network/CanCluster/CAN/PDUs/Multiplexed_Static -->
+                    <SIGNAL-I-PDU UUID="c32a836a633e4f99be88d6e96d9581d3">
+                      <SHORT-NAME>Multiplexed_Static</SHORT-NAME>
+                      <LENGTH>8</LENGTH>
+                      <SIGNAL-TO-PDU-MAPPINGS>
+                        <!-- /Network/CanCluster/CAN/PDUs/Multiplexed_Static/Multiplexed_Static_StaticMapping -->
+                        <I-SIGNAL-TO-I-PDU-MAPPING UUID="fe1853b6a0a64af683cecab9bfcf6590">
+                          <SHORT-NAME>Multiplexed_Static_StaticMapping</SHORT-NAME>
+                          <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/Static</SIGNAL-REF>
+                          <START-POSITION>0</START-POSITION>
+                        </I-SIGNAL-TO-I-PDU-MAPPING>
+                        <!-- /Network/CanCluster/CAN/PDUs/Multiplexed_Static/Multiplexed_Static2_StaticMapping -->
+                        <I-SIGNAL-TO-I-PDU-MAPPING UUID="23e6b3d5038e4b6f9e526c01fc804d78">
+                          <SHORT-NAME>Multiplexed_Static_Static2Mapping</SHORT-NAME>
+                          <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/Static2</SIGNAL-REF>
+                          <START-POSITION>8</START-POSITION>
+                        </I-SIGNAL-TO-I-PDU-MAPPING>
+                      </SIGNAL-TO-PDU-MAPPINGS>
+                    </SIGNAL-I-PDU>
+                    <!-- /Network/CanCluster/CAN/PDUs/Multiplexed_0 -->
+                    <SIGNAL-I-PDU UUID="c6a887e9644c4fde97da40d2aa20a318">
+                      <SHORT-NAME>Multiplexed_0</SHORT-NAME>
+                      <LENGTH>8</LENGTH>
+                      <SIGNAL-TO-PDU-MAPPINGS>
+                        <!-- /Network/CanCluster/CAN/PDUs/Multiplexed_0/Multiplexed_0_HelloMapping -->
+                        <I-SIGNAL-TO-I-PDU-MAPPING UUID="508c19ba4f6f43258b69ed0517d250da">
+                          <SHORT-NAME>Multiplexed_0_HelloMapping</SHORT-NAME>
+                          <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/Hello</SIGNAL-REF>
+                          <START-POSITION>3</START-POSITION>
+                        </I-SIGNAL-TO-I-PDU-MAPPING>
+                        <!-- /Network/CanCluster/CAN/PDUs/Multiplexed_0/Multiplexed_0_SelectorMapping -->
+                        <I-SIGNAL-TO-I-PDU-MAPPING UUID="81898c2a77dd44d6a5b184e48836c093">
+                          <SHORT-NAME>Multiplexed_0_SelectorMapping</SHORT-NAME>
+                          <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-FIRST</PACKING-BYTE-ORDER>
+                          <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/Selector</SIGNAL-REF>
+                          <START-POSITION>7</START-POSITION>
+                        </I-SIGNAL-TO-I-PDU-MAPPING>
+                      </SIGNAL-TO-PDU-MAPPINGS>
+                    </SIGNAL-I-PDU>
+                    <!-- /Network/CanCluster/CAN/PDUs/Multiplexed_1 -->
+                    <SIGNAL-I-PDU UUID="83956540cfc24484942001f169189792">
+                      <SHORT-NAME>Multiplexed_1</SHORT-NAME>
+                      <LENGTH>8</LENGTH>
+                      <!-- /Network/CanCluster/CAN/PDUs/Multiplexed_1/Multiplexed_1_World1Mapping -->
+                      <SIGNAL-TO-PDU-MAPPINGS>
+                        <I-SIGNAL-TO-I-PDU-MAPPING UUID="48d697ab7ac74677b25006a50a79a616">
+                          <SHORT-NAME>Multiplexed_1_World1Mapping</SHORT-NAME>
+                          <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/World1</SIGNAL-REF>
+                          <START-POSITION>4</START-POSITION>
+                        </I-SIGNAL-TO-I-PDU-MAPPING>
+                        <!-- /Network/CanCluster/CAN/PDUs/Multiplexed_1/Multiplexed_2_World1Mapping -->
+                        <I-SIGNAL-TO-I-PDU-MAPPING UUID="f3d9badf61ef48a3bf985c41a769d835">
+                          <SHORT-NAME>Multiplexed_1_World2Mapping</SHORT-NAME>
+                          <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/World2</SIGNAL-REF>
+                          <START-POSITION>3</START-POSITION>
+                        </I-SIGNAL-TO-I-PDU-MAPPING>
+                        <!-- /Network/CanCluster/CAN/PDUs/Multiplexed_1/Multiplexed_1_SelectorMapping -->
+                        <I-SIGNAL-TO-I-PDU-MAPPING UUID="48534de3ef4f49efb18b68d1817b6ee0">
+                          <SHORT-NAME>Multiplexed_1_SelectorMapping</SHORT-NAME>
+                          <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-FIRST</PACKING-BYTE-ORDER>
+                          <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Multiplexed/Selector</SIGNAL-REF>
+                          <START-POSITION>7</START-POSITION>
+                        </I-SIGNAL-TO-I-PDU-MAPPING>
+                      </SIGNAL-TO-PDU-MAPPINGS>
+                    </SIGNAL-I-PDU>
+                    <!-- /Network/CanCluster/CAN/PDUs/Status -->
                     <SIGNAL-I-PDU UUID="02a323c0ebfeeb13c5ac0f42488d767d">
                       <SHORT-NAME>Status</SHORT-NAME>
                       <LENGTH>1</LENGTH>
@@ -382,30 +439,35 @@
                         <MINIMUM-DELAY>0.01</MINIMUM-DELAY>
                       </I-PDU-TIMING-SPECIFICATION>
                       <SIGNAL-TO-PDU-MAPPINGS>
+                        <!-- /Network/CanCluster/CAN/PDUs/AliveMapping -->
                         <I-SIGNAL-TO-I-PDU-MAPPING UUID="193a3a3d59ef551a4007497ed778baeb">
                           <SHORT-NAME>AliveMapping</SHORT-NAME>
                           <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
                           <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Status/Alive</SIGNAL-REF>
                           <START-POSITION>0</START-POSITION>
                         </I-SIGNAL-TO-I-PDU-MAPPING>
+                        <!-- /Network/CanCluster/CAN/PDUs/SleepMapping -->
                         <I-SIGNAL-TO-I-PDU-MAPPING UUID="193a3a3d59ef551a4007497ed778baeb">
                           <SHORT-NAME>SleepMapping</SHORT-NAME>
                           <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
                           <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Status/Sleeps</SIGNAL-REF>
                           <START-POSITION>1</START-POSITION>
                         </I-SIGNAL-TO-I-PDU-MAPPING>
+                        <!-- /Network/CanCluster/CAN/PDUs/PositionMapping -->
                         <I-SIGNAL-TO-I-PDU-MAPPING UUID="8662b1aff79c78cca00b319a89f42fd7">
                           <SHORT-NAME>PositionMapping</SHORT-NAME>
                           <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
                           <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Status/Position</SIGNAL-REF>
                           <START-POSITION>3</START-POSITION>
                         </I-SIGNAL-TO-I-PDU-MAPPING>
+                        <!-- /Network/CanCluster/CAN/PDUs/MovementMapping -->
                         <I-SIGNAL-TO-I-PDU-MAPPING UUID="1af43965e283bd5921b9832d183832c1">
                           <SHORT-NAME>MovementMapping</SHORT-NAME>
                           <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
                           <SIGNAL-REF DEST="I-SIGNAL">/Network/CanCluster/CAN/ISignals/Status/Movement</SIGNAL-REF>
                           <START-POSITION>5</START-POSITION>
                         </I-SIGNAL-TO-I-PDU-MAPPING>
+                        <!-- /Network/CanCluster/CAN/PDUs/PositionMovementGroupMapping -->
                         <I-SIGNAL-TO-I-PDU-MAPPING UUID="ae3fc5e7d33ace46bb8db8ef9d1b32f3">
                           <SHORT-NAME>PositionMovementGroupMapping</SHORT-NAME>
                           <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
@@ -415,41 +477,51 @@
                     </SIGNAL-I-PDU>
                   </ELEMENTS>
                 </AR-PACKAGE>
+                <!-- /Network/CanCluster/CAN/ISignals -->
                 <AR-PACKAGE UUID="1934e8176691c23b7ea8dd899afb3801">
                   <SHORT-NAME>ISignals</SHORT-NAME>
                   <SUB-PACKAGES>
-		    <AR-PACKAGE UUID="194a34211c5548f18c0fca2a6f45135e">
+                    <!-- /Network/CanCluster/CAN/ISignals/Multiplexed -->
+                    <AR-PACKAGE UUID="194a34211c5548f18c0fca2a6f45135e">
                       <SHORT-NAME>Multiplexed</SHORT-NAME>
                       <ELEMENTS>
-			<I-SIGNAL UUID="34b1deb68c83488cbdac4c7dbdb48321">
-			  <SHORT-NAME>Static</SHORT-NAME>
-			  <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedStatic</SYSTEM-SIGNAL-REF>
-			</I-SIGNAL>
-			<I-SIGNAL UUID="375241e112b54d0a94db0f2013cc630f">
-			  <SHORT-NAME>Static2</SHORT-NAME>
-			  <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedStatic2</SYSTEM-SIGNAL-REF>
-			</I-SIGNAL>
-			<I-SIGNAL UUID="3cee3e63ce8547e388994c39846370ca">
-			  <SHORT-NAME>Selector</SHORT-NAME>
-			  <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedSelector</SYSTEM-SIGNAL-REF>
-			</I-SIGNAL>
-			<I-SIGNAL UUID="3750b50b60c54fb39f9a143d54a50066">
-			  <SHORT-NAME>Hello</SHORT-NAME>
-			  <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedHello</SYSTEM-SIGNAL-REF>
-			</I-SIGNAL>
-			<I-SIGNAL UUID="f90b8528ca3f48a59f23c242370d6062">
-			  <SHORT-NAME>World1</SHORT-NAME>
-			  <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedWorld1</SYSTEM-SIGNAL-REF>
-			</I-SIGNAL>
-			<I-SIGNAL UUID="daf651de727a498eb0472b46b9a9948f">
-			  <SHORT-NAME>World2</SHORT-NAME>
-			  <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedWorld2</SYSTEM-SIGNAL-REF>
-			</I-SIGNAL>
-		      </ELEMENTS>
-		    </AR-PACKAGE>
+                        <!-- /Network/CanCluster/CAN/ISignals/Multiplexed/Static -->
+                        <I-SIGNAL UUID="34b1deb68c83488cbdac4c7dbdb48321">
+                          <SHORT-NAME>Static</SHORT-NAME>
+                          <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedStatic</SYSTEM-SIGNAL-REF>
+                        </I-SIGNAL>
+                        <!-- /Network/CanCluster/CAN/ISignals/Multiplexed/Static2 -->
+                        <I-SIGNAL UUID="375241e112b54d0a94db0f2013cc630f">
+                          <SHORT-NAME>Static2</SHORT-NAME>
+                          <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedStatic2</SYSTEM-SIGNAL-REF>
+                        </I-SIGNAL>
+                        <!-- /Network/CanCluster/CAN/ISignals/Multiplexed/Selector -->
+                        <I-SIGNAL UUID="3cee3e63ce8547e388994c39846370ca">
+                          <SHORT-NAME>Selector</SHORT-NAME>
+                          <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedSelector</SYSTEM-SIGNAL-REF>
+                        </I-SIGNAL>
+                        <!-- /Network/CanCluster/CAN/ISignals/Multiplexed/Hello -->
+                        <I-SIGNAL UUID="3750b50b60c54fb39f9a143d54a50066">
+                          <SHORT-NAME>Hello</SHORT-NAME>
+                          <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedHello</SYSTEM-SIGNAL-REF>
+                        </I-SIGNAL>
+                        <!-- /Network/CanCluster/CAN/ISignals/Multiplexed/World1 -->
+                        <I-SIGNAL UUID="f90b8528ca3f48a59f23c242370d6062">
+                          <SHORT-NAME>World1</SHORT-NAME>
+                          <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedWorld1</SYSTEM-SIGNAL-REF>
+                        </I-SIGNAL>
+                        <!-- /Network/CanCluster/CAN/ISignals/Multiplexed/World2 -->
+                        <I-SIGNAL UUID="daf651de727a498eb0472b46b9a9948f">
+                          <SHORT-NAME>World2</SHORT-NAME>
+                          <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/MultiplexedWorld2</SYSTEM-SIGNAL-REF>
+                        </I-SIGNAL>
+                      </ELEMENTS>
+                    </AR-PACKAGE>
+                    <!-- /Network/CanCluster/CAN/ISignals/Status -->
                     <AR-PACKAGE UUID="d092f91b9733319fe3599c2d991c1c80">
                       <SHORT-NAME>Status</SHORT-NAME>
                       <ELEMENTS>
+                        <!-- /Network/CanCluster/CAN/ISignals/Status/Alive -->
                         <I-SIGNAL UUID="8889d143c798e7d0bd8cc6b91c0de364">
                           <SHORT-NAME>Alive</SHORT-NAME>
                           <DESC>
@@ -458,18 +530,22 @@
                           </DESC>
                           <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/IsAlive</SYSTEM-SIGNAL-REF>
                         </I-SIGNAL>
+                        <!-- /Network/CanCluster/CAN/ISignals/Status/Sleeps -->
                         <I-SIGNAL UUID="8889d143c798e7d0bd8cc6b91c0de364">
                           <SHORT-NAME>Sleeps</SHORT-NAME>
                           <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/IsAsleep</SYSTEM-SIGNAL-REF>
                         </I-SIGNAL>
+                        <!-- /Network/CanCluster/CAN/ISignals/Status/Position -->
                         <I-SIGNAL UUID="e4c24ffa18328108d9efd3c61da552b2">
                           <SHORT-NAME>Position</SHORT-NAME>
                           <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/Position</SYSTEM-SIGNAL-REF>
                         </I-SIGNAL>
+                        <!-- /Network/CanCluster/CAN/ISignals/Status/Movement -->
                         <I-SIGNAL UUID="cea9809898332ae973fe7302290723ee">
                           <SHORT-NAME>Movement</SHORT-NAME>
                           <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignals/Movement</SYSTEM-SIGNAL-REF>
                         </I-SIGNAL>
+                        <!-- /Network/CanCluster/CAN/ISignals/Status/PositionMovement -->
                         <I-SIGNAL UUID="84894b12d79934a10df9f3d153841ced">
                           <SHORT-NAME>PositionMovement</SHORT-NAME>
                           <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL-GROUP">/SystemSignals/PositionMovementGroup</SYSTEM-SIGNAL-REF>
@@ -478,13 +554,16 @@
                     </AR-PACKAGE>
                   </SUB-PACKAGES>
                 </AR-PACKAGE>
+                <!-- /Network/CanCluster/CAN/Frames -->
                 <AR-PACKAGE UUID="a91cc39bee2148e9f2b39b3269fee849">
                   <SHORT-NAME>Frames</SHORT-NAME>
                   <ELEMENTS>
+                    <!-- /Network/CanCluster/CAN/Frames/Multiplexed -->
                     <FRAME UUID="4057bedddb864a9bace94ec0323cefcc">
                       <SHORT-NAME>Multiplexed</SHORT-NAME>
                       <FRAME-LENGTH>2</FRAME-LENGTH>
                       <PDU-TO-FRAME-MAPPINGS>
+                        <!-- /Network/CanCluster/CAN/Frames/Multiplexed/MultiplexedMapping -->
                         <PDU-TO-FRAME-MAPPING UUID="4057bedddb864a9bace94ec0323cefcc">
                           <SHORT-NAME>MultiplexedMapping</SHORT-NAME>
                           <PDU-REF DEST="MULTIPLEXED-I-PDU">/Network/CanCluster/CAN/PDUs/Multiplexed</PDU-REF>
@@ -492,6 +571,7 @@
                         </PDU-TO-FRAME-MAPPING>
                       </PDU-TO-FRAME-MAPPINGS>
                     </FRAME>
+                    <!-- /Network/CanCluster/CAN/Frames/Status -->
                     <FRAME UUID="d9f2b086297df956a9b50f7399041012">
                       <SHORT-NAME>Status</SHORT-NAME>
                       <DESC>
@@ -499,6 +579,7 @@
                       </DESC>
                       <FRAME-LENGTH>1</FRAME-LENGTH>
                       <PDU-TO-FRAME-MAPPINGS>
+                        <!-- /Network/CanCluster/CAN/Frames/Status/StatusMapping -->
                         <PDU-TO-FRAME-MAPPING UUID="d95c16e24ffdc90dd424ded01440bc9c">
                           <SHORT-NAME>StatusMapping</SHORT-NAME>
                           <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -209,7 +209,7 @@
             <L-2 L="EN">Comment1</L-2>
             <L-2 L="DE">Kommentar1</L-2>
           </DESC>
-          <FRAME-LENGTH>6</FRAME-LENGTH>
+          <FRAME-LENGTH>9</FRAME-LENGTH>
           <PDU-TO-FRAME-MAPPINGS>
             <!-- /CanFrame/Message1/message1 -->
             <PDU-TO-FRAME-MAPPING UUID="1e160eb8bcb7a75f054eccbf6f47fe9f">
@@ -494,15 +494,114 @@
           <LENGTH>1</LENGTH>
           <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignal/Signal6</SYSTEM-SIGNAL-REF>
         </I-SIGNAL>
+        <!-- /ISignal/message1_CRC -->
+        <I-SIGNAL UUID="387836b304964f1cacc174190af710d3">
+          <SHORT-NAME>message1_CRC</SHORT-NAME>
+          <LENGTH>16</LENGTH>
+        </I-SIGNAL>
+        <!-- /ISignal/message1_SeqCounter -->
+        <I-SIGNAL UUID="0d03dc1f8ec2419baa11f0c6f151325e">
+          <SHORT-NAME>message1_SeqCounter</SHORT-NAME>
+          <LENGTH>16</LENGTH>
+        </I-SIGNAL>
+        <!-- /ISignal/message3_CRC -->
+        <I-SIGNAL UUID="b86c6ab0f4b842f4b3a2c42e8ddd0d05">
+          <SHORT-NAME>message3_CRC</SHORT-NAME>
+          <LENGTH>8</LENGTH>
+        </I-SIGNAL>
+        <!-- /ISignal/message3_SeqCounter -->
+        <I-SIGNAL UUID="7032fb5cfa6f4df996bb5e62b3377dce">
+          <SHORT-NAME>message3_SeqCounter</SHORT-NAME>
+          <LENGTH>4</LENGTH>
+        </I-SIGNAL>
         <!-- /ISignal/message1Group -->
-        <I-SIGNAL-GROUP UUID="a026aa86b94d49e3a9a9cbff071ac39a">
+        <I-SIGNAL-GROUP UUID="3eddf8ea0b7e4e678cbe1e810bd4e160">
           <SHORT-NAME>message1Group</SHORT-NAME>
           <I-SIGNAL-REFS>
             <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/signal1</I-SIGNAL-REF>
             <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/signal5</I-SIGNAL-REF>
             <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/signal6</I-SIGNAL-REF>
           </I-SIGNAL-REFS>
+          <TRANSFORMATION-I-SIGNAL-PROPSS>
+            <END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS>
+              <END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-VARIANTS>
+                <END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-CONDITIONAL>
+                  <TRANSFORMER-REF DEST="TRANSFORMATION-TECHNOLOGY">/Transformers/Decepticons/Starscream</TRANSFORMER-REF>
+                  <DATA-IDS>
+                    <DATA-ID>123</DATA-ID>
+                    <DATA-ID>124</DATA-ID>
+                    <DATA-ID>125</DATA-ID>
+                    <DATA-ID>126</DATA-ID>
+                    <DATA-ID>127</DATA-ID>
+                    <DATA-ID>128</DATA-ID>
+                    <DATA-ID>129</DATA-ID>
+                    <DATA-ID>130</DATA-ID>
+                    <DATA-ID>131</DATA-ID>
+                    <DATA-ID>132</DATA-ID>
+                    <DATA-ID>133</DATA-ID>
+                    <DATA-ID>134</DATA-ID>
+                    <DATA-ID>135</DATA-ID>
+                    <DATA-ID>136</DATA-ID>
+                    <DATA-ID>137</DATA-ID>
+                    <DATA-ID>138</DATA-ID>
+                  </DATA-IDS>
+                </END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-CONDITIONAL>
+              </END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-VARIANTS>
+            </END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS>
+          </TRANSFORMATION-I-SIGNAL-PROPSS>
         </I-SIGNAL-GROUP>
+        <!-- /ISignal/message3Group -->
+        <I-SIGNAL-GROUP UUID="f95abd456e3748dc9b21e242ffc3795e">
+          <SHORT-NAME>message3Group</SHORT-NAME>
+          <I-SIGNAL-REFS>
+            <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/messag3_SeqCounter</I-SIGNAL-REF>
+            <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/messag3_CRC</I-SIGNAL-REF>
+          </I-SIGNAL-REFS>
+          <TRANSFORMATION-I-SIGNAL-PROPSS>
+            <END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS>
+              <END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-VARIANTS>
+                <END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-CONDITIONAL>
+                  <TRANSFORMER-REF DEST="TRANSFORMATION-TECHNOLOGY">/Transformers/Decepticons/Galvatron</TRANSFORMER-REF>
+                  <DATA-IDS>
+                    <DATA-ID>321</DATA-ID>
+                  </DATA-IDS>
+                </END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-CONDITIONAL>
+              </END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS-VARIANTS>
+            </END-TO-END-TRANSFORMATION-I-SIGNAL-PROPS>
+          </TRANSFORMATION-I-SIGNAL-PROPSS>
+        </I-SIGNAL-GROUP>
+      </ELEMENTS>
+    </AR-PACKAGE>
+    <!-- /Transformers -->
+    <AR-PACKAGE UUID="2743d102143a491496938f1436af28d0">
+      <SHORT-NAME>Transformers</SHORT-NAME>
+      <ELEMENTS>
+        <!-- /Transformers/Decepticons -->
+        <DATA-TRANSFORMATION-SET UUID="dbd4091e087b466c90edcdfc0b5a3162">
+          <SHORT-NAME>Decepticons</SHORT-NAME>
+          <TRANSFORMATION-TECHNOLOGYS>
+            <!-- /Transformers/Decepticons/Starscream -->
+                <TRANSFORMATION-TECHNOLOGY UUID="d53f0988652c4f49b57cf84d1299da9d">
+              <SHORT-NAME>Starscream</SHORT-NAME>
+              <PROTOCOL>E2E</PROTOCOL>
+              <TRANSFORMATION-DESCRIPTIONS>
+                <END-TO-END-TRANSFORMATION-DESCRIPTION>
+                  <PROFILE-NAME>Profile2</PROFILE-NAME>
+                </END-TO-END-TRANSFORMATION-DESCRIPTION>
+              </TRANSFORMATION-DESCRIPTIONS>
+            </TRANSFORMATION-TECHNOLOGY>
+            <!-- /Transformers/Decepticons/Galvatron -->
+                <TRANSFORMATION-TECHNOLOGY UUID="daf1a29f227943e2bf733d6eabff5da6">
+              <SHORT-NAME>Galvatron</SHORT-NAME>
+              <PROTOCOL>E2E</PROTOCOL>
+              <TRANSFORMATION-DESCRIPTIONS>
+                <END-TO-END-TRANSFORMATION-DESCRIPTION>
+                  <PROFILE-NAME>Profile5</PROFILE-NAME>
+                </END-TO-END-TRANSFORMATION-DESCRIPTION>
+              </TRANSFORMATION-DESCRIPTIONS>
+            </TRANSFORMATION-TECHNOLOGY>
+          </TRANSFORMATION-TECHNOLOGYS>
+        </DATA-TRANSFORMATION-SET>
       </ELEMENTS>
     </AR-PACKAGE>
     <!-- /Constants -->
@@ -655,35 +754,49 @@
         <!-- /ISignalIPdu/message1 -->
         <I-SIGNAL-I-PDU UUID="3dcbb5ec811c3944980fc28bd7f5a483">
           <SHORT-NAME>message1</SHORT-NAME>
-          <LENGTH>6</LENGTH>
+          <LENGTH>9</LENGTH>
           <CONTAINED-I-PDU-PROPS>
             <HEADER-ID-SHORT-HEADER>0x0a0B0c</HEADER-ID-SHORT-HEADER>
           </CONTAINED-I-PDU-PROPS>
           <I-SIGNAL-TO-PDU-MAPPINGS>
+            <!-- /ISignalIPdu/message1/Counter -->
+            <I-SIGNAL-TO-I-PDU-MAPPING UUID="8157be9345d94cda9c1013b563459b29">
+              <SHORT-NAME>Counter</SHORT-NAME>
+              <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/message1_SeqCounter</I-SIGNAL-REF>
+              <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
+              <START-POSITION>0</START-POSITION>
+            </I-SIGNAL-TO-I-PDU-MAPPING>
+            <!-- /ISignalIPdu/message1/CRC -->
+            <I-SIGNAL-TO-I-PDU-MAPPING UUID="9ed2ba960ba54a7dbec1baee0d767216">
+              <SHORT-NAME>CRC</SHORT-NAME>
+              <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/message1_CRC</I-SIGNAL-REF>
+              <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
+              <START-POSITION>16</START-POSITION>
+            </I-SIGNAL-TO-I-PDU-MAPPING>
             <!-- /ISignalIPdu/message1/Signal1 -->
             <I-SIGNAL-TO-I-PDU-MAPPING UUID="ce8b5fec4f2b524050a02a84410cce80">
               <SHORT-NAME>Signal1</SHORT-NAME>
               <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/signal1</I-SIGNAL-REF>
               <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-FIRST</PACKING-BYTE-ORDER>
-              <START-POSITION>4</START-POSITION>
+              <START-POSITION>36</START-POSITION>
             </I-SIGNAL-TO-I-PDU-MAPPING>
             <!-- /ISignalIPdu/message1/Signal5 -->
             <I-SIGNAL-TO-I-PDU-MAPPING UUID="be19c22b8bc86ed477d522cde2937b71">
               <SHORT-NAME>Signal5</SHORT-NAME>
               <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/signal5</I-SIGNAL-REF>
               <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
-              <START-POSITION>16</START-POSITION>
+              <START-POSITION>40</START-POSITION>
             </I-SIGNAL-TO-I-PDU-MAPPING>
             <!-- /ISignalIPdu/message1/Signal6 -->
             <I-SIGNAL-TO-I-PDU-MAPPING UUID="9c9ed58f86bfc363a231c97532be961f">
               <SHORT-NAME>Signal6</SHORT-NAME>
               <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/signal6</I-SIGNAL-REF>
               <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
-              <START-POSITION>0</START-POSITION>
+              <START-POSITION>32</START-POSITION>
             </I-SIGNAL-TO-I-PDU-MAPPING>
-            <!-- Groups are ignored. -->
+            <!-- Amongst others, signal groups specify the E2E properties -->
             <!-- /ISignalIPdu/message1/SignalGroup -->
-            <I-SIGNAL-TO-I-PDU-MAPPING UUID="3340618ec8eee41339e501f512bc5cc3">
+            <I-SIGNAL-TO-I-PDU-MAPPING UUID="f5d48cb6ec0e4ad188c9617970751bab">
               <SHORT-NAME>SignalGroup</SHORT-NAME>
               <I-SIGNAL-GROUP-REF DEST="I-SIGNAL-GROUP">/ISignal/message1Group</I-SIGNAL-GROUP-REF>
             </I-SIGNAL-TO-I-PDU-MAPPING>
@@ -741,10 +854,31 @@
         <!-- /ISignalIPdu/message3 -->
         <I-SIGNAL-I-PDU UUID="12619847f5492c041fa73a13194455fc">
           <SHORT-NAME>message3</SHORT-NAME>
-          <LENGTH>8</LENGTH>
+          <LENGTH>4</LENGTH>
           <CONTAINED-I-PDU-PROPS>
             <HEADER-ID-SHORT-HEADER>0x010203</HEADER-ID-SHORT-HEADER>
           </CONTAINED-I-PDU-PROPS>
+          <I-SIGNAL-TO-PDU-MAPPINGS>
+            <!-- /ISignalIPdu/message3_CRC -->
+            <I-SIGNAL-TO-I-PDU-MAPPING UUID="fa24c443037c468f96d8137284a2e125">
+              <SHORT-NAME>message3_CRC</SHORT-NAME>
+              <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/message3_CRC</I-SIGNAL-REF>
+              <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
+              <START-POSITION>0</START-POSITION>
+            </I-SIGNAL-TO-I-PDU-MAPPING>
+            <!-- /ISignalIPdu/message3_SeqCounter -->
+            <I-SIGNAL-TO-I-PDU-MAPPING UUID="47bd5345457f412eb99fe90896901f41">
+              <SHORT-NAME>message3_SeqCounter</SHORT-NAME>
+              <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/message3_SeqCounter</I-SIGNAL-REF>
+              <PACKING-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-LAST</PACKING-BYTE-ORDER>
+              <START-POSITION>8</START-POSITION>
+            </I-SIGNAL-TO-I-PDU-MAPPING>
+            <!-- /ISignalIPdu/message3/SignalGroup -->
+            <I-SIGNAL-TO-I-PDU-MAPPING UUID="ec45c4df3cb446e8b8c59fcb1d1381df">
+              <SHORT-NAME>SignalGroup</SHORT-NAME>
+              <I-SIGNAL-GROUP-REF DEST="I-SIGNAL-GROUP">/ISignal/message3Group</I-SIGNAL-GROUP-REF>
+            </I-SIGNAL-TO-I-PDU-MAPPING>
+          </I-SIGNAL-TO-PDU-MAPPINGS>
         </I-SIGNAL-I-PDU>
         <!-- /ISignalIPdu/message4 -->
         <I-SIGNAL-I-PDU UUID="c81f3b83acabf97610a32ccf5121f972">
@@ -784,11 +918,11 @@
         <!-- /SecuredIPdu/message3_secured -->
         <SECURED-I-PDU UUID="9fb09bd0b1f84e86a0c62a2de73be796">
           <SHORT-NAME>message3_secured</SHORT-NAME>
-          <LENGTH>16</LENGTH>
+          <LENGTH>8</LENGTH>
           <CONTAINED-I-PDU-PROPS>
             <HEADER-ID-SHORT-HEADER>0x040506</HEADER-ID-SHORT-HEADER>
           </CONTAINED-I-PDU-PROPS>
-          <!-- we currently do not specify AUTHENTICATION_PROPS, FRESHNESS_PROPS, and SECURE-COMMUNICATION-PROPS. While this is technically allowed, it does not make sense in the context of a secured I-PDU... -->
+          <!-- we currently do not specify AUTHENTICATION_PROPS, FRESHNESS_PROPS, and SECURE-COMMUNICATION-PROPS. While this is technically allowed, it does not make much sense in the context of a secured I-PDU... -->
           <PAYLOAD-REF DEST="PDU-TRIGGERING">/Cluster/Cluster0/Pch0/message3_triggering</PAYLOAD-REF>
         </SECURED-I-PDU>
       </ELEMENTS>

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -494,6 +494,15 @@
           <LENGTH>1</LENGTH>
           <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignal/Signal6</SYSTEM-SIGNAL-REF>
         </I-SIGNAL>
+        <!-- /ISignal/message1Group -->
+        <I-SIGNAL-GROUP UUID="a026aa86b94d49e3a9a9cbff071ac39a">
+          <SHORT-NAME>message1Group</SHORT-NAME>
+          <I-SIGNAL-REFS>
+            <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/signal1</I-SIGNAL-REF>
+            <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/signal5</I-SIGNAL-REF>
+            <I-SIGNAL-REF DEST="I-SIGNAL">/ISignal/signal6</I-SIGNAL-REF>
+          </I-SIGNAL-REFS>
+        </I-SIGNAL-GROUP>
       </ELEMENTS>
     </AR-PACKAGE>
     <!-- /Constants -->
@@ -676,9 +685,7 @@
             <!-- /ISignalIPdu/message1/SignalGroup -->
             <I-SIGNAL-TO-I-PDU-MAPPING UUID="3340618ec8eee41339e501f512bc5cc3">
               <SHORT-NAME>SignalGroup</SHORT-NAME>
-              <I-SIGNAL-GROUP-REF DEST="I-SIGNAL-GROUP">/ISignal/todo</I-SIGNAL-GROUP-REF>
-              <TRANSFER-PROPERTY>PENDING</TRANSFER-PROPERTY>
-              <UPDATE-INDICATION-BIT-POSITION>4</UPDATE-INDICATION-BIT-POSITION>
+              <I-SIGNAL-GROUP-REF DEST="I-SIGNAL-GROUP">/ISignal/message1Group</I-SIGNAL-GROUP-REF>
             </I-SIGNAL-TO-I-PDU-MAPPING>
           </I-SIGNAL-TO-PDU-MAPPINGS>
         </I-SIGNAL-I-PDU>
@@ -740,7 +747,7 @@
           </CONTAINED-I-PDU-PROPS>
         </I-SIGNAL-I-PDU>
         <!-- /ISignalIPdu/message4 -->
-       <I-SIGNAL-I-PDU UUID="c81f3b83acabf97610a32ccf5121f972">
+        <I-SIGNAL-I-PDU UUID="c81f3b83acabf97610a32ccf5121f972">
           <SHORT-NAME>message4</SHORT-NAME>
           <LENGTH>6</LENGTH>
           <I-SIGNAL-TO-PDU-MAPPINGS>
@@ -1092,12 +1099,12 @@
     <AR-PACKAGE UUID="bd2f5e1d4cce486b82cbce545c17d52e">
       <SHORT-NAME>System</SHORT-NAME>
       <ELEMENTS>
-	<!-- /System/cantools_system -->
-	<SYSTEM UUID="d52709739676476087d17fce08ac288d">
-	  <SHORT-NAME>cantools_system</SHORT-NAME>
-	  <CATEGORY>SYSTEM_EXTRACT</CATEGORY>
-	  <CONTAINER-I-PDU-HEADER-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-FIRST</CONTAINER-I-PDU-HEADER-BYTE-ORDER>
-	  </SYSTEM>
+        <!-- /System/cantools_system -->
+        <SYSTEM UUID="d52709739676476087d17fce08ac288d">
+          <SHORT-NAME>cantools_system</SHORT-NAME>
+          <CATEGORY>SYSTEM_EXTRACT</CATEGORY>
+          <CONTAINER-I-PDU-HEADER-BYTE-ORDER>MOST-SIGNIFICANT-BYTE-FIRST</CONTAINER-I-PDU-HEADER-BYTE-ORDER>
+        </SYSTEM>
       </ELEMENTS>
     </AR-PACKAGE>
   </AR-PACKAGES>

--- a/tests/test_autosar.py
+++ b/tests/test_autosar.py
@@ -1,0 +1,123 @@
+# unit tests for the autosar specifics of message and database objects
+# (message.autosar and db.autosar)
+import unittest
+import traceback
+
+import cantools
+import cantools.autosar
+
+class CanToolsAutosarTest(unittest.TestCase):
+    def test_autosar3_e2e_profile2(self):
+        db = cantools.db.load_file('tests/files/arxml/system-3.2.3.arxml')
+
+        msg = db.get_message_by_name('Status')
+
+        # verify the parameters
+        self.assertTrue(msg.autosar is not None)
+        self.assertTrue(msg.autosar.e2e is not None)
+        self.assertEqual(msg.autosar.e2e.category, 'p2')
+        self.assertEqual(msg.autosar.e2e.data_ids, list(range(0,16)))
+
+        # test the crc calculation
+        did = msg.autosar.e2e.data_ids
+        self.assertEqual(cantools.autosar.compute_profile2_crc(b'\x00\x51\x22',
+                                                               did[5]),
+                         173)
+        self.assertEqual(cantools.autosar.compute_profile2_crc(b'\x00\x51\x22',
+                                                               msg),
+                         173)
+
+
+        # test the apply function
+        self.assertEqual(cantools.autosar.apply_profile2_crc(b'\xff',
+                                                             msg),
+                         None)
+        self.assertEqual(cantools.autosar.apply_profile2_crc(b'\xff\x51\x22',
+                                                             msg),
+                         b'\xad\x51\x22')
+
+        # test the check function
+        self.assertFalse(cantools.autosar.check_profile2_crc(b'\xff',
+                                                             msg))
+        self.assertFalse(cantools.autosar.check_profile2_crc(b'\x00\x51\x22',
+                                                             msg))
+        self.assertTrue(cantools.autosar.check_profile2_crc(b'\xad\x51\x22',
+                                                            msg))
+
+    def test_autosar4_e2e_profile5(self):
+        db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
+
+        msg = db.get_message_by_name('Message3')
+
+        # verify the parameters
+        self.assertTrue(msg.autosar is not None)
+        self.assertTrue(msg.autosar.is_secured)
+        self.assertEqual(msg.autosar.secured_payload_length, 4)
+        self.assertTrue(msg.autosar.e2e is not None)
+        self.assertEqual(msg.autosar.e2e.category, 'Profile5')
+        self.assertEqual(msg.autosar.e2e.data_ids, [321])
+
+        # test the crc calculation
+        self.assertEqual(cantools.autosar.compute_profile5_crc(
+            b'\x00\x00\x11\x22', msg.autosar.e2e.data_ids[0]),
+                         12201)
+        self.assertEqual(cantools.autosar.compute_profile5_crc(
+            b'\xff\xff\x11\x22\x33\x44\x55', msg),
+                         12201
+                         )
+
+        # test  the apply function
+        self.assertEqual(cantools.autosar.apply_profile5_crc(b'\xff\x51\x22',
+                                                             msg),
+                         None)
+        self.assertEqual(cantools.autosar.apply_profile5_crc(b'\xff\xee\x22\x33',
+                                                             msg),
+                         b'\xcf\xec"3')
+
+        # test the check function
+        self.assertTrue(cantools.autosar.check_profile5_crc(b'\xcf\xec"3',
+                                                             msg))
+        self.assertFalse(cantools.autosar.check_profile5_crc(b'\xcf\xec"4',
+                                                             msg))
+        self.assertFalse(cantools.autosar.check_profile5_crc(b'\xcf\xec"',
+                                                             msg))
+
+    def test_autosar4_e2e(self):
+        db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
+
+        # verify the E2E parameters for a message that uses profile 5
+        msg = db.get_message_by_name('Message3')
+        self.assertTrue(msg.autosar is not None)
+        self.assertTrue(msg.autosar.e2e is not None)
+        self.assertEqual(msg.autosar.e2e.category, 'Profile5')
+        self.assertEqual(msg.autosar.e2e.data_ids, [321])
+
+        # verify the E2E parameters for a message that uses profile 2
+        msg = db.get_message_by_name('Message1')
+        self.assertTrue(msg.autosar is not None)
+        self.assertTrue(msg.autosar.e2e is not None)
+        self.assertEqual(msg.autosar.e2e.category, 'Profile2')
+        self.assertEqual(msg.autosar.e2e.data_ids, list(range(123, 123+16)))
+
+        # verify the E2E parameters for a contained message
+        cmsg = db.get_message_by_name('OneToContainThemAll')
+        msg = cmsg.get_contained_message_by_name('message1')
+        self.assertTrue(msg.autosar is not None)
+        self.assertFalse(msg.autosar.is_secured)
+        self.assertEqual(msg.autosar.secured_payload_length, 0)
+        self.assertTrue(msg.autosar.e2e is not None)
+        self.assertEqual(msg.autosar.e2e.category, 'Profile2')
+        self.assertEqual(msg.autosar.e2e.data_ids, list(range(123, 123+16)))
+
+        # verify the E2E parameters for a contained secured message
+        cmsg = db.get_message_by_name('OneToContainThemAll')
+        msg = cmsg.get_contained_message_by_name('message3_secured')
+        self.assertTrue(msg.autosar is not None)
+        self.assertTrue(msg.autosar.is_secured)
+        self.assertEqual(msg.autosar.secured_payload_length, 4)
+        self.assertTrue(msg.autosar.e2e is not None)
+        self.assertEqual(msg.autosar.e2e.category, 'Profile5')
+        self.assertEqual(msg.autosar.e2e.data_ids, [321])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,6 +14,7 @@ import logging
 from xml.etree import ElementTree
 import timeit
 
+import cantools.autosar
 from cantools.database.utils import prune_signal_choices
 
 try:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -952,6 +952,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
             (
                 'message1',
                 {
+                    'message1_SeqCounter': 123,
+                    'message1_CRC': 456,
                     'signal6': 'zero',
                     'signal1': 5.2,
                     'signal5': 3.1415
@@ -963,7 +965,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         encoded2 = db.encode_message(db_msg.frame_id, orig_msg)
         encoded3 = db.encode_message(db_msg.name, orig_msg)
 
-        self.assertEqual(encoded, b'\n\x0b\x0c\x06\x04\x00V\x0eI@')
+        self.assertEqual(encoded, b'\n\x0b\x0c\t{\x00\xc8\x01\x04V\x0eI@')
         self.assertEqual(encoded, encoded2)
         self.assertEqual(encoded, encoded3)
 
@@ -1015,8 +1017,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
         orig_msg.append( (0xddeeff, b'\xa0\xa1\xa2\xa3\xa4') )
         encoded = db_msg.encode(orig_msg)
         self.assertEqual(encoded,
-                         b'\n\x0b\x0c\x06\x04\x00V\x0eI@'
-                         b'\xdd\xee\xff\x05\xa0\xa1\xa2\xa3\xa4')
+                         b'\n\x0b\x0c\t{\x00\xc8\x01\x04V\x0e'
+                         b'I@\xdd\xee\xff\x05\xa0\xa1\xa2\xa3\xa4')
+
 
         decoded = db_msg.decode(encoded, decode_containers=True)
         self.assertEqual(decoded[0], decoded2[0])
@@ -1031,12 +1034,12 @@ class CanToolsDatabaseTest(unittest.TestCase):
             encoded2 = db_msg.encode(orig_msg)
 
         # succeed if the sizes match
-        orig_msg[-1] = ('message1', b'\xa0\xa1\xa2\xa3\xa4\xa5')
+        orig_msg[-1] = ('message1', b'\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8')
         encoded2 = db_msg.encode(orig_msg)
 
         self.assertEqual(encoded2,
-                         b'\n\x0b\x0c\x06\x04\x00V\x0eI@'
-                         b'\n\x0b\x0c\x06\xa0\xa1\xa2\xa3\xa4\xa5')
+                         b'\n\x0b\x0c\t{\x00\xc8\x01\x04V\x0eI@\n\x0b\x0c\t'
+                         b'\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8')
 
     def test_gather_signals(self):
         db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
@@ -1054,6 +1057,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
             'signal6' : 'zero',
             'signal1': 15,
             'signal5': 3.141529,
+
+            'message1_SeqCounter': 123,
+            'message1_CRC': 456,
         }
 
         msg_signal_dict = db_msg.gather_signals(global_signal_dict)
@@ -1080,7 +1086,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
                           'MultiplexedMessage_selector1',
                           'MultiplexedStatic2',
                           'World2',
-                          'World1'])
+                          'World1',
+                          ])
 
         # test the gather method for container messages
         cmsg = db.get_message_by_name('OneToContainThemAll')
@@ -1094,8 +1101,10 @@ class CanToolsDatabaseTest(unittest.TestCase):
                          ['message1', 'message1', 'multiplexed_message'])
         csignals = [ list(x[1]) for x in ccontent ]
         self.assertEqual(csignals,
-                         [['signal6', 'signal1', 'signal5'],
-                          ['signal6', 'signal1', 'signal5'],
+                         [['message1_SeqCounter', 'message1_CRC', 'signal6',
+                           'signal1', 'signal5'],
+                          ['message1_SeqCounter', 'message1_CRC', 'signal6',
+                           'signal1', 'signal5'],
                           ['MultiplexedStatic',
                            'OneToContainThemAll_selector1',
                            'MultiplexedStatic2',
@@ -1146,7 +1155,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         # make sure that if payload is specified as raw data must
         # exhibit the correct length
-        ccontent = [ ('message1', b'\x00\x11\x22\x33\x44\x55') ]
+        ccontent = [ ('message1', b'\x00\x11\x22\x33\x44\x55\x66\x77\x88') ]
         cmsg.assert_container_encodable(ccontent, scaling=True)
         ccontent = [ ('message1', b'\x00\x11\x22\x33\x44') ]
         with self.assertRaises(cantools.database.EncodeError):
@@ -4537,11 +4546,11 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_1.is_extended_frame, False)
         self.assertEqual(message_1.is_fd, False)
         self.assertEqual(message_1.name, 'Status')
-        self.assertEqual(message_1.length, 1)
+        self.assertEqual(message_1.length, 3)
         self.assertEqual(message_1.senders, [])
         self.assertEqual(message_1.send_type, None)
         self.assertEqual(message_1.cycle_time, 500)
-        self.assertEqual(len(message_1.signals), 4)
+        self.assertEqual(len(message_1.signals), 6)
         self.assertEqual(message_1.comments["EN"], 'The lonely frame description')
         self.assertEqual(message_1.bus_name, 'Network')
         self.assertTrue(message_1.dbc is None)
@@ -4549,12 +4558,12 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_1.autosar.pdu_paths, [ '/Network/CanCluster/CAN/PDUs/Status' ])
 
         signal_1 = message_1.signals[0]
-        self.assertEqual(signal_1.name, 'Alive')
+        self.assertEqual(signal_1.name, 'Checksum')
         self.assertEqual(signal_1.start, 0)
-        self.assertEqual(signal_1.length, 1)
+        self.assertEqual(signal_1.length, 8)
         self.assertEqual(signal_1.receivers, [])
         self.assertEqual(signal_1.byte_order, 'little_endian')
-        self.assertEqual(signal_1.initial, False)
+        self.assertEqual(signal_1.initial, None)
         self.assertEqual(signal_1.is_signed, False)
         self.assertEqual(signal_1.is_float, False)
         self.assertEqual(signal_1.scale, 1.0)
@@ -4567,17 +4576,17 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_1.decimal.maximum, None)
         self.assertEqual(signal_1.unit, None)
         self.assertEqual(signal_1.choices, None)
-        self.assertEqual(signal_1.comments, {'DE': 'Lebt', 'EN': 'Is alive'})
+        self.assertEqual(signal_1.comments, {'EN': 'AUTOSAR end-to-end protection CRC according to profile 2'})
         self.assertEqual(signal_1.is_multiplexer, False)
         self.assertEqual(signal_1.multiplexer_ids, None)
 
         signal_2 = message_1.signals[1]
-        self.assertEqual(signal_2.name, 'Sleeps')
-        self.assertEqual(signal_2.start, 1)
-        self.assertEqual(signal_2.length, 1)
+        self.assertEqual(signal_2.name, 'SequenceCounter')
+        self.assertEqual(signal_2.start, 12)
+        self.assertEqual(signal_2.length, 4)
         self.assertEqual(signal_2.receivers, [])
         self.assertEqual(signal_2.byte_order, 'little_endian')
-        self.assertEqual(signal_2.initial, True)
+        self.assertEqual(signal_2.initial, None)
         self.assertEqual(signal_2.is_signed, False)
         self.assertEqual(signal_2.is_float, False)
         self.assertEqual(signal_2.scale, 1.0)
@@ -4590,55 +4599,101 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_2.decimal.maximum, None)
         self.assertEqual(signal_2.unit, None)
         self.assertEqual(signal_2.choices, None)
-        self.assertEqual(signal_2.comments, None)
+        self.assertEqual(signal_2.comments, {'EN': 'AUTOSAR end-to-end protection sequence counter according to profile 2'})
         self.assertEqual(signal_2.is_multiplexer, False)
         self.assertEqual(signal_2.multiplexer_ids, None)
 
         signal_3 = message_1.signals[2]
-        self.assertEqual(signal_3.name, 'Position')
-        self.assertEqual(signal_3.start, 3)
-        self.assertEqual(signal_3.length, 2)
+        self.assertEqual(signal_3.name, 'Alive')
+        self.assertEqual(signal_3.start, 16)
+        self.assertEqual(signal_3.length, 1)
         self.assertEqual(signal_3.receivers, [])
         self.assertEqual(signal_3.byte_order, 'little_endian')
+        self.assertEqual(signal_3.initial, False)
         self.assertEqual(signal_3.is_signed, False)
         self.assertEqual(signal_3.is_float, False)
         self.assertEqual(signal_3.scale, 1.0)
         self.assertEqual(signal_3.offset, 0.0)
-        self.assertEqual(signal_3.minimum, 0)
-        self.assertEqual(signal_3.maximum, 2)
-        self.assertEqual(signal_3.decimal.scale, 1.0)
+        self.assertEqual(signal_3.minimum, None)
+        self.assertEqual(signal_3.maximum, None)
+        self.assertEqual(signal_3.decimal.scale, Decimal('1'))
         self.assertEqual(signal_3.decimal.offset, 0.0)
-        self.assertEqual(signal_3.decimal.minimum, 0)
-        self.assertEqual(signal_3.decimal.maximum, 2)
+        self.assertEqual(signal_3.decimal.minimum, None)
+        self.assertEqual(signal_3.decimal.maximum, None)
         self.assertEqual(signal_3.unit, None)
-        self.assertEqual(signal_3.choices, { 0: 'STANDARD_POSITION',
-                                             1: 'FORWARD_POSITION',
-                                             2: 'BACKWARD_POSITION'})
-        self.assertEqual(signal_3.comments, None)
+        self.assertEqual(signal_3.choices, None)
+        self.assertEqual(signal_3.comments, {'DE': 'Lebt', 'EN': 'Is alive'})
         self.assertEqual(signal_3.is_multiplexer, False)
         self.assertEqual(signal_3.multiplexer_ids, None)
 
         signal_4 = message_1.signals[3]
-        self.assertEqual(signal_4.name, 'Movement')
-        self.assertEqual(signal_4.start, 5)
-        self.assertEqual(signal_4.length, 3)
+        self.assertEqual(signal_4.name, 'Sleeps')
+        self.assertEqual(signal_4.start, 17)
+        self.assertEqual(signal_4.length, 1)
         self.assertEqual(signal_4.receivers, [])
         self.assertEqual(signal_4.byte_order, 'little_endian')
+        self.assertEqual(signal_4.initial, True)
         self.assertEqual(signal_4.is_signed, False)
         self.assertEqual(signal_4.is_float, False)
-        self.assertEqual(signal_4.scale, 10.0/4)
-        self.assertEqual(signal_4.offset, 40.0/4)
-        self.assertEqual(signal_4.minimum, 10.0)
-        self.assertEqual(signal_4.maximum, 10.0 + 3*10.0/4)
-        self.assertEqual(signal_4.decimal.scale, 10.0/4)
-        self.assertEqual(signal_4.decimal.offset, 40.0/4)
-        self.assertEqual(signal_4.decimal.minimum, 10.0)
-        self.assertEqual(signal_4.decimal.maximum, 10.0 + 3*10.0/4)
+        self.assertEqual(signal_4.scale, 1.0)
+        self.assertEqual(signal_4.offset, 0.0)
+        self.assertEqual(signal_4.minimum, None)
+        self.assertEqual(signal_4.maximum, None)
+        self.assertEqual(signal_4.decimal.scale, Decimal('1'))
+        self.assertEqual(signal_4.decimal.offset, 0.0)
+        self.assertEqual(signal_4.decimal.minimum, None)
+        self.assertEqual(signal_4.decimal.maximum, None)
         self.assertEqual(signal_4.unit, None)
         self.assertEqual(signal_4.choices, None)
-        self.assertEqual(signal_4.comment, 'Lonely system signal comment')
+        self.assertEqual(signal_4.comments, None)
         self.assertEqual(signal_4.is_multiplexer, False)
         self.assertEqual(signal_4.multiplexer_ids, None)
+
+        signal_5 = message_1.signals[4]
+        self.assertEqual(signal_5.name, 'Position')
+        self.assertEqual(signal_5.start, 19)
+        self.assertEqual(signal_5.length, 2)
+        self.assertEqual(signal_5.receivers, [])
+        self.assertEqual(signal_5.byte_order, 'little_endian')
+        self.assertEqual(signal_5.is_signed, False)
+        self.assertEqual(signal_5.is_float, False)
+        self.assertEqual(signal_5.scale, 1.0)
+        self.assertEqual(signal_5.offset, 0.0)
+        self.assertEqual(signal_5.minimum, 0)
+        self.assertEqual(signal_5.maximum, 2)
+        self.assertEqual(signal_5.decimal.scale, 1.0)
+        self.assertEqual(signal_5.decimal.offset, 0.0)
+        self.assertEqual(signal_5.decimal.minimum, 0)
+        self.assertEqual(signal_5.decimal.maximum, 2)
+        self.assertEqual(signal_5.unit, None)
+        self.assertEqual(signal_5.choices, { 0: 'STANDARD_POSITION',
+                                             1: 'FORWARD_POSITION',
+                                             2: 'BACKWARD_POSITION'})
+        self.assertEqual(signal_5.comments, None)
+        self.assertEqual(signal_5.is_multiplexer, False)
+        self.assertEqual(signal_5.multiplexer_ids, None)
+
+        signal_6 = message_1.signals[5]
+        self.assertEqual(signal_6.name, 'Movement')
+        self.assertEqual(signal_6.start, 21)
+        self.assertEqual(signal_6.length, 3)
+        self.assertEqual(signal_6.receivers, [])
+        self.assertEqual(signal_6.byte_order, 'little_endian')
+        self.assertEqual(signal_6.is_signed, False)
+        self.assertEqual(signal_6.is_float, False)
+        self.assertEqual(signal_6.scale, 10.0/4)
+        self.assertEqual(signal_6.offset, 40.0/4)
+        self.assertEqual(signal_6.minimum, 10.0)
+        self.assertEqual(signal_6.maximum, 10.0 + 3*10.0/4)
+        self.assertEqual(signal_6.decimal.scale, 10.0/4)
+        self.assertEqual(signal_6.decimal.offset, 40.0/4)
+        self.assertEqual(signal_6.decimal.minimum, 10.0)
+        self.assertEqual(signal_6.decimal.maximum, 10.0 + 3*10.0/4)
+        self.assertEqual(signal_6.unit, None)
+        self.assertEqual(signal_6.choices, None)
+        self.assertEqual(signal_6.comment, 'Lonely system signal comment')
+        self.assertEqual(signal_6.is_multiplexer, False)
+        self.assertEqual(signal_6.multiplexer_ids, None)
 
     def test_system_4_arxml(self):
         db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
@@ -4794,11 +4849,11 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_1.is_extended_frame, False)
         self.assertEqual(message_1.is_fd, True)
         self.assertEqual(message_1.name, 'Message1')
-        self.assertEqual(message_1.length, 6)
+        self.assertEqual(message_1.length, 9)
         self.assertEqual(message_1.senders, ['DJ'])
         self.assertEqual(message_1.send_type, None)
         self.assertEqual(message_1.cycle_time, None)
-        self.assertEqual(len(message_1.signals), 3)
+        self.assertEqual(len(message_1.signals), 5)
         self.assertEqual(message_1.comments["DE"], 'Kommentar1')
         self.assertEqual(message_1.comments["EN"], 'Comment1')
         self.assertEqual(message_1.bus_name, 'Cluster0')
@@ -4814,82 +4869,128 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_1.autosar.pdu_paths, [ '/ISignalIPdu/message1' ])
 
         signal_1 = message_1.signals[0]
-        self.assertEqual(signal_1.name, 'signal6')
+        self.assertEqual(signal_1.name, 'message1_SeqCounter')
         self.assertEqual(signal_1.start, 0)
-        self.assertEqual(signal_1.length, 1)
-        self.assertEqual(signal_1.initial, False)
+        self.assertEqual(signal_1.length, 16)
+        self.assertEqual(signal_1.initial, None)
         self.assertEqual(signal_1.receivers, ['Dancer'])
         self.assertEqual(signal_1.byte_order, 'little_endian')
         self.assertEqual(signal_1.is_signed, False)
         self.assertEqual(signal_1.is_float, False)
-        self.assertEqual(signal_1.scale, 0.1)
-        self.assertEqual(signal_1.offset, 0.0)
-        self.assertEqual(signal_1.minimum, 0)
-        self.assertEqual(signal_1.maximum, 0.1)
-        self.assertEqual(signal_1.decimal.scale, Decimal('0.1'))
-        self.assertEqual(signal_1.decimal.offset, 0.0)
-        self.assertEqual(signal_1.decimal.minimum, 0)
-        self.assertEqual(signal_1.decimal.maximum, 0.1)
-        self.assertEqual(signal_1.unit, "wp")
-        self.assertEqual(signal_1.choices, {0: 'zero'})
+        self.assertEqual(signal_1.scale, 1)
+        self.assertEqual(signal_1.offset, 0)
+        self.assertEqual(signal_1.minimum, None)
+        self.assertEqual(signal_1.maximum, None)
+        self.assertEqual(signal_1.decimal.scale, Decimal('1'))
+        self.assertEqual(signal_1.decimal.offset, 0)
+        self.assertEqual(signal_1.decimal.minimum, None)
+        self.assertEqual(signal_1.decimal.maximum, None)
+        self.assertEqual(signal_1.unit, None)
+        self.assertEqual(signal_1.choices, None)
         self.assertEqual(signal_1.comment, None)
         self.assertEqual(signal_1.is_multiplexer, False)
         self.assertEqual(signal_1.multiplexer_ids, None)
 
         signal_2 = message_1.signals[1]
-        self.assertEqual(signal_2.name, 'signal1')
-        self.assertEqual(signal_2.start, 4)
-        self.assertEqual(signal_2.length, 3)
-        self.assertEqual(signal_2.initial, 25.0)
+        self.assertEqual(signal_2.name, 'message1_CRC')
+        self.assertEqual(signal_2.start, 16)
+        self.assertEqual(signal_2.length, 16)
+        self.assertEqual(signal_2.initial, None)
         self.assertEqual(signal_2.receivers, ['Dancer'])
-        self.assertEqual(signal_2.byte_order, 'big_endian')
+        self.assertEqual(signal_2.byte_order, 'little_endian')
         self.assertEqual(signal_2.is_signed, False)
         self.assertEqual(signal_2.is_float, False)
-        self.assertEqual(signal_2.scale, 5.0)
-        self.assertEqual(signal_2.offset, 0.0)
-        self.assertEqual(signal_2.minimum, 0.0)
-        self.assertEqual(signal_2.maximum, 20.0)
-        self.assertEqual(signal_2.decimal.scale, 5.0)
-        self.assertEqual(signal_2.decimal.offset, 0.0)
-        self.assertEqual(signal_2.decimal.minimum, 0.0)
-        self.assertEqual(signal_2.decimal.maximum, 20.0)
-        self.assertEqual(signal_2.unit, 'm')
+        self.assertEqual(signal_2.scale, 1)
+        self.assertEqual(signal_2.offset, 0)
+        self.assertEqual(signal_2.minimum, None)
+        self.assertEqual(signal_2.maximum, None)
+        self.assertEqual(signal_2.decimal.scale, Decimal('1'))
+        self.assertEqual(signal_2.decimal.offset, 0)
+        self.assertEqual(signal_2.decimal.minimum, None)
+        self.assertEqual(signal_2.decimal.maximum, None)
+        self.assertEqual(signal_2.unit, None)
         self.assertEqual(signal_2.choices, None)
-        self.assertEqual(signal_2.comments["EN"], 'Signal comment!')
-        self.assertEqual(signal_2.comments["DE"], 'Signalkommentar!')
-        self.assertEqual(signal_2.comment, 'Signal comment!')
-        signal_2.comments = {'DE': 'Kein Kommentar!', 'EN': 'No comment!'}
-        self.assertEqual(signal_2.comments,
+        self.assertEqual(signal_2.comment, None)
+        self.assertEqual(signal_2.is_multiplexer, False)
+        self.assertEqual(signal_2.multiplexer_ids, None)
+
+        signal_3 = message_1.signals[2]
+        self.assertEqual(signal_3.name, 'signal6')
+        self.assertEqual(signal_3.start, 32)
+        self.assertEqual(signal_3.length, 1)
+        self.assertEqual(signal_3.initial, False)
+        self.assertEqual(signal_3.receivers, ['Dancer'])
+        self.assertEqual(signal_3.byte_order, 'little_endian')
+        self.assertEqual(signal_3.is_signed, False)
+        self.assertEqual(signal_3.is_float, False)
+        self.assertEqual(signal_3.scale, 0.1)
+        self.assertEqual(signal_3.offset, 0.0)
+        self.assertEqual(signal_3.minimum, 0)
+        self.assertEqual(signal_3.maximum, 0.1)
+        self.assertEqual(signal_3.decimal.scale, Decimal('0.1'))
+        self.assertEqual(signal_3.decimal.offset, 0.0)
+        self.assertEqual(signal_3.decimal.minimum, 0)
+        self.assertEqual(signal_3.decimal.maximum, 0.1)
+        self.assertEqual(signal_3.unit, "wp")
+        self.assertEqual(signal_3.choices, {0: 'zero'})
+        self.assertEqual(signal_3.comment, None)
+        self.assertEqual(signal_3.is_multiplexer, False)
+        self.assertEqual(signal_3.multiplexer_ids, None)
+
+        signal_4 = message_1.signals[3]
+        self.assertEqual(signal_4.name, 'signal1')
+        self.assertEqual(signal_4.start, 36)
+        self.assertEqual(signal_4.length, 3)
+        self.assertEqual(signal_4.initial, 25.0)
+        self.assertEqual(signal_4.receivers, ['Dancer'])
+        self.assertEqual(signal_4.byte_order, 'big_endian')
+        self.assertEqual(signal_4.is_signed, False)
+        self.assertEqual(signal_4.is_float, False)
+        self.assertEqual(signal_4.scale, 5.0)
+        self.assertEqual(signal_4.offset, 0.0)
+        self.assertEqual(signal_4.minimum, 0.0)
+        self.assertEqual(signal_4.maximum, 20.0)
+        self.assertEqual(signal_4.decimal.scale, 5.0)
+        self.assertEqual(signal_4.decimal.offset, 0.0)
+        self.assertEqual(signal_4.decimal.minimum, 0.0)
+        self.assertEqual(signal_4.decimal.maximum, 20.0)
+        self.assertEqual(signal_4.unit, 'm')
+        self.assertEqual(signal_4.choices, None)
+        self.assertEqual(signal_4.comments["EN"], 'Signal comment!')
+        self.assertEqual(signal_4.comments["DE"], 'Signalkommentar!')
+        self.assertEqual(signal_4.comment, 'Signal comment!')
+        signal_4.comments = {'DE': 'Kein Kommentar!', 'EN': 'No comment!'}
+        self.assertEqual(signal_4.comments,
                          {
                              'DE': 'Kein Kommentar!',
                              'EN': 'No comment!'
                          })
 
-        self.assertEqual(signal_2.is_multiplexer, False)
-        self.assertEqual(signal_2.multiplexer_ids, None)
+        self.assertEqual(signal_4.is_multiplexer, False)
+        self.assertEqual(signal_4.multiplexer_ids, None)
 
-        signal_3 = message_1.signals[2]
-        self.assertEqual(signal_3.name, 'signal5')
-        self.assertEqual(signal_3.start, 16)
-        self.assertEqual(signal_3.initial, None)
-        self.assertEqual(signal_3.length, 32)
-        self.assertEqual(signal_3.receivers, ['Dancer'])
-        self.assertEqual(signal_3.byte_order, 'little_endian')
-        self.assertEqual(signal_3.is_signed, False)
-        self.assertEqual(signal_3.is_float, True)
-        self.assertEqual(signal_3.scale, 1)
-        self.assertEqual(signal_3.offset, 0)
-        self.assertEqual(signal_3.minimum, None)
-        self.assertEqual(signal_3.maximum, None)
-        self.assertEqual(signal_3.decimal.scale, 1)
-        self.assertEqual(signal_3.decimal.offset, 0)
-        self.assertEqual(signal_3.decimal.minimum, None)
-        self.assertEqual(signal_3.decimal.maximum, None)
-        self.assertEqual(signal_3.unit, None)
-        self.assertEqual(signal_3.choices, None)
-        self.assertEqual(signal_3.comment, None)
-        self.assertEqual(signal_3.is_multiplexer, False)
-        self.assertEqual(signal_3.multiplexer_ids, None)
+        signal_5 = message_1.signals[4]
+        self.assertEqual(signal_5.name, 'signal5')
+        self.assertEqual(signal_5.start, 40)
+        self.assertEqual(signal_5.initial, None)
+        self.assertEqual(signal_5.length, 32)
+        self.assertEqual(signal_5.receivers, ['Dancer'])
+        self.assertEqual(signal_5.byte_order, 'little_endian')
+        self.assertEqual(signal_5.is_signed, False)
+        self.assertEqual(signal_5.is_float, True)
+        self.assertEqual(signal_5.scale, 1)
+        self.assertEqual(signal_5.offset, 0)
+        self.assertEqual(signal_5.minimum, None)
+        self.assertEqual(signal_5.maximum, None)
+        self.assertEqual(signal_5.decimal.scale, 1)
+        self.assertEqual(signal_5.decimal.offset, 0)
+        self.assertEqual(signal_5.decimal.minimum, None)
+        self.assertEqual(signal_5.decimal.maximum, None)
+        self.assertEqual(signal_5.unit, None)
+        self.assertEqual(signal_5.choices, None)
+        self.assertEqual(signal_5.comment, None)
+        self.assertEqual(signal_5.is_multiplexer, False)
+        self.assertEqual(signal_5.multiplexer_ids, None)
 
         message_2 = db.messages[2]
         self.assertEqual(message_2.frame_id, 6)
@@ -4985,7 +5086,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_3.senders, [])
         self.assertEqual(message_3.send_type, None)
         self.assertEqual(message_3.cycle_time, None)
-        self.assertEqual(len(message_3.signals), 0)
+        self.assertEqual(len(message_3.signals), 2)
         self.assertEqual(message_3.comment, None)
         self.assertEqual(message_3.bus_name, 'Cluster0')
         self.assertTrue(message_3.dbc is None)
@@ -5087,6 +5188,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
                              'Cluster',
                              'CanFrame',
                              'ISignal',
+                             'Transformers',
                              'Constants',
                              'MultiplexedIPdu',
                              'ContainerIPdu',
@@ -5488,17 +5590,19 @@ class CanToolsDatabaseTest(unittest.TestCase):
         db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
 
         decoded_message = {
-            "signal1" : 0.0,
-            "signal5" : 1e5,
-            "signal6" : "zero",
+            'message1_SeqCounter': 123,
+            'message1_CRC': 456,
+            'signal1' : 0.0,
+            'signal5' : 1e5,
+            'signal6' : 'zero',
         }
 
-        encoded_message = db.encode_message("Message1", decoded_message)
+        encoded_message = db.encode_message('Message1', decoded_message)
 
-        self.assertEqual(encoded_message, b'\x00\x00\x00P\xc3G')
+        self.assertEqual(encoded_message, b'{\x00\xc8\x01\x00\x00P\xc3G')
 
-        decoded_message2 = db.decode_message("Message1", encoded_message)
-        encoded_message2 = db.encode_message("Message1", decoded_message2)
+        decoded_message2 = db.decode_message('Message1', encoded_message)
+        encoded_message2 = db.encode_message('Message1', decoded_message2)
 
         self.assertEqual(encoded_message2, encoded_message)
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -67,6 +67,7 @@ ExampleMessage:
   Size: 8 bytes
   Is extended frame: False
   Is CAN-FD frame: False
+  Is secured: False
   Signal tree:
 
     -- {root}
@@ -188,6 +189,7 @@ Message2:
   Is extended frame: True
   Is CAN-FD frame: True
   Cycle time: 200 ms
+  Is secured: False
   Signal tree:
 
     -- {root}
@@ -298,6 +300,7 @@ Message1:
   Is CAN-FD frame: True
   End-to-end category: Profile2
   Data IDs: [123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138]
+  Is secured: False
   Signal tree:
 
     -- {root}
@@ -403,6 +406,7 @@ Message1:
   Size: 5 bytes
   Is extended frame: False
   Is CAN-FD frame: False
+  Is secured: False
   Signal tree:
 
     -- {root}
@@ -433,6 +437,7 @@ Message2:
   Is extended frame: False
   Is CAN-FD frame: False
   Cycle time: 100 ms
+  Is secured: False
   Signal tree:
 
     -- {root}
@@ -514,6 +519,7 @@ Message4:
   Size: 5 bytes
   Is extended frame: False
   Is CAN-FD frame: False
+  Is secured: False
   Signal tree:
 
     -- {root}
@@ -554,6 +560,7 @@ Message3:
   Size: 8 bytes
   Is extended frame: True
   Is CAN-FD frame: False
+  Is secured: False
   Signal tree:
 
     -- {root}

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -296,6 +296,8 @@ Message1:
   Size: 9 bytes
   Is extended frame: False
   Is CAN-FD frame: True
+  End-to-end category: Profile2
+  Data IDs: [123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138]
   Signal tree:
 
     -- {root}

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -293,21 +293,35 @@ Message1:
   Bus: Cluster0
   Sending ECUs: DJ
   Frame ID: 0x5 (5)
-  Size: 6 bytes
+  Size: 9 bytes
   Is extended frame: False
   Is CAN-FD frame: True
   Signal tree:
 
     -- {root}
+       +-- message1_SeqCounter
+       +-- message1_CRC
        +-- signal6
        +-- signal1
        +-- signal5
 
   Signal details:
-    signal6:
+    message1_SeqCounter:
       Receiving ECUs: Dancer
       Type: Integer
       Start bit: 0
+      Length: 16 bits
+      Is signed: False
+    message1_CRC:
+      Receiving ECUs: Dancer
+      Type: Integer
+      Start bit: 16
+      Length: 16 bits
+      Is signed: False
+    signal6:
+      Receiving ECUs: Dancer
+      Type: Integer
+      Start bit: 32
       Length: 1 bits
       Unit: wp
       Initial value: False
@@ -325,7 +339,7 @@ Message1:
       Comment[DE]: Signalkommentar!
       Receiving ECUs: Dancer
       Type: Integer
-      Start bit: 4
+      Start bit: 36
       Length: 3 bits
       Unit: m
       Initial value: 25.0 m
@@ -337,7 +351,7 @@ Message1:
     signal5:
       Receiving ECUs: Dancer
       Type: Float
-      Start bit: 16
+      Start bit: 40
       Length: 32 bits
       Is signed: False
 """


### PR DESCRIPTION
Currently we limit ourselves to profile 2 and profile 5. Besides implementing the actual E2E functionality, this PR implements the extraction the required data ids for PDUs from ARXML files into the autosar specifics of messages. Also it includes the associated unit tests and modifies the `list` subparser to display the properties required for E2E protection.

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)
