### PR TITLE
Improve encoding performance

### DIFF
--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -630,12 +630,12 @@ class SystemLoader(object):
                 if comm_dir == 'IN':
                     for pdu_message in pdu_messages:
                         for signal in pdu_message.signals:
-                            if ecu_name not in signal._receivers:
-                                signal._receivers.append(ecu_name)
+                            if ecu_name not in signal.receivers:
+                                signal.receivers.append(ecu_name)
                 elif comm_dir == 'OUT':
                     for pdu_message in pdu_messages:
-                        if ecu_name not in pdu_message._senders:
-                            pdu_message._senders.append(ecu_name)
+                        if ecu_name not in pdu_message.senders:
+                            pdu_message.senders.append(ecu_name)
 
     def _load_senders_receivers_of_nm_pdus(self, package, messages):
         ####
@@ -695,9 +695,9 @@ class SystemLoader(object):
                                                               pdu_path)
 
                     for pdu_message in pdu_messages:
-                        for signal in pdu_message._signals:
-                            if ecu_name not in signal._receivers:
-                                signal._receivers.append(ecu_name)
+                        for signal in pdu_message.signals:
+                            if ecu_name not in signal.receivers:
+                                signal.receivers.append(ecu_name)
 
                 # deal with transmit PDUs
                 for tx_pdu in self._get_arxml_children(nm_node,
@@ -710,8 +710,8 @@ class SystemLoader(object):
                                                               pdu_path)
 
                     for pdu_message in pdu_messages:
-                        if ecu_name not in pdu_message._senders:
-                            pdu_message._senders.append(ecu_name)
+                        if ecu_name not in pdu_message.senders:
+                            pdu_message.senders.append(ecu_name)
 
     def _load_system(self, package_list, messages):
         """Internalize the information specified by the system.
@@ -2198,7 +2198,7 @@ class SystemLoader(object):
 
             if base_type_encoding is None:
                 btt = base_type.find('./ns:SHORT-NAME', self._xml_namespaces)
-                btt = bt.text
+                btt = btt.text
                 raise ValueError(
                     f'BASE-TYPE-ENCODING in base type "{btt}" does not exist.')
 

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -921,7 +921,7 @@ class Message(object):
                                                           scaling)
 
         if padding:
-            padding_pattern = int.from_bytes([self._unused_bit_pattern] * 64, "big")
+            padding_pattern = int.from_bytes([self._unused_bit_pattern] * self._length, "big")
             encoded |= (padding_mask & padding_pattern)
 
         return encoded.to_bytes(self._length, "big")

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -1,6 +1,5 @@
 # A CAN message.
 
-import binascii
 import logging
 from copy import deepcopy
 from typing import (
@@ -606,14 +605,13 @@ class Message(object):
         :param scaling: If ``False`` no scaling of signals is performed.
 
         :param assert_values_valid: If ``True``, the values of all
-        specified signals must be valid/encodable. If at least one is
-        not, an ``EncodeError`` exception is raised. (Note that the
-        values of multiplexer selector signals must always be valid!)
+            specified signals must be valid/encodable. If at least one is
+            not, an ``EncodeError`` exception is raised. (Note that the
+            values of multiplexer selector signals must always be valid!)
 
         :param assert_all_known: If ``True``, all specified signals must
-        be used by the encoding operation or an ``EncodeError``
-        exception is raised. This is useful to prevent typos.
-
+            be used by the encoding operation or an ``EncodeError``
+            exception is raised. This is useful to prevent typos.
         '''
 
         # this method only deals with ordinary messages
@@ -925,19 +923,10 @@ class Message(object):
                                                           scaling)
 
         if padding:
-            # there is probably a cleaner and more performant way to
-            # do this...
-            padding_pattern = 0
-            for i in range(0, self.length):
-                padding_pattern |= self.unused_bit_pattern << (8*i)
+            padding_pattern = int.from_bytes([self._unused_bit_pattern] * 64, "big")
+            encoded |= (padding_mask & padding_pattern)
 
-            encoded &= ~padding_mask
-            encoded |= padding_mask & padding_pattern
-
-        encoded |= (0x80 << (8 * self._length))
-        hex_string = hex(encoded)[4:].rstrip('L')
-
-        return binascii.unhexlify(hex_string)[:self._length]
+        return encoded.to_bytes(self._length, "big")
 
     def _decode(self,
                 node: Codec,

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -112,6 +112,7 @@ class Message(object):
             self._signals = sort_signals(signals)
         else:
             self._signals = signals
+        self._signal_dict: Dict[str, Signal] = {}
         self._contained_messages = contained_messages
 
         # if the 'comment' argument is a string, we assume that is an
@@ -713,9 +714,6 @@ class Message(object):
         for signal_name, signal_value in data.items():
             signal = self.get_signal_by_name(signal_name)
 
-            if not signal:
-                continue
-
             if isinstance(signal_value, (str, NamedSignalValue)):
                 # Check choices
                 signal_value_num = signal.choice_string_to_number(str(signal_value))
@@ -1118,11 +1116,7 @@ class Message(object):
         return tmp[0]
 
     def get_signal_by_name(self, name: str) -> Signal:
-        for signal in self._signals:
-            if signal.name == name:
-                return signal
-
-        raise KeyError(name)
+        return self._signal_dict[name]
 
     def is_multiplexed(self) -> bool:
         """Returns ``True`` if the message is multiplexed, otherwise
