### PR TITLE
Implement support for AUTOSAR secure on-board communication

### DIFF
--- a/cantools/autosar/__init__.py
+++ b/cantools/autosar/__init__.py
@@ -1,3 +1,4 @@
 # a collection of AUTOSAR specific functionality
 
 from .end_to_end import *
+from .secoc import *

--- a/cantools/autosar/secoc.py
+++ b/cantools/autosar/secoc.py
@@ -1,0 +1,83 @@
+# Utilities for dealing with AUTOSAR secure on-board communication.
+# (SecOC, i.e., verification of the authenticity of the sender of
+# messages.)
+
+from cantools.database.can.message import Message
+from cantools.errors import Error
+
+from typing import Union, List, Optional, Callable
+
+import bitstruct
+
+class SecOCError(Error):
+    """Exception that is raised if something SecOC related goes wrong.
+
+    """
+    pass
+
+def apply_authenticator(raw_payload: Union[bytes, bytearray],
+                        dbmsg: Message,
+                        authenticator_fn: Callable[[Message,
+                                                    bytearray,
+                                                    int],
+                                                   bytearray],
+                        freshness_value: int) \
+                        -> bytearray:
+    """Given a byte-like object that contains the encoded signals to be
+    send, compute the full message which ought to be send.
+
+    This is basically the concatination of the raw payload, the
+    truncated freshness value and the truncated authenticator for the
+    message.
+    """
+
+    if dbmsg.autosar is None or dbmsg.autosar.secoc is None:
+        raise SecOCError(f'Message "{dbmsg.name}" is not secured')
+
+    secoc_props = dbmsg.autosar.secoc
+    result = bytearray(raw_payload)
+
+    payload_len = secoc_props.payload_length
+
+    # get the last N bits of the freshness value. we assume that the
+    # full freshness value is at most 64 bits.
+    n_fresh = secoc_props.freshness_bit_length
+    n_fresh_tx = secoc_props.freshness_tx_bit_length
+    mask = 0xffffffffffffffff >> (64 - n_fresh_tx)
+    freshness_header_value = freshness_value&mask
+
+    # compute the authentificator value
+    auth_data = bitstruct.pack(f'u16' # data ID
+                               f'r{payload_len*8}' # payload to be secured
+                               f'u{n_fresh}', # freshness value
+                               secoc_props.data_id,
+                               raw_payload[:payload_len],
+                               freshness_value)
+
+    # compute authenticator and pack it into the result array
+    auth_value = authenticator_fn(dbmsg, auth_data, freshness_value)
+
+    bitstruct.pack_into(f'u{n_fresh_tx}r{secoc_props.auth_tx_bit_length}',
+                        result,
+                        payload_len*8,
+                        freshness_header_value,
+                        auth_value)
+
+    return result
+
+def verify_authenticator(raw_payload: Union[bytes, bytearray],
+                         dbmsg: Message,
+                         authenticator_fn: Callable[[Message,
+                                                     bytearray,
+                                                     int],
+                                                    bytearray],
+                         freshness_value: int) \
+                    -> bool:
+    """Verify that a message that is secured via SecOC is valid."""
+
+    tmp_payload = apply_authenticator(raw_payload,
+                                      dbmsg,
+                                      authenticator_fn,
+                                      freshness_value)
+
+    return raw_payload == tmp_payload

--- a/cantools/autosar/snakeauth.py
+++ b/cantools/autosar/snakeauth.py
@@ -1,0 +1,36 @@
+# An example cipher suite for secure on-board communication. This is
+# in no way cryptographically secure. DO NOT USE IN THE REAL WORLD!
+
+from cantools.database import Message
+
+from typing import Union
+
+class SnakeOilAuthenticator:
+    """A snake oil authenticator for secure on-board communication
+
+    The sole purpose of this class is to demonstrate how SecOC can be
+    implemented using cantools. These algorithms are in no way
+    cryptographically secure! DO NOT USE THEM IN THE REAL WORLD!
+    """
+    def __init__(self,
+                 secret: Union[str, bytes, bytearray]):
+        if isinstance(secret, str):
+            self._secret = secret.encode()
+        else:
+            self._secret = bytes(secret)
+
+    def __call__(self,
+                 dbmsg: Message,
+                 auth_data: bytearray,
+                 freshness_value: int) \
+                -> bytearray:
+
+        v0 = freshness_value%253
+
+        # XOR the secret and the data which we ought to authenticate
+        result = bytearray([v0]*5)
+        for i in range(0, len(auth_data)):
+            result[i % len(result)] ^= auth_data[i]
+            result[i % len(result)] ^= self._secret[i%len(self._secret)]
+
+        return result

