### PR TITLE
Distribute & expose type annotations per PEP 561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(name='cantools',
       keywords=['can', 'can bus', 'dbc', 'kcd', 'automotive'],
       url='https://github.com/eerimoq/cantools',
       packages=find_packages(exclude=['tests']),
+      package_data={"cantools": ["py.typed"]},
       python_requires='>=3.6',
       install_requires=[
           'bitstruct>=6.0.0',


### PR DESCRIPTION
Type annotations were added in #378 but these are not exposed to clients of cantools:

	error: Skipping analyzing "cantools": module is installed, but
	missing library stubs or py.typed marker

Per [PEP 561], packages that include type annotations in the source code should include an empty file py.typed in the package (or a parent package). The [mypy docs] show an example using setuptools.

Diff from `pip install .; pip show -f cantools`:

	--- a/before.txt
	+++ b/after.txt
	@@ -98,6 +98,7 @@ Files:
	   cantools\logreader.py
	+  cantools\py.typed
	   cantools\subparsers\__init__.py

[PEP 561]: https://peps.python.org/pep-0561/
[mypy docs]: https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

Fixes #421