@@ -1227,6 +1221,7 @@ class Message(object):
         self._check_signal_lengths()
         self._codecs = self._create_codec()
         self._signal_tree = self._create_signal_tree(self._codecs)
+        self._signal_dict = {signal.name: signal for signal in self._signals}
 
         if strict is None:
             strict = self._strict

--- a/cantools/database/can/signal.py
+++ b/cantools/database/can/signal.py
@@ -210,15 +210,24 @@ class Signal(object):
                  decimal: Optional[Decimal] = None,
                  spn: Optional[int] = None
                  ) -> None:
-        self._name = name
+        #: The signal name as a string.
+        self.name: str = name
+
+        #: The scale factor of the signal value.
+        self.scale: float = scale
+
+        #: The offset of the signal value.
+        self.offset: float = offset
+
+        #: ``True`` if the signal is a float, ``False`` otherwise.
+        self.is_float: bool = is_float
+
         self._start = start
         self._length = length
         self._byte_order = byte_order
         self._is_signed = is_signed
         self._initial = initial
         self._invalid = invalid
-        self._scale = scale
-        self._offset = offset
         self._minimum = minimum
         self._maximum = maximum
         self._decimal = Decimal() if decimal is None else decimal
@@ -243,20 +252,7 @@ class Signal(object):
         self._is_multiplexer = is_multiplexer
         self._multiplexer_ids = multiplexer_ids
         self._multiplexer_signal = multiplexer_signal
-        self._is_float = is_float
         self._spn = spn
-
-    @property
-    def name(self) -> str:
-        """The signal name as a string.
-
-        """
-
-        return self._name
-
-    @name.setter
-    def name(self, value: str) -> None:
-        self._name = value
 
     @property
     def start(self) -> int:
@@ -309,18 +305,6 @@ class Signal(object):
         self._is_signed = value
 
     @property