--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -62,8 +62,7 @@ class AutosarMessageSpecifics(object):
     def __init__(self):
         self._pdu_paths = []
         self._is_nm = False
-        self._is_secured = False
-        self._secured_payload_length = 0
+        self._secoc: Optional['AutosarSecOCProperties'] = None
         self._e2e: Optional['AutosarEnd2EndProperties'] = None
         self._signal_group = None
 
@@ -87,17 +86,13 @@ class AutosarMessageSpecifics(object):
     def is_secured(self):
         """True iff the message integrity is secured using SecOC
         """
-        return self._is_secured
+        return self._secoc is not None
 
     @property
-    def secured_payload_length(self):
-        """Returns the number of bytes covered by the payload of the secured
-        message
-
-        (The full message length is the length of the payload plus the
-        size of the security header.)
+    def secoc(self):
+        """The properties required to implement secured on-board communication
         """
-        return self._secured_payload_length
+        return self._secoc
 
     @property
     def e2e(self) -> Optional['AutosarEnd2EndProperties']:
@@ -107,6 +102,100 @@ class AutosarMessageSpecifics(object):
     @e2e.setter
     def e2e(self, value: Optional['AutosarEnd2EndProperties']) -> None:
         self._e2e = value
+
+class AutosarSecOCProperties:
+    """This class collects all attributes that are required to implement the
+    AUTOSAR secure on-board communication (SecOC) specification.
+
+    Be aware that the AUTOSAR SecOC specification does not cover the
+    required cryptographic primitives themselves, just the
+    "scaffolding" around them...
+    """
+    def __init__(self,
+                 auth_algorithm_name: Optional[str],
+                 freshness_algorithm_name: Optional[str],
+                 payload_length: Optional[int],
+                 data_id: Optional[int],
+                 auth_tx_bit_length: Optional[int],
+                 freshness_bit_length: Optional[int],
+                 freshness_tx_bit_length: Optional[int],
+                 ):
+
+        self._auth_algorithm_name = auth_algorithm_name
+        self._freshness_algorithm_name = freshness_algorithm_name
+
+        self._payload_length = payload_length
+        self._data_id = data_id
+
+        self._freshness_bit_length = freshness_bit_length
+        self._freshness_tx_bit_length = freshness_tx_bit_length
+        self._auth_tx_bit_length = auth_tx_bit_length
+
+    @property
+    def freshness_algorithm_name(self) -> Optional[str]:
+        """The name of the algorithm used for verifying the freshness of a
+        message.
+
+        This can be used to prevent replay attacks. Note that the
+        algorithms themselves are manufacturer-specific, i.e., AUTOSAR
+        does not define *any* freshness schemes.
+        """
+        return self._freshness_algorithm_name
+
+    @property
+    def auth_algorithm_name(self) -> Optional[str]:
+        """The name of the algorithm used for authentication
+
+        Note that the algorithms themselves are manufacturer-specific,
+        i.e., AUTOSAR does not define *any* cryptographic schemes.
+        """
+        return self._auth_algorithm_name
+
+    @property
+    def payload_length(self) -> Optional[int]:
+        """Returns the number of bytes covered by the payload of the secured
+        message
+
+        (The full message length is the length of the payload plus the
+        size of the security trailer.)
+        """
+        return self._payload_length
+
+    @property
+    def data_id(self) -> Optional[int]:
+        """The data ID required for authentication.
+
+        Be aware that this is a different data ID than that required
+        for End-To-End protection.
+        """
+        return self._data_id
+
+    @property
+    def freshness_bit_length(self) -> Optional[int]:
+        """The number of bits of the full freshness counter.
+        """
+        return self._freshness_bit_length
+
+    @property
+    def freshness_tx_bit_length(self) -> Optional[int]:
+        """The number of least-significant bits of the freshness counter that
+        is send as part of the secured frame.
+
+        This number is at most as large as the number of bits of
+        freshness counter objects.
+
+        """
+        return self._freshness_tx_bit_length
+
+    @property
+    def auth_tx_bit_length(self) -> Optional[int]:
+        """The number of most significant bits of the authenticator object
+        send as part of the secured frame
+
+        This is at most the length of the authenicator.
+        """
+        return self._auth_tx_bit_length
+
 
 class AutosarEnd2EndProperties:
     """This class collects all attributes that are required to implement
@@ -916,7 +1005,7 @@ class SystemLoader(object):
         autosar_specifics._pdu_paths.append(pdu_path)
 
         _, \
-            payload_length, \
+            _, \
             signals, \
             cycle_time, \
             child_pdu_paths, \
@@ -925,21 +1014,12 @@ class SystemLoader(object):
         autosar_specifics._pdu_paths.extend(child_pdu_paths)
         autosar_specifics._is_nm = \
             (pdu.tag == f'{{{self.xml_namespace}}}NM-PDU')
-        autosar_specifics._is_secured = \
+        is_secured = \
             (pdu.tag == f'{{{self.xml_namespace}}}SECURED-I-PDU')
 
         self._load_e2e_data_id_from_signal_group(pdu, autosar_specifics)
-        if autosar_specifics.is_secured:
-            autosar_specifics._secured_payload_length = payload_length
-            if autosar_specifics.e2e is None:
-                # use the data id from the signal group associated with
-                # the payload PDU if the secured PDU does not define a
-                # group with a data id...
-                payload_pdu = \
-                    self._get_unique_arxml_child(pdu, [ '&PAYLOAD', '&I-PDU' ])
-
-                self._load_e2e_data_id_from_signal_group(payload_pdu,
-                                                         autosar_specifics)
+        if is_secured:
+            self._load_secured_properties(name, pdu, signals, autosar_specifics)
 
         # the bit pattern used to fill in unused bits to avoid
         # undefined behaviour/information leaks
@@ -965,6 +1045,99 @@ class SystemLoader(object):
                        autosar_specifics=autosar_specifics,
                        strict=self._strict,
                        sort_signals=self._sort_signals)