-    def is_float(self) -> bool:
-        """``True`` if the signal is a float, ``False`` otherwise.
-
-        """
-
-        return self._is_float
-
-    @is_float.setter
-    def is_float(self, value: bool) -> None:
-        self._is_float = value
-
-    @property
     def initial(self) -> Optional[int]:
         """The initial value of the signal, or ``None`` if unavailable.
 
@@ -343,30 +327,6 @@ class Signal(object):
     @invalid.setter
     def invalid(self, value: int) -> None:
         self._invalid = value
-
-    @property
-    def scale(self) -> float:
-        """The scale factor of the signal value.
-
-        """
-
-        return self._scale
-
-    @scale.setter
-    def scale(self, value: float) -> None:
-        self._scale = value
-
-    @property
-    def offset(self) -> float:
-        """The offset of the signal value.
-
-        """
-
-        return self._offset
-
-    @offset.setter
-    def offset(self, value: float) -> None:
-        self._offset = value
 
     @property
     def minimum(self) -> Optional[float]:
@@ -555,14 +515,14 @@ class Signal(object):
                  for value, text in self._choices.items()]))
 
         return "signal('{}', {}, {}, '{}', {}, {}, {}, {}, {}, {}, '{}', {}, {}, {}, {}, {})".format(
-            self._name,
+            self.name,
             self._start,
             self._length,
             self._byte_order,
             self._is_signed,
             self._initial,
-            self._scale,
-            self._offset,
+            self.scale,
+            self.offset,
             self._minimum,
             self._maximum,
             self._unit,

--- a/cantools/database/can/signal.py
+++ b/cantools/database/can/signal.py
@@ -222,14 +222,18 @@ class Signal(object):
         #: ``True`` if the signal is a float, ``False`` otherwise.
         self.is_float: bool = is_float
 
+        #: The minimum value of the signal, or ``None`` if unavailable.
+        self.minimum: Optional[float] = minimum
+
+        #: The maximum value of the signal, or ``None`` if unavailable.
+        self.maximum: Optional[float] = maximum
+
         self._start = start
         self._length = length
         self._byte_order = byte_order
         self._is_signed = is_signed
         self._initial = initial
         self._invalid = invalid
-        self._minimum = minimum
-        self._maximum = maximum
         self._decimal = Decimal() if decimal is None else decimal
         self._unit = unit
         self._choices = choices
@@ -327,30 +331,6 @@ class Signal(object):
     @invalid.setter
     def invalid(self, value: int) -> None:
         self._invalid = value
-
-    @property
-    def minimum(self) -> Optional[float]:
-        """The minimum value of the signal, or ``None`` if unavailable.
-
-        """
-
-        return self._minimum
-
-    @minimum.setter
-    def minimum(self, value: Optional[float]) -> None:
-        self._minimum = value
-
-    @property
-    def maximum(self) -> Optional[float]:
-        """The maximum value of the signal, or ``None`` if unavailable.
-
-        """
-
-        return self._maximum
-
-    @maximum.setter
-    def maximum(self, value: Optional[float]) -> None:
-        self._maximum = value
 
     @property
     def decimal(self) -> Decimal:
@@ -523,8 +503,8 @@ class Signal(object):
             self._initial,
             self.scale,
             self.offset,
-            self._minimum,
-            self._maximum,
+            self.minimum,
+            self.maximum,
             self._unit,
             self._is_multiplexer,
             self._multiplexer_ids,

--- a/cantools/database/diagnostics/data.py
+++ b/cantools/database/diagnostics/data.py
@@ -17,12 +17,18 @@ class Data(object):
                  maximum=None,
                  unit=None,
                  choices=None):
-        self._name = name
+        #: The data name as a string.
+        self.name: str = name
+
+        #: The scale factor of the data value.
+        self.scale: float = scale
+
+        #: The offset of the data value.
+        self.offset: float = offset
+
         self._start = start
         self._length = length
         self._byte_order = byte_order
-        self._scale = scale
-        self._offset = offset
         self._minimum = minimum
         self._maximum = maximum
         self._unit = unit
@@ -30,18 +36,6 @@ class Data(object):
         # ToDo: Remove once types are handled properly.
         self.is_float = False
         self.is_signed = False
-
-    @property
-    def name(self):
-        """The data name as a string.
-
-        """
-
-        return self._name
-
-    @name.setter
-    def name(self, value):
-        self._name = value
 
     @property
     def start(self):
@@ -78,30 +72,6 @@ class Data(object):
     @byte_order.setter
     def byte_order(self, value):
         self._byte_order = value
-
-    @property
-    def scale(self):
-        """The scale factor of the data value.
-
-        """
-
-        return self._scale
-
-    @scale.setter
-    def scale(self, value):
-        self._scale = value
-
-    @property
-    def offset(self):
-        """The offset of the data value.
-
-        """
-
-        return self._offset
-
-    @offset.setter
-    def offset(self, value):
-        self._offset = value
 
     @property
     def minimum(self):
@@ -163,12 +133,12 @@ class Data(object):
                  for value, text in self._choices.items()]))
 
         return "data('{}', {}, {}, '{}', {}, {}, {}, {}, '{}', {})".format(
-            self._name,
+            self.name,
             self._start,
             self._length,
             self._byte_order,
-            self._scale,
-            self._offset,
+            self.scale,
+            self.offset,
             self._minimum,
             self._maximum,
             self._unit,

--- a/cantools/database/diagnostics/data.py
+++ b/cantools/database/diagnostics/data.py
@@ -1,4 +1,8 @@
 # DID data.
+from typing import Optional
+
+from cantools.typechecking import ByteOrder, Choices
+
 
 class Data(object):
     """A data data with position, size, unit and other information. A data