+
+    def _load_secured_properties(self,
+                                 message_name,
+                                 pdu,
+                                 signals,
+                                 autosar_specifics):
+        payload_pdu = \
+            self._get_unique_arxml_child(pdu, [ '&PAYLOAD', '&I-PDU' ])
+
+        payload_length = self._get_unique_arxml_child(payload_pdu, 'LENGTH')
+        payload_length = parse_number_string(payload_length.text)
+
+        if autosar_specifics.e2e is None:
+            # use the data id from the signal group associated with
+            # the payload PDU if the secured PDU does not define a
+            # group with a data id...
+            self._load_e2e_data_id_from_signal_group(payload_pdu,
+                                                     autosar_specifics)
+
+        # data specifying the SecOC "footer" of a secured frame
+        auth_algo = self._get_unique_arxml_child(pdu, [
+            '&AUTHENTICATION-PROPS',
+            'SHORT-NAME' ])
+        if auth_algo is not None:
+            auth_algo = auth_algo.text
+
+        fresh_algo = self._get_unique_arxml_child(pdu, [
+            '&FRESHNESS-PROPS',
+            'SHORT-NAME' ])
+        if fresh_algo is not None:
+            fresh_algo = fresh_algo.text
+
+        data_id = self._get_unique_arxml_child(pdu, [
+            'SECURE-COMMUNICATION-PROPS',
+            'DATA-ID' ])
+        if data_id is not None:
+            data_id = parse_number_string(data_id.text)
+
+        auth_tx_len = self._get_unique_arxml_child(pdu, [
+            '&AUTHENTICATION-PROPS',
+            'AUTH-INFO-TX-LENGTH' ])
+        if auth_tx_len is not None:
+            auth_tx_len = parse_number_string(auth_tx_len.text)
+
+        fresh_len = self._get_unique_arxml_child(pdu, [
+            '&FRESHNESS-PROPS',
+            'FRESHNESS-VALUE-LENGTH' ])
+        if fresh_len is not None:
+            fresh_len = parse_number_string(fresh_len.text)
+
+        fresh_tx_len = self._get_unique_arxml_child(pdu, [
+            '&FRESHNESS-PROPS',
+            'FRESHNESS-VALUE-TX-LENGTH' ])
+        if fresh_tx_len is not None:
+            fresh_tx_len = parse_number_string(fresh_tx_len.text)
+
+        # add "pseudo signals" for the truncated freshness value and
+        # the truncated authenticator
+        if fresh_tx_len is not None:
+            signals.append(Signal(name=f'{message_name}_Freshness',
+                                  start=payload_length*8 + 7,
+                                  length=fresh_tx_len,
+                                  byte_order='big_endian',
+                                  comment=\
+                                  {'FOR-ALL':
+                                   f'Truncated freshness value for '
+                                   f"'{message_name}'"}))
+        if auth_tx_len is not None:
+            n0 = payload_length*8 + (fresh_tx_len//8)*8 + (7-fresh_tx_len%8)
+            signals.append(Signal(name=f'{message_name}_Authenticator',
+                                  start=n0,
+                                  length=auth_tx_len,
+                                  byte_order='big_endian',
+                                  comment=\
+                                  { 'FOR-ALL':
+                                    f'Truncated authenticator value for '
+                                    f"'{message_name}'"}))
+
+        # note that the length of the authenificator is implicit:
+        # e.g., for an MD5 based message authencation code, it would
+        # be 128 bits long which algorithm is used is highly
+        # manufacturer specific and determined via the authenticator
+        # name.
+        autosar_specifics._secoc = \
+            AutosarSecOCProperties(
+                auth_algorithm_name=auth_algo,
+                freshness_algorithm_name=fresh_algo,
+                payload_length=payload_length,
+                data_id=data_id,
+                freshness_bit_length=fresh_len,
+                freshness_tx_bit_length=fresh_tx_len,
+                auth_tx_bit_length=auth_tx_len)
+
 
     def _load_pdu(self, pdu, frame_name, next_selector_idx):
         is_secured = pdu.tag == f'{{{self.xml_namespace}}}SECURED-I-PDU'
@@ -1046,7 +1219,7 @@ class SystemLoader(object):
                 # create the autosar specifics of the contained_message
                 contained_autosar_specifics = AutosarMessageSpecifics()
                 contained_autosar_specifics._pdu_paths = contained_pdu_paths
-                contained_autosar_specifics._is_secured = \
+                is_secured = \
                     (contained_pdu.tag ==
                      f'{{{self.xml_namespace}}}SECURED-I-PDU')
 
@@ -1055,21 +1228,11 @@ class SystemLoader(object):
                 self._load_e2e_data_id_from_signal_group(
                     contained_pdu,
                     contained_autosar_specifics)
-                if contained_autosar_specifics.is_secured:
-                    contained_autosar_specifics._secured_payload_length = \
-                        payload_length
-                    if contained_autosar_specifics.e2e is None:
-                        # use the data id from the signal group
-                        # associated with the payload PDU if the
-                        # secured PDU does not define a group with a
-                        # data id...
-                        payload_pdu = \
-                            self._get_unique_arxml_child(contained_pdu, [
-                                '&PAYLOAD', '&I-PDU' ])
-
-                        self._load_e2e_data_id_from_signal_group(
-                            payload_pdu,
-                            contained_autosar_specifics)
+                if is_secured:
+                    self._load_secured_properties(name,
+                                                  contained_pdu,
+                                                  signals,
+                                                  contained_autosar_specifics)
 
                 contained_message = \
                     Message(header_id=header_id,

--- a/cantools/subparsers/list.py
+++ b/cantools/subparsers/list.py
@@ -42,10 +42,16 @@ def _print_message(message, indent=''):
             print(f'{indent}    Protected size: {e2e.payload_length} bytes')
 
         print(f'{indent}  Is secured: {message.autosar.is_secured}')
-        if message.autosar.is_secured:
+        secoc = message.autosar.secoc
+        if secoc:
             print(f'{indent}  Security properties:')
-            print(f'{indent}    Secured size: '
-                  f'{message.autosar.secured_payload_length}')
+            print(f'{indent}    Authentication algorithm: {secoc.auth_algorithm_name}')
+            print(f'{indent}    Freshness algorithm: {secoc.freshness_algorithm_name}')
+            print(f'{indent}    Data ID: {secoc.data_id}')
+            print(f'{indent}    Authentication transmit bits: {secoc.auth_tx_bit_length}')
+            print(f'{indent}    Freshness counter size: {secoc.freshness_bit_length} bits')
+            print(f'{indent}    Freshness counter transmit size: {secoc.freshness_tx_bit_length} bits')
+            print(f'{indent}    Secured size: {secoc.payload_length} bytes')
 
     if message.signals:
         print(f'{indent}  Signal tree:')

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -305,7 +305,7 @@
         <!-- /CanFrame/Message3 -->
         <CAN-FRAME UUID="02f3b1a9e14f4f2167bde58cfcdc00a0">
           <SHORT-NAME>Message3</SHORT-NAME>
-          <FRAME-LENGTH>8</FRAME-LENGTH>
+          <FRAME-LENGTH>6</FRAME-LENGTH>
           <PDU-TO-FRAME-MAPPINGS>
             <!-- /CanFrame/Message3/message3 -->
             <PDU-TO-FRAME-MAPPING UUID="c2102052cd836391401149341e964b5f">
@@ -1043,13 +1043,42 @@
         <!-- /SecuredIPdu/message3_secured -->
         <SECURED-I-PDU UUID="9fb09bd0b1f84e86a0c62a2de73be796">
           <SHORT-NAME>message3_secured</SHORT-NAME>
-          <LENGTH>8</LENGTH>
+          <LENGTH>6</LENGTH>
           <CONTAINED-I-PDU-PROPS>
             <HEADER-ID-SHORT-HEADER>0x040506</HEADER-ID-SHORT-HEADER>
           </CONTAINED-I-PDU-PROPS>
-          <!-- we currently do not specify AUTHENTICATION_PROPS, FRESHNESS_PROPS, and SECURE-COMMUNICATION-PROPS. While this is technically allowed, it does not make much sense in the context of a secured I-PDU... -->
+          <AUTHENTICATION-PROPS-REF DEST="SECURE-COMMUNICATION-AUTHENTICATION-PROPS">/SecOCProps/S/KnockKnock</AUTHENTICATION-PROPS-REF>
+          <FRESHNESS-PROPS-REF DEST="SECURE-COMMUNICATION-FRESHNESS-PROPS">/SecOCProps/S/SmellyCheese</FRESHNESS-PROPS-REF>
           <PAYLOAD-REF DEST="PDU-TRIGGERING">/Cluster/Cluster0/Pch0/message3_triggering</PAYLOAD-REF>
+          <SECURE-COMMUNICATION-PROPS>
+            <DATA-ID>1337</DATA-ID>
+          </SECURE-COMMUNICATION-PROPS>
         </SECURED-I-PDU>
+      </ELEMENTS>
+    </AR-PACKAGE>
+    <!-- /SecOCProps -->
+    <AR-PACKAGE UUID="7449c6261f6b409d90dea14df10e1482">
+      <SHORT-NAME>SecOCProps</SHORT-NAME>
+      <ELEMENTS>
+        <!-- /SecOCProps/S -->
+        <SECURE-COMMUNICATION-PROPS-SET UUID="5d34ccae5222458787330a7d4f0a29be">
+          <SHORT-NAME>S</SHORT-NAME>
+          <AUTHENTICATION-PROPSS>
+            <!-- /SecOCProps/S/KnockKnock -->
+            <SECURE-COMMUNICATION-AUTHENTICATION-PROPS UUID="b3cdd53432914128a81d59fee81bee9b">
+              <SHORT-NAME>KnockKnock</SHORT-NAME>
+              <AUTH-INFO-TX-LENGTH>10</AUTH-INFO-TX-LENGTH>
+            </SECURE-COMMUNICATION-AUTHENTICATION-PROPS>
+          </AUTHENTICATION-PROPSS>
+          <FRESHNESS-PROPSS>
+            <!-- /SecOCProps/S/SmellyCheese -->
+            <SECURE-COMMUNICATION-FRESHNESS-PROPS UUID="f964643f4aad43e6aa8a420afd6835ac">
+              <SHORT-NAME>SmellyCheese</SHORT-NAME>
+              <FRESHNESS-VALUE-LENGTH>32</FRESHNESS-VALUE-LENGTH>
+              <FRESHNESS-VALUE-TX-LENGTH>6</FRESHNESS-VALUE-TX-LENGTH>
+            </SECURE-COMMUNICATION-FRESHNESS-PROPS>
+          </FRESHNESS-PROPSS>
+        </SECURE-COMMUNICATION-PROPS-SET>
       </ELEMENTS>
     </AR-PACKAGE>
     <!-- /Unit -->

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -5096,12 +5096,12 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_3.is_extended_frame, False)
         self.assertEqual(message_3.is_fd, False)
         self.assertEqual(message_3.name, 'Message3')
-        self.assertEqual(message_3.length, 8)
+        self.assertEqual(message_3.length, 6)
         self.assertEqual(message_3.unused_bit_pattern, 0xff)
         self.assertEqual(message_3.senders, [])
         self.assertEqual(message_3.send_type, None)
         self.assertEqual(message_3.cycle_time, None)
-        self.assertEqual(len(message_3.signals), 2)
+        self.assertEqual(len(message_3.signals), 4)
         self.assertEqual(message_3.comment, None)
         self.assertEqual(message_3.bus_name, 'Cluster0')
         self.assertTrue(message_3.dbc is None)
@@ -5155,6 +5155,50 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_2.comment, None)
         self.assertEqual(signal_2.is_multiplexer, False)
         self.assertEqual(signal_2.multiplexer_ids, None)
+
+        signal_3 = message_3.signals[2]
+        self.assertEqual(signal_3.name, 'Message3_Freshness')
+        self.assertEqual(signal_3.start, 39)
+        self.assertEqual(signal_3.length, 6)
+        self.assertEqual(signal_3.receivers, [])
+        self.assertEqual(signal_3.byte_order, 'big_endian')
+        self.assertEqual(signal_3.is_signed, False)
+        self.assertEqual(signal_3.is_float, False)
+        self.assertEqual(signal_3.scale, 1)
+        self.assertEqual(signal_3.offset, 0)
+        self.assertEqual(signal_3.minimum, None)
+        self.assertEqual(signal_3.maximum, None)
+        self.assertEqual(signal_3.decimal.scale, None)
+        self.assertEqual(signal_3.decimal.offset, None)
+        self.assertEqual(signal_3.decimal.minimum, None)
+        self.assertEqual(signal_3.decimal.maximum, None)
+        self.assertEqual(signal_3.unit, None)
+        self.assertEqual(signal_3.choices, None)
+        self.assertEqual(signal_3.comment, "Truncated freshness value for 'Message3'")
+        self.assertEqual(signal_3.is_multiplexer, False)
+        self.assertEqual(signal_3.multiplexer_ids, None)
+
+        signal_4 = message_3.signals[3]
+        self.assertEqual(signal_4.name, 'Message3_Authenticator')
+        self.assertEqual(signal_4.start, 33)
+        self.assertEqual(signal_4.length, 10)
+        self.assertEqual(signal_4.receivers, [])
+        self.assertEqual(signal_4.byte_order, 'big_endian')
+        self.assertEqual(signal_4.is_signed, False)
+        self.assertEqual(signal_4.is_float, False)
+        self.assertEqual(signal_4.scale, 1)
+        self.assertEqual(signal_4.offset, 0)
+        self.assertEqual(signal_4.minimum, None)
+        self.assertEqual(signal_4.maximum, None)
+        self.assertEqual(signal_4.decimal.scale, None)
+        self.assertEqual(signal_4.decimal.offset, None)
+        self.assertEqual(signal_4.decimal.minimum, None)
+        self.assertEqual(signal_4.decimal.maximum, None)
+        self.assertEqual(signal_4.unit, None)
+        self.assertEqual(signal_4.choices, None)
+        self.assertEqual(signal_4.comment, "Truncated authenticator value for 'Message3'")
+        self.assertEqual(signal_4.is_multiplexer, False)
+        self.assertEqual(signal_4.multiplexer_ids, None)
 
         # message 4 tests different base encodings
         message_4 = db.messages[4]