@@ -7,16 +11,17 @@ class Data(object):
     """
 
     def __init__(self,
-                 name,
-                 start,
-                 length,
-                 byte_order='little_endian',
-                 scale=1,
-                 offset=0,
-                 minimum=None,
-                 maximum=None,
-                 unit=None,
-                 choices=None):
+                 name: str,
+                 start: int,
+                 length: int,
+                 byte_order: ByteOrder = 'little_endian',
+                 scale: float = 1,
+                 offset: float = 0,
+                 minimum: Optional[float] = None,
+                 maximum: Optional[float] = None,
+                 unit: Optional[str] = None,
+                 choices: Optional[Choices] = None,
+                 ) -> None:
         #: The data name as a string.
         self.name: str = name
 
@@ -26,120 +31,58 @@ class Data(object):
         #: The offset of the data value.
         self.offset: float = offset
 
-        self._start = start
-        self._length = length
-        self._byte_order = byte_order
-        self._minimum = minimum
-        self._maximum = maximum
-        self._unit = unit
-        self._choices = choices
+        #: The start bit position of the data within its DID.
+        self.start: int = start
+
+        #: The length of the data in bits.
+        self.length = length
+
+        #: Data byte order as ``'little_endian'`` or ``'big_endian'``.
+        self.byte_order: ByteOrder = byte_order
+
+        #: The minimum value of the data, or ``None`` if unavailable.
+        self.minimum: Optional[float] = minimum
+
+        #: The maximum value of the data, or ``None`` if unavailable.
+        self.maximum: Optional[float] = maximum
+
+        #: The unit of the data as a string, or ``None`` if unavailable.
+        self.unit = unit
+
+        #: A dictionary mapping data values to enumerated choices, or ``None``
+        #: if unavailable.
+        self.choices: Optional[Choices] = choices
+
         # ToDo: Remove once types are handled properly.
-        self.is_float = False
-        self.is_signed = False
+        self.is_float: bool = False
+        self.is_signed: bool = False
 
-    @property
-    def start(self):
-        """The start bit position of the data within its DID.
+    def choice_string_to_number(self, string: str) -> int:
+        if self.choices is None:
+            raise ValueError(f"Data {self.name} has no choices.")
 