@@ -5269,6 +5313,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
                              'ISignalIPdu',
                              'NMPdu',
                              'SecuredIPdu',
+                             'SecOCProps',
                              'Unit',
                              'CompuMethod',
                              'SystemSignal',

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -407,6 +407,72 @@ Message1:
             self.assertEqual(actual_output, expected_output)
 
         args = Args('tests/files/arxml/system-4.2.arxml')
+        args.items = [ "Message3" ]
+
+        stdout = StringIO()
+        with patch('sys.stdout', stdout):
+            # Run the main function of the subparser
+            list_module._do_list(args)
+
+            # check make sure it behaves as expected
+            expected_output = """\
+Message3:
+  Bus: Cluster0
+  Frame ID: 0x64 (100)
+  Size: 6 bytes
+  Is extended frame: False
+  Is CAN-FD frame: False
+  Is network management frame: False
+  End-to-end properties:
+    Category: Profile5
+    Data IDs: [321]
+    Protected size: 4 bytes
+  Is secured: True
+  Security properties:
+    Authentication algorithm: KnockKnock
+    Freshness algorithm: SmellyCheese
+    Data ID: 1337
+    Authentication transmit bits: 10
+    Freshness counter size: 32 bits
+    Freshness counter transmit size: 6 bits
+    Secured size: 4 bytes
+  Signal tree:
+
+    -- {root}
+       +-- message3_CRC
+       +-- message3_SeqCounter
+       +-- Message3_Freshness
+       +-- Message3_Authenticator
+
+  Signal details:
+    message3_CRC:
+      Type: Integer
+      Start bit: 0
+      Length: 8 bits
+      Is signed: False
+    message3_SeqCounter:
+      Type: Integer
+      Start bit: 8
+      Length: 4 bits
+      Is signed: False
+    Message3_Freshness:
+      Comment[FOR-ALL]: Truncated freshness value for 'Message3'
+      Type: Integer
+      Start bit: 39
+      Length: 6 bits
+      Is signed: False
+    Message3_Authenticator:
+      Comment[FOR-ALL]: Truncated authenticator value for 'Message3'
+      Type: Integer
+      Start bit: 33
+      Length: 10 bits
+      Is signed: False
+"""
+
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
+
+        args = Args('tests/files/arxml/system-4.2.arxml')
         args.print_buses = True
 
         stdout = StringIO()


### PR DESCRIPTION
The purpose of secure on-board communication (SecOC) is to ensure that only signals are accepted if they have been send by ECUs that are supposed to do so and that these signals are "fresh", i.e., that they are not a replay of a previous recording of the bus. Note that SecOC does *not* encrypt anything and that it also does nothing to prevent DOS attacks like a rouge ECU preventing somebody else from sending.

Also be aware that the AUTOSAR SecOC specification only specifies the scaffolding around verifying the authenticity and "freshness" of messages and does not specify any cryptographic primitives or how the freshness counter is determined (i.e., these are highly manufacturer specific). For this reason, this PR provides a `SnakeOilAuthenticator`, a set of "fake" primitives of highly dubious cryptographic quality, to demonstrate how SecOC can be implemented.

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)