-        """
-
-        return self._start
-
-    @start.setter
-    def start(self, value):
-        self._start = value
-
-    @property
-    def length(self):
-        """The length of the data in bits.
-
-        """
-
-        return self._length
-
-    @length.setter
-    def length(self, value):
-        self._length = value
-
-    @property
-    def byte_order(self):
-        """Data byte order as ``'little_endian'`` or ``'big_endian'``.
-
-        """
-
-        return self._byte_order
-
-    @byte_order.setter
-    def byte_order(self, value):
-        self._byte_order = value
-
-    @property
-    def minimum(self):
-        """The minimum value of the data, or ``None`` if unavailable.
-
-        """
-
-        return self._minimum
-
-    @minimum.setter
-    def minimum(self, value):
-        self._minimum = value
-
-    @property
-    def maximum(self):
-        """The maximum value of the data, or ``None`` if unavailable.
-
-        """
-
-        return self._maximum
-
-    @maximum.setter
-    def maximum(self, value):
-        self._maximum = value
-
-    @property
-    def unit(self):
-        """The unit of the data as a string, or ``None`` if unavailable.
-
-        """
-
-        return self._unit
-
-    @unit.setter
-    def unit(self, value):
-        self._unit = value
-
-    @property
-    def choices(self):
-        """A dictionary mapping data values to enumerated choices, or ``None``
-        if unavailable.
-
-        """
-
-        return self._choices
-
-    def choice_string_to_number(self, string):
         for choice_number, choice_string in self.choices.items():
             if choice_string == string:
                 return choice_number
 
-    def __repr__(self):
+        raise KeyError(f"Choice {string} not found in Data {self.name}.")
 
-        if self._choices is None:
+    def __repr__(self) -> str:
+        if self.choices is None:
             choices = None
         else:
             choices = '{{{}}}'.format(', '.join(
                 ["{}: '{}'".format(value, text)
-                 for value, text in self._choices.items()]))
+                 for value, text in self.choices.items()]))
 
         return "data('{}', {}, {}, '{}', {}, {}, {}, {}, '{}', {})".format(
             self.name,
-            self._start,
-            self._length,
-            self._byte_order,
+            self.start,
+            self.length,
+            self.byte_order,
             self.scale,
             self.offset,
-            self._minimum,
-            self._maximum,
-            self._unit,
+            self.minimum,
+            self.maximum,
+            self.unit,
             choices)

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -4,11 +4,16 @@ import contextlib
 import os.path
 import re
 from decimal import Decimal
-from typing import Union, List, Callable, Tuple, Optional, Dict, Sequence
+from typing import Union, List, Callable, Tuple, Optional, Dict, Sequence, TYPE_CHECKING
 
 from typing_extensions import Literal, Final, TypeGuard
 
-from cantools.typechecking import Formats, SignalDictType, SignalValueType, TYPE_CHECKING
+from cantools.typechecking import (
+    Formats,
+    SignalDictType,
+    SignalValueType,
+    ByteOrder,
+)
 
 if TYPE_CHECKING:
     from cantools.database import Database
@@ -248,7 +253,7 @@ def sawtooth_to_network_bitnum(sawtooth_bitnum: int) -> int:
     return (8 * (sawtooth_bitnum // 8)) + (7 - (sawtooth_bitnum % 8))
 
 
-def cdd_offset_to_dbc_start_bit(cdd_offset: int, bit_length: int, byte_order: str) -> int:
+def cdd_offset_to_dbc_start_bit(cdd_offset: int, bit_length: int, byte_order: ByteOrder) -> int:
     '''Convert CDD/c-style field bit offset to DBC field start bit convention.
 
     BigEndian (BE) fields are located by their MSBit's sawtooth index.

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -41,7 +41,7 @@ def format_and(items: List[Union[int, str]]) -> str:
                                   string_items[-1])
 
 
-def start_bit(data: "Signal") -> int:
+def start_bit(data: Union["Data", "Signal"]) -> int:
     if data.byte_order == 'big_endian':
         return 8 * (data.start // 8) + (7 - (data.start % 8))
     else:
@@ -130,10 +130,10 @@ def decode_data(data: bytes,
     }
 
 
-def create_encode_decode_formats(datas: List["Signal"], number_of_bytes: int) -> Formats:
+def create_encode_decode_formats(datas: Sequence[Union["Data", "Signal"]], number_of_bytes: int) -> Formats:
     format_length = (8 * number_of_bytes)
 
-    def get_format_string_type(data: "Signal") -> str:
+    def get_format_string_type(data: Union["Data", "Signal"]) -> str:
         if data.is_float:
             return 'f'
         elif data.is_signed:
@@ -147,7 +147,7 @@ def create_encode_decode_formats(datas: List["Signal"], number_of_bytes: int) ->
 
         return fmt, padding_mask, None
 
-    def data_item(data: "Signal") -> Tuple[str, str, str]:
+    def data_item(data: Union["Data", "Signal"]) -> Tuple[str, str, str]:
         fmt = '{}{}'.format(get_format_string_type(data),
                             data.length)
         padding_mask = '0' * data.length

--- a/cantools/typechecking.py
+++ b/cantools/typechecking.py
@@ -10,7 +10,7 @@ from typing import (
     Tuple,
 )
 
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, Literal, OrderedDict
 from bitstruct import CompiledFormatDict
 
 
@@ -38,6 +38,8 @@ Codec = TypedDict(
     },
 )
 
+ByteOrder = Literal["little_endian", "big_endian"]
+Choices = OrderedDict[int, Union[str, "NamedSignalValue"]]
 
 # Type aliases. Introduced to reduce type annotation complexity while
 # allowing for more complex encode/decode schemes like the one used

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,10 @@ Functions and classes
     :members:
 
 .. autoclass:: cantools.database.can.signal.Decimal
-    :members:                      
+    :members:
+
+.. autoclass:: cantools.database.can.signal.NamedSignalValue
+    :members:
 
 .. autoclass:: cantools.database.diagnostics.Database
     :members:


### PR DESCRIPTION
Most of the perfomance benefits come from converting properties into normal attributes. Each property call results in a new stack frame which is quite expensive.

Benchmarks with some random message on my laptop:

`message.encode(data, strict=True, scaling=True)`: 49.19% improvement
`message.encode(data, strict=False, scaling=True)`: 22.98% improvement
`message.encode(data, strict=False, scaling=False)`: 60.74% improvement

This is the code i used for benchmarking:
```python3
import timeit

setup = """
import cantools
db = cantools.db.load_file("path_to_OEM_dbc")

message = db.get_message_by_name("OEM_message_name")
data = {signal.name: min(0x40, signal.maximum-1) for signal in message.signals}
"""

print(min(timeit.Timer('message.encode(data, strict=False, scaling=False)', setup=setup).repeat(100, 1000)))
```


Here is a cProfile dump for 10000 encode calls of the master branch (strict=False, scaling=True):
```
         2570002 function calls in 0.762 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.013    0.000    0.758    0.000 message.py:863(encode)
    10000    0.009    0.000    0.740    0.000 message.py:759(_encode)
    10000    0.015    0.000    0.731    0.000 utils.py:88(encode_data)
    10000    0.077    0.000    0.706    0.000 utils.py:92(<dictcomp>)
   270000    0.493    0.000    0.614    0.000 utils.py:51(_encode_field)
   540000    0.032    0.000    0.032    0.000 {built-in method builtins.isinstance}
   540000    0.031    0.000    0.031    0.000 signal.py:249(name)
   270000    0.023    0.000    0.023    0.000 {method 'to_integral' of 'decimal.Decimal' objects}
   270000    0.018    0.000    0.018    0.000 signal.py:359(offset)
   270000    0.016    0.000    0.016    0.000 signal.py:347(scale)
   270000    0.016    0.000    0.016    0.000 signal.py:311(is_float)
    20000    0.006    0.000    0.006    0.000 {method 'pack' of 'bitstruct.c.CompiledFormatDict' objects}
    20000    0.003    0.000    0.003    0.000 {built-in method binascii.hexlify}
    10000    0.002    0.000    0.002    0.000 {built-in method builtins.hex}
    10000    0.001    0.000    0.001    0.000 {built-in method binascii.unhexlify}
    10000    0.001    0.000    0.001    0.000 {method 'rstrip' of 'str' objects}
    10000    0.001    0.000    0.001    0.000 message.py:323(is_container)
    10000    0.001    0.000    0.001    0.000 {built-in method builtins.len}
    10000    0.001    0.000    0.001    0.000 typing.py:898(cast)
```

And here is the same with my changes:
```
         660002 function calls in 0.412 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.007    0.000    0.409    0.000 message.py:859(encode)
    10000    0.007    0.000    0.399    0.000 message.py:755(_encode)
    10000    0.009    0.000    0.392    0.000 utils.py:99(encode_data)
    10000    0.338    0.000    0.375    0.000 utils.py:51(_encode_fields)
   270000    0.020    0.000    0.020    0.000 {method 'to_integral_value' of 'decimal.Decimal' objects}
   270000    0.017    0.000    0.017    0.000 {built-in method builtins.isinstance}
    20000    0.005    0.000    0.005    0.000 {method 'pack' of 'bitstruct.c.CompiledFormatDict' objects}
    20000    0.002    0.000    0.002    0.000 {built-in method from_bytes}
    10000    0.001    0.000    0.001    0.000 {method 'to_bytes' of 'int' objects}
    10000    0.001    0.000    0.001    0.000 message.py:323(is_container)
    10000    0.001    0.000    0.001    0.000 {built-in method builtins.len}
    10000    0.000    0.000    0.000    0.000 typing.py:898(cast)
```