### PR TITLE
Fix parsing of referenced data in CDDs

### DIFF
--- a/cantools/database/diagnostics/formats/cdd.py
+++ b/cantools/database/diagnostics/formats/cdd.py
@@ -1,5 +1,6 @@
 # Load and dump a diagnostics database in CDD format.
 import logging
+from typing import Dict
 
 from xml.etree import ElementTree
 
@@ -197,15 +198,16 @@ def _load_did_element(did, data_types, did_data_lib):
                datas=datas)
 
 
-def _load_did_data_refs(ecu_doc: ElementTree.Element):
+def _load_did_data_refs(ecu_doc: ElementTree.Element) -> Dict[str, ElementTree.Element]:
     """Load DID data references from given ECU doc element.
 
     """
+    dids = ecu_doc.find('DIDS')
 
-    try:
-        return {k.attrib['id']: k for k in ecu_doc.find('DIDS').findall('DID')}
-    except AttributeError:
+    if dids is None:
         return {}
+    else:
+        return {did.attrib['id']: did for did in dids.findall('DID')}
 
 
 def load_string(string):

--- a/tests/files/cdd/example-diddatarefs.cdd
+++ b/tests/files/cdd/example-diddatarefs.cdd
@@ -1,0 +1,21277 @@
+<?xml version='1.0' encoding='utf-8' standalone='no'?>
+<!DOCTYPE CANDELA SYSTEM 'candela.dtd'>
+<CANDELA dtdvers='10.0.108'>
+<ECUDOC oid='DCA1EB2CBF084f719F261BE35BBAEC31' temploid='{1DCA0988-4B31-4443-A70D-5056F6DD703B}' doctype='inst' manufacturer='Vector' mid='S9JkrbhBj9mehrSgeNmt1g==' saveno='22' languages='(en-US)' uptodateLanguages='(en-US)' jobfileext='' ftbPoolPath='qpath://[DATATYPE]SAE_J2012_Failure_Type_Byte' xdtauth='30' dtNesting='all'>
+<EXTSTORAGEITEMS>
+<EXTSTORAGEITEM id='_000001B1ADA4AD60'>
+<CAPTION>
+<TUV xml:lang='en-US'></TUV>
+</CAPTION>
+<EXTDOC creationdt='2004-12-03 12:40:09+01:00' changedt='2004-12-03 12:40:09+01:00'>
+<FILENAME>D:\ExampleDocTemplate\Ecu.jpg</FILENAME>
+<FILECONTENTS len='13216'>
+/9j/4AAQSkZJRgABAgEASABIAAD/7QE0UGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA
+AgBIAAAAAQACOEJJTQPzAAAAAAAIAAAAAAAAAAA4QklNJxAAAAAAAAoAAQAAAAAAAAACOEJJTQP1
+AAAAAABIAC9mZgABAGxmZgAGAAAAAAABAC9mZgABAKGZmgAGAAAAAAABADIAAAABAFoAAAAGAAAA
+AAABADUAAAABAC0AAAAGAAAAAAABOEJJTQP4AAAAAABwAAD/////////////////////////////
+A+gAAAAA/////////////////////////////wPoAAAAAP////////////////////////////8D
+6AAAAAD/////////////////////////////A+gAADhCSU0EBgAAAAAAAgAE/+4ADkFkb2JlAGQA
+AAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoKDBAMDAwMDAwQDAwMDAwMDAwMDAwM
+DAwMDAwMDAwMDAwMDAwMDAEHBwcNDA0YEBAYFA4ODhQUDg4ODhQRDAwMDAwREQwMDAwMDBEMDAwM
+DAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM/8AAEQgA4AEsAwERAAIRAQMRAf/EAaIAAAAHAQEBAQEA
+AAAAAAAAAAQFAwIGAQAHCAkKCwEAAgIDAQEBAQEAAAAAAAAAAQACAwQFBgcICQoLEAACAQMDAgQC
+BgcDBAIGAnMBAgMRBAAFIRIxQVEGE2EicYEUMpGhBxWxQiPBUtHhMxZi8CRygvElQzRTkqKyY3PC
+NUQnk6OzNhdUZHTD0uIIJoMJChgZhJRFRqS0VtNVKBry4/PE1OT0ZXWFlaW1xdXl9WZ2hpamtsbW
+5vY3R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo+Ck5SVlpeYmZqbnJ2en5KjpKWmp6ipqqusra6voR
+AAICAQIDBQUEBQYECAMDbQEAAhEDBCESMUEFURNhIgZxgZEyobHwFMHR4SNCFVJicvEzJDRDghaS
+UyWiY7LCB3PSNeJEgxdUkwgJChgZJjZFGidkdFU38qOzwygp0+PzhJSktMTU5PRldYWVpbXF1eX1
+RlZmdoaWprbG1ub2R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo+DlJWWl5iZmpucnZ6fkqOkpaanqK
+mqq6ytrq+v/dAAQAJv/aAAwDAQACEQMRAD8A9UYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7
+FWqYpdTFXVxtadXG1bxY07FaUJr20g+KeZIv9dlX+OGkcSU3nnfyra/3upQn/JQ+p/xGuPCvEl8P
+5n+T5J/S+tMh/neN1XDSBJk8UsU0ayRMrRv8SuvxK2QIZgq2FXYq7FXYq7FXYq7FXYq7FXYq7FXY
+q//Q9UYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FUFPrWk2wrPewRf60qj9eFjaU3Pn/wAq
+Qfav0l/yYlZjjS2lF1+a+kRD/R7We4/1uMf68nwNfiJRd/m7qfH/AEbT4ov+MrM3/EeOPAviJPcf
+mf5rkZ/3sUCfselF/wA1c8aYeIkt35n8x3n9/qVw6/yIzqv/AAuGl8RKXi9V+TSu/P8A363LJ8LX
+xtor8+f2V/kw8K8axHdpX5J8f2MgQyEnoP5Y+azZ3C6Detxgl/3ilb7Kyf77/wBnlZDYJPWsi3h2
+KuxV2KuxV2KuxV2KuxV2KuxV2Kv/0fVGKuxV2KuxVrFFt4rZapjbK3UxtbdgpjYU5JUjXkzKqf5W
+NLYS6780+X7U0nv4E/yQ4Y/8LkuFh4gSu4/MrytF9iWWf/jFE/8Axtxx4V8VKrv82bFf95tPllf9
+nkyL/wAR55Lga/ESqX81NYkFIreK3H+ykbHgXxEtuPPfmmdB/pvpcv8AfSIuWcDHxEnm1XU7l+d1
+eyy/6zPjwrxofj8f2/tfzYsViW7umKr/AKvxf/IyVseJY8SK78PjT+TG14ls1oF+JuESfzs3H/iW
+RtbQX1vS+fxagksv8kXOX/kzyxtWnuLZU+GG4l4/b/dely/5HNFjaeFEWjW8/wAM9pLbo3wJLzWV
+f9kvwY2vAtdfSbh9tPto6/tLigBY7Pz5I/xp9j9nFsBe0+Q/Nya5YNBO3+5K1+GVf51/ZkyohyBJ
+lmVkM28kh2KuxV2KuxV2KuxV2KuxV2Kv/9L1RirsVdiqhPfWdt/f3EcX+u6r+vFFpNceefKsDcW1
+GJn/AJY+Un/ERiw8UJdcfmf5fTl6UU8rJ24cf+JYo8UJZL+aMsp42en7/wDFsv8AzTlnA1eKllx+
+YfmaX7LwQcvsJFGWb/kpyw8C+Kltx5n8zXJ4tfzov+R8H/EcPCwspZcfWZ/inleX/Wfl/wASx4UW
+VD6v8fKL/Z5LhQ6G0d/ibDSFX6p9hlyPEtO+qfB8Cc3/AJMeJaWTW8sSO06pbxJ9iWVkX/iWHiZc
+KX3F7pa84nu4pX/5d+c//JlXx4lpZb30PP4bS6lT+dlSJf8AkpJzwMkQja5O/Gw0r/g5Xl/4WGP/
+AJmYqm1v5J8/3zo3pfVf9SBIv+ohpcjxMuBMrf8AKPzNOP8ATNQ9L+blO/8AxGFYkx4l4E20/wDJ
+LQ4hzvLhZZf23SJf+JTerkbbPDT+1/LLyrB9qKW449pZG4/8CnDG18NN7Tyr5ctDWDTYEbx4Bv8A
+iWC2zgR0llZyxNBLBG0DfaiZV4/divC8l85eVU0jUOEXw6bePysv+K5ftND/ALP7ceWAtEgxB4uH
+xcOeFqJRWj6rcaRqVvfWb/vYG+x/vxf2o2wENkJPeNF1e01jTYdQtG5QzL/slb9pT8srcuKY5FDs
+VdirsVdirsVdirsVdirsVf/T9UYq7FWF/mt5sufK/ku91Cxob9+MVr7M5+J/9gnx4Qsjs8zdIdR0
+601FJXuvrUSO7yty+L9pcmHAmg0eZXRfS/1MlTFEIi8/8v8AbwqqcEVOK4sl6Qs3wryZ/wDIxVyI
+8CStK/BE+KV3+Hjiq63mt54UltZUuoufDnEySry/2OKod9Q+OWK1tLif0n4u68IouS/aXk3/ADLj
+yRLZIWiok8yT/DY6VF8f7crSz/8AJmOL/k5lZKIwTO38nefrz41f6v8A6sEUH/UR674LZ8KNi/KX
+XbmjX2pvzP2uU8rf8LH6SY2nhRtp+Sujq/q3V1yf/iqJFb/gn5vjxsvDZBaflp5Uth8Vu83/ABll
+b/jXjg418NNoNA0G3CiHT7dOH2aRLgSAjhsoRFCqOigUGPCzteFkPtjslcEPc4LWl3HAl3HFWiMV
+axVL9b0e01jTZbG6X91J9l/2lb9llyQLHILeJ63p97aXFxBcp/pVqyxXH+V/vuZf8h8sBcThSt4e
+XDj+x9t/+NckUMn8g+aG0DU/Qum46XeMqS8vsxy/78/6qZUQ5GOT2sUyDdduxQ3il2KuxV2KuxV2
+KuxV2Kv/1PVGKuxV4h+a+svqfmP6jE3K105fSf8AlaRvik/6p4Q1yLCPIV89rqF15Znl4W91+90x
+3/Zl/lyYaJBOpXuFldWif918Lu2TaUW9sssPwt/kfHiqmkWpwXEssV2npcF4WjwIyt/sv77/AJF4
+sll9FbajbxNKjekrszxc3+Fl+Flbj9vhiq63V5UezlfnwTlFz+LlEv7Pxfyf5/3WKumm9J/rSp/d
+fBdov7UX7X/Af3keKs9/Lkaat1cQTqktw3721lfi3wftccgS34xb0XIEuRwN42jhdja8LqHBTK3c
+CcUEtiNRhtFLqDAl2KuxV2KuxV2KrSMVargBQN2J+efLcmoWg1CzTnf2av8AD/v6Bv7yH/qnkwWu
+cXlE0SRBPS+O3lXlE/2fhy0ONJSd+X7HJssEURk9L/LPzV9Zt10W8b/S4E/0V2/3ZGvb/YZit+GV
+s/wOQW8VdirsVdirsVdirsVdir//1fVGKClHmbW4dF0K81KX/dCfB/lSN8Kj/gjhYF89I80ryyyv
+6ssrc3f/ACm+LAhItesXT0rq1/3ot39WL/WxVn1pqFprGjW+t2v+7UVNQhT9mf8A5vy8FxiFF7dG
+bkr5YGshVm9Zk4/tLgSpW7os3L/j3uvgl/yZ/sxt/s/7v/kViqx7OZZf3XwSxPzt3/lxTStKFleK
+8iT90397E/7P8y/66YrSN0y4l064WKBuMsH72yb/ACPtMv8AsP8Ak1kCzg9f0bU4dT0+K8i/b+0n
+8rftLlRcuMkfkWTsVXgYq7FXYq7FXYq7FXYq7FXYq0emKrcVdirzHzz5cTTr763Gn+428f4v+Kbl
+v+NJv+TuWRLiyxsKlRld1/3bFloLQdlkLXEFxFeWr8biL4on/wApcZM4PbvK/mG313SkuY+KTp8N
+1EP91yeGY5DmRkneBk7FXYq7FXYq7FXYq7FX/9b1RigvIfzp1t53i0a2ba24z3a+7KeC4sC8+t+a
+wxP/ADJih13aevFyX9r9jFVPyxdy+VtefTNR5rpWspw/yeX82TBaSGW3ds1rcPEy/Y/kywFrIa/v
+U/lfJsUPbwxM8trKnwN9tG/yvtYqqPzileKV+dxB8Ly/syK32W/2af8AJXFspV/upuX/AB73XFX/
+AMmX7Mbf7P8Au/8AkVitLJoZuARX4yxfHE//ABH/AKpyZAqGS+TfMH1HUEWVuNhffDLH/vmVPh/6
+9yZWWYk9RyDlBsdcVXYq7FXYq7FXYq7FXYq7FXYq0Tiq3FXYqhtR0+01Gxms7pPUt514SphBYy3e
+Na3pV3pV3LZzvyuLX4vVb/d1s3wxyf8AMuXLAXHljtLX58/h+B/5MsYBMvLPmC40DU/rSfFayvxv
+Yv5l/mX/AC0xMbZiT2u3uIbm3S4hYSQyryjdf2lbMZyQrYpdirsVdirsVdirsVf/1/VGKC+ePPtj
+fReadVll+L1bhm/2P+6/+ExaykssvwYq53fh+2uKqWsvNfaTFZy/3tu/7qX9pfg+HJAoplHlvVv0
+toMLXPBdQsv9Hl5fab/KywFoyBW9FFf+X+TCxdLDKr+qrf66PiqJuIuVul1F8bxJ+9RP2ov2v+A/
+vI8WTdtFbypLZy/Hbyp8D4qhedx6vGV/VuIuKy/5X8sn/Pb/AJO5FVVeCy8/+Ped1V/8mX9lv9n/
+AHf/ACKxSHp/k7W/0hZfVp/96rP4X/yl/ZbIEN4kyEHINgXchhS2CD0xV2KuxV2KuxV2KtFhhpFr
+anGltTWeFn4K6s3Hlx5fs/zY0q/fBbKnYbWnYgMREMW8/aZaz6O18zKl5Y/HaM37XL4Wjb+ZHycW
+E4h5ZcIiy8lT4H/4XLnEQ8qPw4q/Hn9h8VZr+WnmcWc40S5f/RZ2pYP/ACyf77/2WVyi3YpPUqZQ
+XKtvCh2KuxV2KuxV2Kv/0PVGKC8//NHy8k9l+mIoubwL6d0i/tRfzf7DCwLxh4ZoL6W1b9nAhW5v
+9X5L9v8AkxVa/wBhP23fACzAXaZfJomuW+oy/wC8Vx+41Bf9b4eWTBaMgZtdwpBccV+NOHKKX+ZW
++y2WtKkipz5cPjbFVS3uHgfj+xL/AML/AC4slnpeh+6X7H2rT/JX9pf+eP8AyaxVTvv3sP1xP72L
+lzRPtNF/uxf9h/eR5FXJ6TI8TfFFL/J+0rf5+piqP0fVbjT7qK7V/VltWWK4X/f0b/t/7NP+SuEh
+MJPW7e4hureKeBuUUq80b/JbKyHLgqsKjAClYOanbJMV3qP4YKC208xRSz0VR1J2xoJU21C0VPUe
+4jVOJfkXFOI79caRxKB1eOXTJL6zRrkIjMkS/C7Ff2aNjS8SWHXtYuDE9lp/K3enN3ZuS/zLx4/5
+Uf8AyV/31hpjbbjzLPPzR1gjjZWT1eK+opXkVbjz+x/1Ux2RaFls0g9YajrMTeq78VfZljZuUkf9
+5itoeHV/Ken3HrxTy3M6H4XVfspw48f2fg/5m4aW1K7/ADMtY/7qzdv5WZv+aceBHiJRd/mZrDuy
+xxRQL/Px5f8AEseBfESq48069Ovqz6hLx/bii+H/AIVeGEBrEil7tLL8UrvK/wDlc2b/AIbLAGuc
+ih/SRf5EwoUvq/wccVUU5ovH7D/zr9rCQx4nr3kLzQ+s6aYLtv8AcnafDcf8WL+zKv8Ar5jSDmYp
+WyvItrsVdirsVdirsVf/0fVGKqVzbw3FvJBKvKKVSrr/AJLbYq+dfNmjy6Rr13bS/Eyv8Dt+1E39
+22LUlSOnPFUTwRHRf+AxZq13aQ3VpLFKnwypxfFCaeS76W+0x9FvH/3K6Nye3dvtTWf83xfyZaC0
+SCYS8P2/t5YC48gvZ/3Xq/abh8f+rkWQRHBLqL0l+G4i+O3d/wCb/m/+7kxZhCW8yrL9jikv7H7S
+t/13+7xVZLaehziX4UT47dF/4aP/AGH/ACa/4xYqvL8+E6/Fw+GWL+aL9pV/1P7yPEhHJm/kfVfQ
+lbTJH5W8vxWj/s8v5f8AZ/3mVkORjkzfI0207GlpTkmiiHKR1Rf8puOFjxJfqGraE0LwXNwjxSr8
+SL8X/EcaXiY/ca75djYyOk99L2eTf/Y/6mT4GrxEKPPMVunGxsIoF/l/1v8AVx4EeIgbvztrcn2Z
+fS/yFXjkuBHipNd65qN18E8rt/rM+HhW7QM3Pjy/mwMWnWb7P/G+KodE+Pj6v/A4oQuo6npMEPpN
+exLK/wAHxyorYqgf09aLw9BLq/8Ag+3FA/H/AIKTgn/JTFV6anrk/wDcaasSf8vU/wDxrCsv/JzF
+XOuv/aa7ii/nS3g5f8nGfFUdYzXfP0p3+2vBJU+FW/1l/YfFVWVH/wA/hywlrIa0rVdQ0vUoL+y/
+vIP91fsyL+1G2VkNuMvc9G1a11XTYL+2blFOoYDurftKf9XKSHLiUd2yuklvJhQ7FXYq7FX/0vVG
+KuxVgv5n+VV1XTVvoh/pNnu3+VH/AM2YtbxtIft8vtxPihWldF4N+22LNz33FPi+P4MVXfW0sIot
+ftf72ydZUf8AaaL/AHYv/AYQWuQZXdwwu6XUCerZXierbyr/AMR/2GWAuPIKMLzL8a5JiHJL6Enq
+/Z/nxZhG3dp6r+qvxxXHwP8A5Mv/AF+/5O/8ZcVW+l9ci4/YuIv23/mX7Lf9VMQqHdPS4S/ZVvt/
+5LfZb/gMsIRJ0KTQOiQPw9L97b8f2VX7Sr/qf3kf/XrKyFjJOpvzMv7b0rW4ureOWVOSs6Py4/zf
+DkOFt8Rbqvm7W4rbkzS3UrOnCC1ZFX4v8vkqcMaXxEvTU3vIvrSI6S/ZlildGZW/Z+KNn+DJ0x4k
+vsdWvvV+q6ncRT8vgSWKJoPTb/kY/NMV4lW4aZX4v/q5LiancIlTlK/BP23f4ceJaS+XzD5bg+B9
+Qill/kib1W/4GHlg4mXA2/mRG/3m0+9uv8v0vSX/AIKZoseJbUZtT8yT/DBZW9r+2jzyvO3/AAMa
+p/ycwJQ7w65LC/1rUOPx/wC6Ioov+TnqviqGTy3Yzuiz/WL92+wk8srL/wADy4YqmcOiafpyJ6UU
+Vq/8iRccVXy2NxL9r4on+Dh9nFXW9jdrcPFL8Kfz/s/8Fiqr9WiXn69x9j7H7LYqtaG34v6TfBz+
+DFXPzli5N9uL7af5WEFMwh1X41bnx/yMmA1Ask8leaE0PUvQmf8A3F3jfvX/AGY5P2ZP9T/fmUSD
+kY5PYsrIcl2KuxV2KuxV/9P1RirsVU3VGQq3xI3wsuFBeH+f/Lz6VrEvoJ+6l/excftY8LAyY1cW
+OpraPdLbv6UCeq6cfi4/tcVxpjbEtT8yW883+jfDFx/4bGk2neiagj26QS/FEqM7p/rYZMiyryLq
+HOG48rS/G68rrR3f9pf994waymsyPE/Fv3To/DLWle6I3+V/r4qq2KcontZX/dfbT+biv/NGKrHe
+WL96v21f0rj/AFvtf8P/AHmKr7iJfR9X7SS8Vl/4y/Zjb/Z/3f8AyKxVDokzxMv+7YviiZ/i+Jfs
+tiqhFLwT65EnpcvglRf2eL/Z/wBg+TYyRFpzbnFw/wAuL+X+Zv8AqpH/AM9cVil6zS2d8/L4lX4Z
+UT9pWyCadq2mM0qTxOnCX9v9luX2f+DxWkbp8zz2/KVf9Ii+CVG+1/Krf8y/+wuKUsTyhoLXHqz2
+n1y9lf8Ae3F0zzs3/BfBiqZpY2VmnpRQ+kn7HpcF/wCIrkrRTnt3/ZHwf5X/AAWNrSk+ncXTk/wf
+ayHEy4Que2sVTlL8UvPnw/yceJPCEJzSJ+UX214f8FhYuleKX/JdPt/81fZxVe99L6XpK/Pn8Tun
+2eX83xYaW0FK7ypy5u/DGltRmX1U/wAv+TJNa/0v2lf/AF8VXwu8HxMnPj8Dp/MuQZOmlhZ1eJuU
+T/GnDFVnBHXkyP6TcslJEHpP5aebPrUT6HfS8ru2WtpK32pIR+z/AK8XTMeUXMhJ6BgbHYq7FXYq
+/wD/1PVGKuxVjnnvVZ9M8tXFzbsyShokLL9vizrz4/5XCuMUSeaXerWNqkvqv8f/AC0N+1+1yzIi
+HElJSh8w6Mz8otQ5XCp9h4n+Jf2uS5CmdsE178v7FnuLzRZeH/HwlkzcuS/teg3/ADLwUtpFplxx
+dPj+19jIybSyCO7uP3V9Z/Be2r+rDx/yftLjFgXoWovb6nZWWu2P+8t+v+kJ+zHOv2stakPbvFLF
+8L/Yfg/+xxQivj4c1+CX4cVVr6a34RT/AO6nTjcf8Yv5v+eL/wDM3FXWn989nPw9JkdHT9rFV7RX
+EXBv92q/B/8AK/yv9mmKof6vEsvJX/0e6/n/AGZP2f8Ag/7v/kVk0RdbpN8cHPi6fGnL7S/yt/sH
+xWSlq1k8sP1xU4PF/exL/k/3i5BspfpnCVHs5f7qX/ed/wBrl9po/wDmZ/yNxWmuHC4WdU/0iD4J
+U/34v/N+LBVlhiidJYn5RP8AEkv/ABHFK10eV+LL8Spw5/s8cjbKls1eCRc+Xpf7HG1pR9Hk/wAP
+Pnk+IMOFSe2ueH2OHL4v9jjxBeFVTTEf7Vwqf9d4FQ8toqc+PNv8vliqX1VfsvwZssphbvWPN8NL
+aikssr8Pqj/6/H/mrIoRcUNx8HwcOeKongkX2k+1kGSEeJPsL9j/AI1xVdwfh8HwKmSQFkUN0t0t
+zaS+ndWrLLBL/lLjwtgk9q8q+YoNd0pbxV9KdP3d1b/77kXqMxnLBTrFLsVdir//1fVGKuxV57+a
+2sJbppumcGd7p3l5/sr6S/tf62ILAvOL3QZdY0yXTon43VqnG3lT/fDfZ+H/AJdn/wCZWWAtZeKv
++T3n21d/QheW4if/AHrWXivH/fjM3F0yKTJ615b07zD9Xt4G+PjxZ3Vf2lReTf5CO+FgZMX8xW6N
+5n1BrVES3S4ZIkReK/D8OFkEw0zlx4/7LINgZX5I1GKz1CbQrp+Gn6z8du/++7lcsBayE7+o3Frd
+vFKnCWL4XRsmC1kK7ui4GLrf4JviTmjfY/1sVX8OCekv97F8UTt+1F+z/wAB/d4quS4+xL9n9iX/
+AFf2v+A/vMVdcRRRSvBP/dT/APEv+b8VWw82f1efK9tX4XHL/dit9lv+eyf8lcVRV28SzJdQfHZT
+8Vu3/wB9/sq3+w/u5MUpb9U+q3ctrxdX+1bv/Lx+L/hMVRTvzRL7hwdX43CJ/wAMv/MyPFCtcW8X
+90n+89x8cX+Szfs/7P8Az/vcVUElms/739v9v+bFPEs4JzeWJ+ac/wDP7WK8SlLLEroiv8CfyYrx
+Ie4u3l+FUd0/1cV4kMiaj9n4Ik/y35YtdKX1GZv724/4Bf8AmrFacmmWy/GyM7/zuztk0qzpw/1M
+VUX9aV/g+x/w2K8SIR3R+LfE/wCxivEiEh9dPSr8f2XTBaKS97dFuOVf8hMbWkQluzJ9l8bWkR+i
+ZW58l4fyfF9rG1pG6bqd75e1BNW4crDgq6lEv+++X97/AM8cqLfjL1uKSOWJJY35oy8kZe6tvkC3
+2rYGTsVf/9b1RirsVYP+Zej+vpianEnOWz+GVf8Aipv+acgGBefWmoXEUyXlq/CWJP3Lr/w2TBYF
+J/Mn5m+ZFvvqtr9ViRU+OX0E5cv8nlyySmKVad5k8yanqHq6jqcrWVujT3EK/u19KJOX2Y+P28WB
+ixk8/Wdv22fJMgE80vnXj+2+QLYEbNbytbp8f71H527/AMrL9nEFSHotpqf+IvLcWsL8OoW/7jU4
+v2uS/tZYC1kITn8PNck0qqcGT/hP5cVd61xzSWJ+dxb8uCN+1/NH/s8VVUSL62jJ/dT/ABI//EcV
+Xvb8kezlfg8Sc7f/AIxfy/8APF/+SWKreUUXpXn+7Yk9K7i/aZW+0v8AzMjxVXdPqruvP/R7r4v8
+luX/ADXiq23dLq04s/8ApVk/wO/2mX9lv+ZcmKr7i29J/rUX+89wnKVP5f8AK/2GKtQy/wCj/VZf
+2fsf6v8AzZirTmKdHin+L9iVf+Nv9ninhQL6ZbxJ8KP6X+Wz/wDC4rwqSRIv918GK8LpXTnxxXhU
+Xc/BiinfH9rjitKUtxw+D7WTYqH+lyv+4R3xVGWmk6zL9qLh/Pz+HFeFHJ5el+FpZl/y8V4UbDo9
+pE/Jn5P+x+zlVsqVkeGL7Kelja0udU+Dj8Px88NrShM/x/Y4fycsbWlG4uXVHRk5RP8Ab/65wFSW
+Q/lnqv8Aosugyvyl06jWnP7TWjH93/yK/u8rLkYyzrA2uxV//9f1RirsVUpoo5omikXlHIvFl/yW
+2xV4p5m0m+0PVZYIrd7i0dvg4/a4/wCq328VeQ+ZNTml1Z/3Lrx+2j/C2LVSrpI1mWxu7qKJEt5+
+MDv8fLivxfD8P7eK0i7HTrhndWT48WbIbG3ROHFOXHFUb6Pw/wCXz+xikory/rP6C19JZ/8Ajlap
++41BP5eXwrJi1lk2q2iaZdzcvii/3U/7LK2XtRQ9t8Q+F/gf4sWsqkVwkEvxpyV/tv8A8RxSvZ3l
+9WKL7bcpbf8A1v2l/wCZn/I3FVK41C4fjLK6fWIPj/yW/wCu8UxREtpFPwvIP7qX4X/m/wA/914r
+JFRW7+l9TlT+d7R/8lfiZf8AYf3keKEPbxXCuzMnOWJ2+x+1E37P/VPFVZPtosDcreV/28laOJY6
+8P3H8n2Jf2f8nG14nSw8UWVH/e/tp+yy/wDXeR4Ugof4+fxPjwtgLaW7t/dI7v8A5GNsOIlEReXN
+Yn/urR/9d/hxteElMLfyLqEvxzzJF/q/FjxtvAjbfyLpfL9/cPcf8KuPGvAjIvL2iQP8NunwfYf7
+WRVWuH0+BePFYv8AUxVK3u7dn5L8WLFZ6v8ALiqBlhmZ+OLCl/1ReH+XitLvqvwcv2P2OOStbWyx
+Jz/k/a/2WK2gbiW0ROc7on+tkbQIsfg80abpfmLTb62uPrEsUvp3EMXxcoZvgk/6qYGyIe8I3IVy
+tyW8Vf/Q9UYq7FXYqhL7TNPvk4Xluk6f5eKpfZeTPKljK01tpVqkr/E0vpKzf8E2KKXeZtCt9W0m
+W2aJWlReVv8A5LYrTwt7eaC7dZU+NPt/zYoWQ8Hi5fYTFVju7v8Aun+xikqs1pFeWjwSp8Eq4sCy
+Xyrd/p3y5Lp14/8Aua0T4Of+/IP5suaSibGF/wBv7CfY/wArC1lv0eSf8TT+XFKHhhuFufhfiy8X
+R/8AV+y2KqmoxPO/O2h4uycHT+Vv2l/6p4pkitGimgT0GTmnD4+X83/N6YrFVS3u/W5fW+cXPlwf
+7Xw/ytiqNREb4f2G/kbFVS30fUZ/7iLgn/A5G2XAjV8qahK/73gv+WzcseJeBGxeULReDTzO3+r8
+K5HjbBjRaaDpKty+r/8AB48bYMaN4W8CfDwTG0cIC17uJf8AL/1cbXiCHl1A8PgxpbQj3sz/AOTj
+S2gZpU+wzv8A8FkmtCXEVv8AA3D4/wDiWKtQujf3SYsUR9W/m+HniqU32uaJZ/FdXsUX8nxcm/4F
+cU0x3UfzL8vQI/perK/+wiX/AIbFaY3rP5zRRS/uLeKJE/bld2/5oyNrwMK1H88FnldbrWOKL+zA
+v/NONp4Eqb80/Ldx/vNp9xeXX7Et1L6UX/M18jaRFkHkjzpr2u+ZLSC2tLWz034pbj0ldpWii/4s
+5ftv/wAV422APqry9rVvrGmpcx/C6/BPF/vuReq4GSaYq//R9UYq7FXYq7FXYq7FXk35k+X0sdYT
+U4k4Wt5/fOv2Vl/yv9fFixj0UbhF/M/xviq6HQYp9H1C8gu+NxYP6qW7/wC7Iv2sWIQumc3R2/2W
+LMKK6nL5e1a18w2vxeg3C9i/35A32uWSBayHot3b2yuk9r/vFeIs9vy/aVviywFrIQSO6vKrK/BP
+sYbY8KIht7mX4YrR5eHx/CmNrwou00HWWdJZbf0Iv5HdMhxsvDTCHys8Ery+r8DfsJ/Njxp8NME0
+GzXgrpyf7acsizpG2lvYwfCiLitI76zbKn28FNlqL36fZX43xpbQlxfTVRXRfj/YfCxKCuL6bn9v
+Fgh0u+WKVr3D/s4qppFfS/ZTJWxQ9w9pa/72XsUX+QzJhtaSK+8+eVNO5skr3j/b5xfZxWmNan+d
+Gnxc/q1onNP52/5pxWmFaz/zkDcwO/pXcVuj8vgThy/43yNsuFgOrfndfXTPzuLq6/2bcf8AhsbT
+wsduPPnmO8H+jWvFP5mb/mnhjSbS95fNl5/e3bxK/wCwvw40tr/8NpL+9uZpZ3/ym5Y0tohNAsYv
+j9JMaW0JqOmW32ovhX9vh+zkiGL2X8pEtLXRr28ldPrUrxWqIrcW9JUaRm/2b/8AJrK6V7F+W19c
+P5jSKzd5LWWCT67+0q8D+6b/AF8Noxh633wM3//S9UYq7FXYq7FXYq7FUt8waPDrGk3Gny7CVfhb
++Vv2ThYvFkt3gu/SnXhLE7QXCf5S4FQPmO4eCKVon4v8KP8A7L4cWIb0ZPQsov8AU+PFmHXcPJPi
++xKnx8/5WyIKkMu/KLUIpdNvfLN4vqPYO0tlz+16EvxZYC1kM/t7Syih5xQpE37f+thtlwphFz4c
+6fb/AGMbXhchDJx/l/4HI0ytZNyZH440tqSQs0XNm+1/xLCtIR4ZW+Lm/H+TFad8S/z88lTXa/jd
+tw44ptCXvCBfVvLhIE/ymTIpLH9W86eTbHny1BJ3T9iL4v8AiOLWkV3+b2hwfBY6e1xL+3z4RYsm
+P6n+e97Aj8vqFn/kM/Jv+JLil51rf54vPz9XVri6f9hLfnx/4XgmC00wTUPzYvp3dLW3fm/7bt8X
+/C42tJVNrfnG8f8AYt+X8i/F/wANk1pR/QN3c/HeXcsvL/KbCq//AAzaL8XD/XyXAjiTCLTLSL7M
+S48C8SrwRfhVMaYWvpjS2sflwxpbWcI2xpbUnt+aP+0jYSGSZ+VtZuNF1BOKcuCcODf7si/aX/X/
+AN95AhL6x/JZTc6BLqxlSVbplW39P9mP7X/G+UJAek4pf//T9UYq7FXYq7FXYq7FXYq8z/Mny/6F
+9FrEHwRXXGK6/wAmT/dbYq8415Hn+rqyfH6vK4/55f8AN+LFF27v/sGxVVm+FkVfjyISWtD1P9B+
+a9N1Ff8Aeed/qt2/+TJlgYPbJY/9OT7PpN+1/k4s7RsUSc2Zftfy4ra5+auqr9h8UKPP0kf1fs/t
+u+KpLqfnLytp3NZdTt+a/wC6uXL/AIjirEdW/O7ynbcGgSW6lX7HFfSX/hsVYhrP/ORNx6T/AFO0
+t4E+wjyvy+H/AIXDTBgWuf8AOQ2qNzX9L8f8m1/5txpLCtR/Ni8vH/dQ3F5/xbK/2v8AiWNKlMvm
+zzref3SJAn+ry/4ljSpfLF5pvj/pN7L/AC8Fbj/xHJEM7S17eW25pP8Ab/nyshbQVxcfy4UojQXT
+68jS/Fir0W7tknt0niy1pQKNLwxQs4fzZK2S+mNq7n/L9v8AY5fzZG2NJPp73sV3xvIvjVG5Ov7T
+fs42tJg90i/ayNsqS+41vTovtSp/qJ8WNrSX3Hmi2X+4iZ/9b4cbTSDl8x3rOnGJeCfsfF/xLBag
+PvX8jmlf8q/L88sPoSzwNK6/Z5cnbizf6y0ytsDPcVf/1PVGKuxV2KuxV2KuxV2KoPVNMt9R0+4s
+bleUNwnFxirxXWNMaxumW5i/fxN6Uv8Asfst/s8WKWu6Kn8n2sULreXlD/l5EMih9QtPrlo8X8/x
+p/rZYGsvQtG/MfQpPLlu+rztBf2y8ZkWJ25ccUpHqf556dA7/o6yeX4P72dvSXl/qrzxRbBvMP8A
+zkTqy8l/ScVl/kW6Jy/43fFm881n88L6+T0nu7q//wCD/wCNsVYvd+efMNzza1tOCf8AFrcv+aMK
+pe7ecr7+9uPST/J+HEIbTyhNL8VzcO2WUxRtv5W02L7Scv8AXxpUwt7G1gf4U4J+3jSoj/R/5XbG
+lWMnN/gThhIW0n17TvVh9Vf9nkCE2wu4R4n4tkGx1vM8T/DhV6B5T1lJU9CXLGlH30XofEv9037e
+KEquNTtIv72VF/1nyNs0vl80acv2GaX/AFVxtaS9/NMzclgt/s/F8X8uRtNIV9b1SQqDOtusi8uS
+/wDNuNrSCe49Xg88ssrc/wB6n/NLZG2VKPNOC/B8Svy5f5P8uNrSynJsbWmQeQvKtx5p846VoECf
+Hf3CRO/8sf2pG/2CY2tP0h0+wt9PsbextU9O2tYkgt1/lSNeK4EorFX/1fVGKuxV2KuxV2KuxV2K
+uxVhfnjTLSe7sU+zLfM0Tlf+Kl9RcIYFIofL2jRK6/V0lR/tvL+9+1kw1l5lq1jcaFr81mzv9X/v
+bfl/vpvs4lQmemP68yr9lMgWwPKfzV89agvmeXTtJlSKytU4/ZT7X7TYUvNJdR1DU5uMt3Lcf67f
+D/wOFCcw+UYViSe4+Llli2mVpplnEnwoi8cVtHQpaL/l4ta9PhTFWsWSHaVFd0/bi/vU/wBbFVbg
+clwsVjoceFadzORtlSjcTW/DhPwRf8v4cbTTDdTsUnZms3SXh9vg3L4cqbAlU1pcQTelKjxSp9tG
+Ti2Kpnp0rwc5V+Djx/yfibFULfatqF5+9ubp2+LiYl5fCv8AxDFUI/o/Gi8m+L90/wBn4f8AKXIq
+55fjfgiIkv7H2uP/AAWKrHllbhyflwTgn+riqzFXcMVXw280r+lEjPK/2ET4mxVnXln8jPzS8wvF
+9R8v3UVvL/x9XSfVo/8AgpeOKvqn8jP+cfrDyBGdX1V0vvNEqsnqx/3NvG37EPIfb/nkxV7LirsV
+f//W9UYq7FXYq7FXYq7FXYq7FXnH5g34m1BLe3l4Napy5r+zLy5YQwLdjcRXlol4qf3/APep+ysq
+/wB4uTDWUh/MXRotT0xLqD4tSsPjRUT7UX7S4lQwjS7t7XRLjU2+HhySL/iOQLYHzprN39a1a4nl
++P1Xb4/9Z8KVW40yKzt7e/glVkl4+qi/s4VZdo19DeWPpP8AbyxqtSdEif4mxW1/q4quR/gdv5MV
+a9VOeLNJ9WsdOlu2vJbj6vL8PqvyReWKqVx5m0yL/j4aV/8AITI8aaQEvnF+Dta2nwL+2zf8048a
+0l93rGuSuyvceh8PPgvw/DkbZUlLu8v967t/rY2tPQPyE8st5h/NLQrNdooJfrlx/wAY7b943/VP
+Al75/wA5S/lZHqNpF540yAG7slWLV0RfikgH93N/zw/5Nf8AGLAFfKOrfuoorX+f96//ABFcKpZi
+q/g7fZyKoux0nU76b07O3lupW/YgRpW/5J4q9A8vf845/m1rvF4tClsom/3bfslsv/Ayfvv+SeKv
+T9B/5ws1R+D695it4P5orKBp2/5Gzel/ybxV6Z5c/wCcVfym0kK13aT6zMv2mvZfh/5Fw+kmKvSd
+H8oeVNDRE0fR7Kw4/Y+rwRRN/wAEq4qnOKuxV2KuxV//1/VGKuxV2KuxV2KuxV2KuxV5D53sZbPz
+ZLK/+8t6n8v+7f2W5f8AJPFit0G7azS4idOVvPxZ05cWVl/ajb4vjxQuvvM1tY/7w2LtL/v24lT/
+AJlr8eKeF5Z581N4PLmoOsMVvF8UqRRfZVm/5vbFeF863bv6vL9j9jCGSe6HcJLZvay/Gv8Axrlg
+VdpN89jfelz5Ir8HdMlbVTINb1TRoOE7XafWH+3EvxNja0kFx5us1/ukeX/Lb4cja0hZfNeptF6s
+VukUSNxd+PLi2NppL7vU9TleVZ73jx+L4W+Fv8n93kGxBF7bnEzc5fh/eo/w/F/kt8WKrPW+BUVV
+5K3L1f2sirTyys7uz/3vxv8A5WKrcVdir6s/5w8/L/ULKHUvOGoQNDHfxJbaXyX4niLcpJF/yP7v
+FX0tc28F1bS206LLBOrRyxt9llYcWXFXyt5z/wCcQPMl15jefy5qVmdGl/ukvWlWSFf5f3atzxVN
+tB/5wvsVVG13zE7N+3FYQIq/8jJuf/JvFXpXl/8A5xv/ACj0YK40b9JTL0l1GVp/+E2i/wCSeKvQ
+9O0jTNMh9DT7WCzg/wB9QRLEv3LiqMxV2KuxV2KuxV2KuxV2Kv8A/9D1RirsVdirsVdirsVdirsV
+Y1560JNU0Z+O00HxKy/a44sXl0Oo29siWt5cJFdRJwdJ+ETScf8Adi/z/wDPPFWOa9rkMrv6D/B9
+hJV+zivEwjz/AAahfafb6ZY/HLcMrv8AaZuMX7PGP9vFeJgOvflh500zRG1i/wBHurfTVZV+tXEX
+pL8X2fhb4/jwhkxzS3/YyYVNtQ422mPdfD6q/DF/rNgtFMXeZWleXi8vJf22+Ll/N8ONrS36w6+l
+x+B4vjR0+1/wWRtaWcmZ+bftY2tOwpX8HbFVyW832f28irK/L35RfmPr6o2k+X72eJ/+PhovSi/5
+GTekmKvTfLn/ADh5+YV9wfWLqy0mL9pGZrmX/gY/g/5KYq9X8qf84k+QNJmiudYurnW5o2VvSk4w
+2zMv80a/E/8AyMxV7fDDDbwpFEixxRrxVV+FVVewxVVxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV/
+/9H1RirsVdirsVdirsVdirsVds2KsQ1v8uNK1NvhlaBOXMKFV+Lf5PLFUNaflD5QijcyJPdSv9qW
+SWn/AAKpwTFU+8ueVtJ0C09CyT4nZmadgpkbl/lYqq+ZNAsNf0K+0bUF52l/E0Uop/N9lv8AYYq+
+BvOPlDU/Knma40++i/e2rcZf5W4/tL/rp+8xVKPM92ktpZRL9hv3rp/wuSVj6RO37GKqtvZXE8vp
+RI8srfYiReTf8CuRVnXlz8h/zR1zi1n5fuoom/3fdItpH/yW44q9L8vf84a+a5+La3qtlpsX7aQI
+93J/zKTFXp/l3/nE38s9OCPqTXmsTL9oTy+jF/yLg4f8TxV6P5e/LjyJ5d4/oXQrKydekqRL6v8A
+yMb48VZLirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdir//0vVGKuxV2KuxV2KuxV2KuxV2
+KuxV2KuxV2KvM/zU/I/R/wAwr6yvZ9Ql0y4gR4rh7dFZpoz9lW5fyYqxS+/5xB/L6ezt4E1HU45Y
+PtXDSxNy/wBj6eG1Tvy//wA4wflRpQVriyl1aVej38rMv/IuP00xtXo2j+VvLOiJx0fSrXTh/wAu
+sCRf8RXAqbYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq//2Q==</FILECONTENTS>
+</EXTDOC>
+</EXTSTORAGEITEM>
+</EXTSTORAGEITEMS>
+<DESC>
+<TUV xml:lang='en-US' struct='1'><PARA><FC>This CANdela template is based on ISO 14229-1:2013.</FC>
+</PARA>
+</TUV>
+</DESC>
+<PROTOCOLSTANDARD>UDS</PROTOCOLSTANDARD>
+<SPECOWNER>Vector</SPECOWNER>
+<DTID>Y1NUTFZIG2l5bQ==</DTID>
+<QUALGENOPTIONS case='ignore' minLen='1' maxLen='128'/>
+<ATTRCATS>
+<ATTRCAT id='_000001B18D08D2C0' oid='2C41287C4FDB42bbBA3652096C99FD88' temploid='{FC008A0F-60C7-452e-B108-760C1B1D8ADA}' usage='sys' xauth='r'>
+<NAME>
+<TUV xml:lang='en-US'>Available interfaces</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>(System category)</TUV>
+</DESC>
+<QUAL>COM.INTERFACES</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08D420' oid='B0C926E8820E409e91B29D659974B5A8' temploid='{89B35B76-F79D-4efe-B8C3-833BB92787D3}' usage='sys' xauth='r'>
+<NAME>
+<TUV xml:lang='en-US'>Initialization</TUV>
+</NAME>
+<QUAL>COM.INIT</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08E4A0' oid='479D2A14409147b08F99EAF5E3005D46' temploid='{043AF51A-F4F4-4405-B33C-56BB7F772C27}' usage='sys' xauth='r'>
+<NAME>
+<TUV xml:lang='en-US'>Communication</TUV>
+</NAME>
+<QUAL>COM.COM</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08E550' oid='3ADA1E98000543859205F9418351B099' temploid='{6F0C0C14-292F-45d3-97F8-040F99C9FB4D}' usage='sys' xauth='r'>
+<NAME>
+<TUV xml:lang='en-US'>Timing</TUV>
+</NAME>
+<QUAL>COM.TIMING</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08E6B0' oid='0FC9046B8DC14bbaB5B46748533A5E45' temploid='XED1A31B21D7B4fcbAD252773B0170925' usage='sys' xauth='r'>
+<NAME>
+<TUV xml:lang='en-US'>Autosar </TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Autosar software configuration relevant parameters (name with trailing blank)</TUV>
+</DESC>
+<QUAL>COM.AUTOSAR</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08D630' oid='B8B09EED6AD44b57868F7F9E2E19EDDE' temploid='{DE9212D7-AC58-4397-8DE1-CFFA5F118A24}'>
+<NAME>
+<TUV xml:lang='en-US'>CANdesc</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Information used by CANdelaGen to configure diagnostic software components.</TUV>
+</DESC>
+<QUAL>CANdesc</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08EA20' oid='97EBC3B6291C4d62AB23219B3DA85D78' temploid='{62402351-7D94-4c8f-8315-C3D2D49608FD}'>
+<NAME>
+<TUV xml:lang='en-US'>Any attribute category</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Example of a user-defined attribute category and its usage in CANdelaStudio documents.</TUV>
+</DESC>
+<QUAL>AnyAttributeCategory</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08D0B0' oid='1E2297CDF5D44e4dB8B3B6E8217C743D' temploid='{D8290D4C-277B-4ac2-B42C-64AF62A6567E}'>
+<NAME>
+<TUV xml:lang='en-US'>Quality Management</TUV>
+</NAME>
+<QUAL>Quality_Management</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08D8F0' oid='0E59CFC8C4D24ce68ACBE4D1FF47C01A' temploid='{0234B386-65D2-4a56-8A3F-D948E204B430}'>
+<NAME>
+<TUV xml:lang='en-US'>Editor</TUV>
+</NAME>
+<QUAL>Editor</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08EAD0' oid='345E8B587F464fd09D13BBD3C41447B7' temploid='0CD6E4BB804C4f3d92D36A629A593A53'>
+<NAME>
+<TUV xml:lang='en-US'>ODX</TUV>
+</NAME>
+<QUAL>ODX</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08D580' oid='2A471083E5364885A506193122602A53' temploid='9270F2ADE9B743ba95BDE1C13E296BFB'>
+<NAME>
+<TUV xml:lang='en-US'>Autosar</TUV>
+</NAME>
+<QUAL>Autosar</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08E130' oid='5105F047934243bcB7E061141769B605' temploid='7869BACD10E24d57927FBEE70F835373'>
+<NAME>
+<TUV xml:lang='en-US'>UDS</TUV>
+</NAME>
+<QUAL>UDS</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08CBE0' oid='9E4BDE72F94D44e1893103D7172F1391' temploid='BFA7F5A5BF0C4173BBF487470DC08729'>
+<NAME>
+<TUV xml:lang='en-US'>DEXT</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>AUTOSAR Diagnostic Extract</TUV>
+</DESC>
+<QUAL>DEXT</QUAL>
+</ATTRCAT>
+<ATTRCAT id='_000001B18D08D840' oid='F41E8AF0401D4ba0BD21FACFC9888BB4'>
+<NAME>
+<TUV xml:lang='en-US'>Migration</TUV>
+</NAME>
+<QUAL>Migration</QUAL>
+</ATTRCAT>
+</ATTRCATS>
+<DEFATTS>
+<DATAOBJATTS>
+<STRDEF id='_000001B1ADA28C40' oid='4152578D00AA4cf1ADD663518FB0EE8F' temploid='{8F512672-51E6-4ab8-93B0-8B6A178B6288}' attrcatref='_000001B18D08D630'>
+<NAME>
+<TUV xml:lang='en-US'>VariableForDirectAccess</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Specifiy name of application variable to be accessed by CANdesc. Currently, no (extended) type specifiers are allowed. If no variable for direct access is specified, a callback function will be generated.
+Restriction: Only evaluated if:
+  - Service attribute 'MainHandler (on Service Level)' is set to 'generated' or
+  - Diagnostic instance attribute 'PacketHandlerOption' is set to 'generated').</TUV>
+</DESC>
+<QUAL>VariableForDirectAccess</QUAL>
+<STRING>
+<TUV xml:lang='en-US'></TUV>
+</STRING>
+</STRDEF>
+<STRDEF id='_000001B1ADA2A590' oid='2898DACEF5C14cb2BD2D56AE58736F44' temploid='{C1F4DC7B-56AD-4b10-88EC-A0178C1DEAD6}' attrcatref='_000001B18D08D630'>
+<NAME>
+<TUV xml:lang='en-US'>SignalHandlerOverrideName</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Provide alternative name for Signal Handler instead of generated one (default prefix + SignalHandlerOverrideName). You can reuse a Signal Handler for different Signals, if you specify the same Override Name. Pay attention that the function signature must match the different use-cases.
+Restriction: Only evaluated if:
+  - Service attribute 'MainHandler (on Service Level)' is set to 'generated' or
+  - Diagnostic instance attribute 'PacketHandlerOption' is set to 'generated').</TUV>
+</DESC>
+<QUAL>SignalHandlerOverrideName</QUAL>
+<STRING>
+<TUV xml:lang='en-US'></TUV>
+</STRING>
+</STRDEF>
+<ENUMDEF id='_000001B18CF22AB0' oid='764D8D4015C24f58B4B8B0DAC2883BB5' temploid='{9EAF18B7-10AF-4cb1-B4BE-979A9BDF7D14}' attrcatref='_000001B18D08D8F0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Maturity</TUV>
+</NAME>
+<QUAL>Maturity</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>in progress</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>completed</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>verified</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>released</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B18CF22150' oid='7779FAB8FAC44b56A19414BF74956FC9' temploid='2BA8A5E838804be4AF6495FAE399A435' attrcatref='_000001B18D08D630' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>IoSignalType</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Specifies the signal type for IO Control</TUV>
+</DESC>
+<QUAL>IoSignalType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>signal</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>mask</TUV>
+</ETAG>
+</ENUMDEF>
+<CSTRDEF id='_000001B1AD93DAB0' oid='8458F427E90C46c98C06AE24D6B3564C' temploid='349153311DF04cf187789FA9B03CFF36' attrcatref='_000001B18D08D630'>
+<NAME>
+<TUV xml:lang='en-US'>IoSignalDescriptor</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Input, Output</TUV>
+</DESC>
+<QUAL>IoSignalDescriptor</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1AD93E1F0' oid='DE4494753074491890CFE75AA271F8D9' temploid='A52A177B6B8F4369BA8D6D0A223DBA68' attrcatref='_000001B18D08D580'>
+<NAME>
+<TUV xml:lang='en-US'>ASR SWC DataElement Ref</TUV>
+</NAME>
+<QUAL>ASR_SWC_DataElement_Ref</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1AD93DC80' oid='2E60231B3F79435996DC633040BC0E6E' temploid='FB2D831920D649f58D3F95053760E064' attrcatref='_000001B18D08D8F0'>
+<NAME>
+<TUV xml:lang='en-US'>SYNCHELEMENT</TUV>
+</NAME>
+<QUAL>SYNCHELEMENT</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+</DATAOBJATTS>
+<DATATYPEATTS>
+<ENUMDEF id='_000001B18CF21D90' oid='E262F765A31C42b3A856936DA2542497' temploid='030F6E70A56A40f6B8171FD951DF720F' attrcatref='_000001B18D08E130' xauth='rm' restr='[DT_ID]Variant_CodingFlash_JobsGeneric_JobsStored_DataDynamic_DataUpload_DownloadResponse_on_EventLinkControl[DT_TT][DT_CL][DT_VT][DT_CT][DT_PC][DT_F][DT_ST]Communication_Control_EnhancedAddressInformationPowertrain_Diagnostic_and_Freeze_Frame_DataEmission_related_Trouble_CodesOnboard_Monitoring_Test_Results_for_Specific_Monitored_SystemsControl_of_Onboard_Systems_Test_or_ControlVehicle_Information' mayBeReported='0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Faultmemory Relevance</TUV>
+</NAME>
+<QUAL>FaultmemoryData</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>N/A</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>OccurrenceCounter</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>AgingCounter_Upward</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>OverflowIndication</TUV>
+</ETAG>
+<ETAG v='4'>
+<TUV xml:lang='en-US'>Significance</TUV>
+</ETAG>
+<ETAG v='5'>
+<TUV xml:lang='en-US'>StaticPriority</TUV>
+</ETAG>
+<ETAG v='6'>
+<TUV xml:lang='en-US'>AgingCounter_Downward</TUV>
+</ETAG>
+<ETAG v='7'>
+<TUV xml:lang='en-US'>FaultDetectionCounter</TUV>
+</ETAG>
+<ETAG v='8'>
+<TUV xml:lang='en-US'>MaxFaultDetectionCounter_SinceLastClear</TUV>
+</ETAG>
+<ETAG v='9'>
+<TUV xml:lang='en-US'>MaxFaultDetectionCounter_ThisCycle</TUV>
+</ETAG>
+<ETAG v='10'>
+<TUV xml:lang='en-US'>NumCyclesSinceLastFailed</TUV>
+</ETAG>
+<ETAG v='11'>
+<TUV xml:lang='en-US'>NumCyclesSinceFirstFailed</TUV>
+</ETAG>
+<ETAG v='12'>
+<TUV xml:lang='en-US'>NumFailedCycles</TUV>
+</ETAG>
+<ETAG v='13'>
+<TUV xml:lang='en-US'>Daimler_StdEnvData</TUV>
+</ETAG>
+<ETAG v='14'>
+<TUV xml:lang='en-US'>VolvoCar_OCC1</TUV>
+</ETAG>
+<ETAG v='15'>
+<TUV xml:lang='en-US'>VolvoCar_OCC2</TUV>
+</ETAG>
+<ETAG v='16'>
+<TUV xml:lang='en-US'>VolvoCar_OCC3</TUV>
+</ETAG>
+<ETAG v='17'>
+<TUV xml:lang='en-US'>VolvoCar_OCC4</TUV>
+</ETAG>
+<ETAG v='18'>
+<TUV xml:lang='en-US'>VolvoCar_OCC5</TUV>
+</ETAG>
+<ETAG v='19'>
+<TUV xml:lang='en-US'>VolvoCar_OCC6</TUV>
+</ETAG>
+<ETAG v='20'>
+<TUV xml:lang='en-US'>VolvoCar_OCC7</TUV>
+</ETAG>
+<ETAG v='21'>
+<TUV xml:lang='en-US'>VolvoCar_FDC10</TUV>
+</ETAG>
+<ETAG v='22'>
+<TUV xml:lang='en-US'>VolvoCar_FDC11</TUV>
+</ETAG>
+<ETAG v='23'>
+<TUV xml:lang='en-US'>VolvoCar_FDC12</TUV>
+</ETAG>
+<ETAG v='24'>
+<TUV xml:lang='en-US'>VolvoCar_SI30</TUV>
+</ETAG>
+<ETAG v='25'>
+<TUV xml:lang='en-US'>OccurrenceCounter_2Byte</TUV>
+</ETAG>
+<ETAG v='26'>
+<TUV xml:lang='en-US'>NumConsecutiveFailedCycles</TUV>
+</ETAG>
+<ETAG v='27'>
+<TUV xml:lang='en-US'>NumTestedCyclesSinceFirstFailed</TUV>
+</ETAG>
+<ETAG v='28'>
+<TUV xml:lang='en-US'>RootCauseEventId</TUV>
+</ETAG>
+<ETAG v='29'>
+<TUV xml:lang='en-US'>ObdDTC</TUV>
+</ETAG>
+<ETAG v='30'>
+<TUV xml:lang='en-US'>ObdDTC_3Byte</TUV>
+</ETAG>
+<ETAG v='31'>
+<TUV xml:lang='en-US'>Obd_Ratio</TUV>
+</ETAG>
+<ETAG v='32'>
+<TUV xml:lang='en-US'>HealingCounter_Downward</TUV>
+</ETAG>
+<ETAG v='33'>
+<TUV xml:lang='en-US'>NumTestedCyclesSinceLastFailed</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B18CF226F0' oid='59695009D96745d798EAE5A93DDDD18D' temploid='7051AAAB670D4e9e95495C51D00B5AFE' attrcatref='_000001B18D08EAD0' xauth='m' mayBeReported='0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>DOCTYPE</TUV>
+</NAME>
+<QUAL>DOCTYPE</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>CONTAINER</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>LAYER</TUV>
+</ETAG>
+</ENUMDEF>
+<CSTRDEF id='_000001B1AD93D8E0' oid='73C4FBF5EA024df690B314F11DAE7F1C' temploid='B757A6B067314335A9083A8527ECF828' attrcatref='_000001B18D08EAD0' xauth='m' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>DOCREF</TUV>
+</NAME>
+<QUAL>DOCREF</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1AD93DE50' oid='453C41CD9DA94eb39CBA5BAFD5817AAA' temploid='67F1703482CB4daa92A5D958FF9B1070' attrcatref='_000001B18D08EAD0' xauth='m' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>ID-REF</TUV>
+</NAME>
+<QUAL>ID_REF</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<ENUMDEF id='_000001B18CF22510' oid='51CC65A012DE416aBFE1837271FC1979' temploid='AC31D2DD76424d298BEAAD96B9400F6D' attrcatref='_000001B18D08EAD0' xauth='m' mayBeReported='0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>DataType is empty MIN-MAX-LENGTH-TYPE BYTEFIELD</TUV>
+</NAME>
+<QUAL>IsEmptyMinMaxLengthTypeByteField</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>no</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>yes</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADA7F6F0' oid='F0E9E63CE2264871A8E81289F987B027' temploid='C862B140F06C4c46AB0363D7B803CE2F' attrcatref='_000001B18D08EAD0' xauth='m' mayBeReported='0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>IsLeadingLengthInfoTypeByteField</TUV>
+</NAME>
+<QUAL>IsLeadingLengthInfoTypeByteField</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>no</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>yes</TUV>
+</ETAG>
+</ENUMDEF>
+<CSTRDEF id='_000001B1AD93E020' oid='23FB0D7F069547a5A0AB61984F2BD120' temploid='AD72728713D14e3eBB182231A411CDE7' attrcatref='_000001B18D08D580'>
+<NAME>
+<TUV xml:lang='en-US'>ASR Encoding</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Used in DEXT Export to set ASR encoding e.g. to BOOLEAN</TUV>
+</DESC>
+<QUAL>ASR_Encoding</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+</DATATYPEATTS>
+<DIAGCLASSATTS>
+<ENUMDEF id='_000001B1ADA7F330' oid='4F823BD8FE4B418aBAFDDBCBE485B568' temploid='{75986856-94EB-438d-8DF9-F494703E0DEE}' attrcatref='_000001B18D08D630' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>MainHandlerSupport (on Protocol Service Level)</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Provide MainHandlers and select type for all protocol services of the diagnostic class.</TUV>
+</DESC>
+<QUAL>MainHandlerSupport</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>none</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>oem</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>user</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADA7FE70' oid='FFE8D61C59F54bafB01A55E3D221195F' temploid='{8B44DE04-E103-43c4-9C86-32AF42218C85}' attrcatref='_000001B18D08D630' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>PreHandlerSupport (for all Protocol Services)</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Provide type of PreServiceHandlers for all protocol services of the diagnostic class Restriction: Only evaluated if 'MainHandlerSupport (on Protocol Service Level)' is set, i.e. unequals to 'none'.</TUV>
+</DESC>
+<QUAL>PreHandlerSupport</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>none</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>oem</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>user</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADA80D70' oid='7F73917713504e29A72D7D06B7F2FDB0' temploid='{4F0672B7-A634-45dc-9B25-DA5FA17F26ED}' attrcatref='_000001B18D08D630' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>PostHandlerSupport (for all Protocol Services)</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Provide type of PostServiceHandlers for all protocol services of the diagnostic class Restriction: Only evaluated if 'MainHandlerSupport (on Protocol Service Level)' is set, i.e. unequals to 'none'.</TUV>
+</DESC>
+<QUAL>PostHandlerSupport</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>none</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>oem</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>user</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADA7F8D0' oid='4DC2FD01776F40d78432EF3B780B2001' temploid='{C2A07D22-69EC-492d-B5A5-BDEE23B938BB}' attrcatref='_000001B18D08D630' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>PacketHandlerSupport</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Switch on/off Packet Handlers support for each Diagnostic instance of currrent Diagnostic class.
+Restriction: Only evaluated if 'MainHandlerSupport' (on ProtocolService Level)' is set, i.e. unequal to 'none'.</TUV>
+</DESC>
+<QUAL>PacketHandlerSupport</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>none</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>all</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADA80410' oid='4355D82CE10E4e50B757754CC59E5F59' temploid='{14AE92AC-6C3A-4c0e-86AD-0177FA001FBB}' attrcatref='_000001B18D08D8F0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Maturity</TUV>
+</NAME>
+<QUAL>Maturity</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>in progress</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>completed</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>verified</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>released</TUV>
+</ETAG>
+</ENUMDEF>
+</DIAGCLASSATTS>
+<DIAGINSTATTS>
+<ENUMDEF id='_000001B1ADA80F50' oid='AD50946CFA1445a79E6745FDF8A74281' temploid='{BA67B991-04B3-4baf-B9B0-1D55BEFDEDF2}' attrcatref='_000001B18D08D630' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>PacketHandlerOption</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Provide type of current PacketHandler for first found Service Positive Response.
+Restriction: Only evaluated if attribute 'PacketHandlerSupport' is set to 'all'.</TUV>
+</DESC>
+<QUAL>PacketHandlerOption</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>user</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>generated</TUV>
+</ETAG>
+</ENUMDEF>
+<UNSDEF id='_000001B1ABDB8880' oid='5360513FCFD0464798732BFACF6D64AC' temploid='{41A82C33-4E2D-4c0f-B7F8-37F42C5D1E4D}' attrcatref='_000001B18D08EA20' v='85' df='bin'>
+<NAME>
+<TUV xml:lang='en-US'>Example of a diagnostic instance attribute</TUV>
+</NAME>
+<QUAL>ExampleOfADiagInstAttr</QUAL>
+</UNSDEF>
+<ENUMDEF id='_000001B1ADA7FAB0' oid='6370DC6C8D5E44a3BDA92E2BC2887020' temploid='{3BA0715E-7DDB-4082-B9E0-186993137E05}' attrcatref='_000001B18D08D8F0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Maturity</TUV>
+</NAME>
+<QUAL>Maturity</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>in progress</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>completed</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>verified</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>released</TUV>
+</ETAG>
+</ENUMDEF>
+<UNSDEF id='_000001B1ABDB8C60' oid='2F2579FC22D3453aAE11D5D43CA90FBB' temploid='6B2B46CAFF19433fA9CFBBB409643ACA' attrcatref='_000001B18D08E130' restr='SecurityAccessPowertrain_Diagnostic_and_Freeze_Frame_DataEmission_related_Trouble_CodesOnboard_Monitoring_Test_Results_for_Specific_Monitored_SystemsControl_of_Onboard_Systems_Test_or_ControlVehicle_Information' v='3' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>MaxAttemptsToDelay</TUV>
+</NAME>
+<QUAL>MaxAttemptsToDelay</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ABDB9230' oid='800AD4F4679D4d95871C1A916A9ABF69' temploid='3C4DF1D5A2714257B9D443F4D06D3206' attrcatref='_000001B18D08E130' restr='SecurityAccessPowertrain_Diagnostic_and_Freeze_Frame_DataEmission_related_Trouble_CodesOnboard_Monitoring_Test_Results_for_Specific_Monitored_SystemsControl_of_Onboard_Systems_Test_or_ControlVehicle_Information' v='3' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>MaxAttemptsToLock</TUV>
+</NAME>
+<QUAL>MaxAttemptsToLock</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ABDB8A70' oid='D1F1ED1A696C4e49A856212DDA13F6DD' temploid='23DEC173907643969E8B5B408F635324' attrcatref='_000001B18D08E130' restr='SecurityAccessPowertrain_Diagnostic_and_Freeze_Frame_DataEmission_related_Trouble_CodesOnboard_Monitoring_Test_Results_for_Specific_Monitored_SystemsControl_of_Onboard_Systems_Test_or_ControlVehicle_Information' v='10000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>DelayTimeMs</TUV>
+</NAME>
+<QUAL>DelayTimeMs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ABDB8E50' oid='EA4BCE16F4104552BF4E69A963C2982E' temploid='8041EF62FB6A4a87AB0940717E4959DC' attrcatref='_000001B18D08E130' restr='SecurityAccessPowertrain_Diagnostic_and_Freeze_Frame_DataEmission_related_Trouble_CodesOnboard_Monitoring_Test_Results_for_Specific_Monitored_SystemsControl_of_Onboard_Systems_Test_or_ControlVehicle_Information' v='0' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>DelayTimeOnPowerOnMs</TUV>
+</NAME>
+<QUAL>DelayTimeOnPowerOnMs</QUAL>
+</UNSDEF>
+<ENUMDEF id='_000001B1ADA805F0' oid='5824853B8396488eA2966F8FC29C6752' temploid='4DFC5E47C8D240a3B9CE7F44A5D36E74' attrcatref='_000001B18D08D580' restr='IOControlMemoryCommunication_ControlPeriodic_DataECU_IdentificationVariant_CodingFlash_JobsGeneric_JobsStored_DataDynamic_DataUpload_DownloadResponse_on_EventLinkControlCommunication_Control_EnhancedAddressInformationPowertrain_Diagnostic_and_Freeze_Frame_DataEmission_related_Trouble_CodesOnboard_Monitoring_Test_Results_for_Specific_Monitored_SystemsControl_of_Onboard_Systems_Test_or_ControlVehicle_Information' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>IoHwAbManaged</TUV>
+</NAME>
+<QUAL>IoHwAbManaged</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>no</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>yes</TUV>
+</ETAG>
+</ENUMDEF>
+<CSTRDEF id='_000001B1ADA87E50' oid='C735A939DBF44be2BC153FC8211FD368' temploid='80FCF04145304d449917EF494607EB79' attrcatref='_000001B18D08D580'>
+<NAME>
+<TUV xml:lang='en-US'>NvmBlockDescriptor</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Specifies the NvM block name</TUV>
+</DESC>
+<QUAL>NvmBlockDescriptor</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<ENUMDEF id='_000001B1ADA807D0' oid='BC813FC9DD4D4f4a9401659F8738DB06' temploid='9ECCE7FD714B4accBC2CC8FC7A7EADCF' attrcatref='_000001B18D08D630' restr='SecurityAccessPowertrain_Diagnostic_and_Freeze_Frame_DataEmission_related_Trouble_CodesOnboard_Monitoring_Test_Results_for_Specific_Monitored_SystemsControl_of_Onboard_Systems_Test_or_ControlVehicle_Information' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Static_Seed</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>This is used to indicate whether or not a static_seed is used or not for non-standard security algorithms.  This value shall always be false if Delay_Timer and Att_Cnt are not supported.</TUV>
+</DESC>
+<QUAL>Static_Seed</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>False</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>True</TUV>
+</ETAG>
+</ENUMDEF>
+<CSTRDEF id='_000001B1ADA878E0' oid='CD903576FF914853A78CE4677CAA2F24' temploid='7F608A1246C140468B53AAECBE1786AE' attrcatref='_000001B18D08D580' restr='IOControlRoutine_Control' listable='1'>
+<NAME>
+<TUV xml:lang='en-US'>Instance Type</TUV>
+</NAME>
+<QUAL>Instance_Type</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA89070' oid='502AD25389844f6dB0E0A7FA32262468' temploid='E4EA632F6CE4455599BAFF1724C03CD6' attrcatref='_000001B18D08D580'>
+<NAME>
+<TUV xml:lang='en-US'>ASR SWC DataElement Ref</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Path to the system description data element which corresponds to the CANdela object. It is set by the SWC Sync and evaluated by DEXT export.</TUV>
+</DESC>
+<QUAL>ASR_SWC_DataElement_Ref</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA881F0' oid='26E7BA590293493a9FB555F8143EA3A3' temploid='838D7847DA66406684C6C6871EDF7280' attrcatref='_000001B18D08D580'>
+<NAME>
+<TUV xml:lang='en-US'>ASR SWC ServiceDependency Ref</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Path to the system description service dependency which corresponds to the CANdela diagnostic instance. It is set by SWC Sync and evaluated by DEXT export.</TUV>
+</DESC>
+<QUAL>ASR_SWC_ServiceDependency_Ref</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA88B00' oid='5CB19B58E55846c78F6681DB0E70159A' temploid='46001989E26B46ce81FCB57B0F3DCA56' attrcatref='_000001B18D08D8F0'>
+<NAME>
+<TUV xml:lang='en-US'>SYNCHELEMENT</TUV>
+</NAME>
+<QUAL>SYNCHELEMENT</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<ENUMDEF id='_000001B1ADA7F510' oid='86CBCF7B0F7746d1B7467D0745570C49' temploid='53CF966B7EC74fa8BD2BEBC16F847790' attrcatref='_000001B18D08D8F0' v='1' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Check Identifier for Uniqueness</TUV>
+</NAME>
+<QUAL>CheckIdentifierForUniqueness</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>no</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>yes</TUV>
+</ETAG>
+</ENUMDEF>
+</DIAGINSTATTS>
+<ECUATTS>
+<ENUMDEF id='_000001B1ADA7FC90' oid='4CCF2C81C09D4bd0A2E413F6F6779B4D' temploid='{D868B540-005B-4134-B690-D924A90E7E07}' attrcatref='_000001B18D08D8F0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Maturity</TUV>
+</NAME>
+<QUAL>Maturity</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>in progress</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>completed</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>verified</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>released</TUV>
+</ETAG>
+</ENUMDEF>
+<UNSDEF id='_000001B1ABDB9040' oid='62CE9DE1A41941feA7B6071DE095CA2E' temploid='BFF7A922ADFD4dfc9B313A217ABAC898' attrcatref='_000001B18D08E130' v='5' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>MaxNumberOfDynDefinedDidReferences</TUV>
+</NAME>
+<QUAL>MaxNumberOfDynDefinedDidReferences</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ABDB84A0' oid='A68BC7E16F9548cd8C2047347552A013' temploid='A08F84D629CC4cd99C36F8828F0531C1' attrcatref='_000001B18D08E130' v='1000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Periodic Rate (Slow) in ms</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only exported if Service $2A with transmissionMode $01 (sendAtSlowRate) is supported.</TUV>
+</DESC>
+<QUAL>Periodic_Rate_Slow_in_ms</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ABDB8690' oid='55CE687B40A146799FCAE00E726FA704' temploid='FBE63A8D027B419394833B66F9950CA4' attrcatref='_000001B18D08E130' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Periodic Rate (Medium) in ms</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only exported if Service $2A with transmissionMode $02 (sendAtMediumRate) is supported.</TUV>
+</DESC>
+<QUAL>Periodic_Rate_Medium_in_ms</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA98170' oid='4D75B76CEA1141b2B42CA0B4C9114E0B' temploid='FF06A0BADCE348dc983363E67E5D1CB8' attrcatref='_000001B18D08E130' v='20' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Periodic Rate (Fast) in ms</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only exported if Service $2A with transmissionMode $03 (sendAtFastRate) is supported.</TUV>
+</DESC>
+<QUAL>Periodic_Rate_Fast_in_ms</QUAL>
+</UNSDEF>
+<CSTRDEF id='_000001B1ADA87370' oid='93E8CA3C569943dc944514EB9F8BD609' temploid='1FBAB3E16F67472084218EDEDF388E7F' attrcatref='_000001B18D08EAD0' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>FUNCTIONAL-GROUP.SHORT-NAME</TUV>
+</NAME>
+<QUAL>FUNCTIONAL_GROUP_SHORT_NAME</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<STRDEF id='_000001B1ADA2A080' oid='5922051A39C64d43BC6FF0B6D9D2C871' temploid='CD3CF6605C134b79BA75B62A012B013E' attrcatref='_000001B18D08EAD0' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>FUNCTIONAL-GROUP.LONG-NAME</TUV>
+</NAME>
+<QUAL>FUNCTIONAL_GROUP_LONG_NAME</QUAL>
+<STRING>
+<TUV xml:lang='en-US'></TUV>
+</STRING>
+</STRDEF>
+<CSTRDEF id='_000001B1ADA88590' oid='44AC9F5E15974b7eA808440E63C12D20' temploid='F18757B601894e6c9222B3BE84B68DED' attrcatref='_000001B18D08EAD0' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>PROTOCOL.SHORT-NAME</TUV>
+</NAME>
+<QUAL>PROTOCOL_SHORT_NAME</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<STRDEF id='_000001B1ADA28A90' oid='98D0495A94FA47689109097C6EC950EF' temploid='DC0A08EE0EBE4ab6B6D71516BDF0D098' attrcatref='_000001B18D08EAD0' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>PROTOCOL.LONG-NAME</TUV>
+</NAME>
+<QUAL>PROTOCOL_LONG_NAME</QUAL>
+<STRING>
+<TUV xml:lang='en-US'></TUV>
+</STRING>
+</STRDEF>
+<CSTRDEF id='_000001B1ADA87AB0' oid='A213382637194125A476A6FAD2A2BA88' temploid='2845FFAF8538460aAB6EC94FD25B1B4F' attrcatref='_000001B18D08EAD0' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>BASE-VARIANT.PARENT-REF.DOCTYPE</TUV>
+</NAME>
+<QUAL>BASE_VARIANT_PARENT_REF_DOCTYPE</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA88760' oid='0A682358A14F473fA0F36654EFD3C3F7' temploid='FE66CB49E9B74e8a91BAFB04C5AEE2DE' attrcatref='_000001B18D08EAD0' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>BASE-VARIANT.PARENT-REF.DOCREF</TUV>
+</NAME>
+<QUAL>BASE_VARIANT_PARENT_REF_DOCREF</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA87540' oid='82A933FAB96D4c5d8353F695386B46FF' temploid='578C060037854f9095C3AE8052C2F67B' attrcatref='_000001B18D08EAD0' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>BASE-VARIANT.PARENT-REF.ID-REF</TUV>
+</NAME>
+<QUAL>BASE_VARIANT_PARENT_REF_ID_REF</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA883C0' oid='FDE65C76CD5447a690FE64ED6C28B238' temploid='307332AE0CA1459d854678744CD58273' attrcatref='_000001B18D08EAD0' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>FUNCTIONAL-GROUP.PARENT-REF.DOCTYPE</TUV>
+</NAME>
+<QUAL>FUNCTIONAL_GROUP_PARENT_REF_DOCTYPE</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA88930' oid='E9A21E51B097498289BB83D1CAAB28D9' temploid='AAB9EC35A65041699FCAB47A408A92D5' attrcatref='_000001B18D08EAD0' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>FUNCTIONAL-GROUP.PARENT-REF.DOCREF</TUV>
+</NAME>
+<QUAL>FUNCTIONAL_GROUP_PARENT_REF_DOCREF</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA9DB50' oid='633D9998CBAE46afAF5D763CF062EBCC' temploid='F9A64A365E38421cAC0AEFDE0DC29343' attrcatref='_000001B18D08EAD0' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>FUNCTIONAL-GROUP.PARENT-REF.ID-REF</TUV>
+</NAME>
+<QUAL>FUNCTIONAL_GROUP_PARENT_REF_ID_REF</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<ENUMDEF id='_000001B1ADA809B0' oid='06F14021530B42a0BFFEB3A895BC7DFF' temploid='18CACDDFC528407e864C9F49E0BC7EA0' attrcatref='_000001B18D08EAD0' mayBeReported='0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>ODX Mode Enabled</TUV>
+</NAME>
+<QUAL>ODX_Mode_Enabled</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>no</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>yes</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADA80050' oid='09DAEE3A5998442a81A8A331847A8CAA' temploid='AEF271723DD54742B7D63C667C00114D' attrcatref='_000001B18D08D8F0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Units</TUV>
+</NAME>
+<QUAL>Units</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>m</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>kg</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>s</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>A</TUV>
+</ETAG>
+<ETAG v='4'>
+<TUV xml:lang='en-US'>K</TUV>
+</ETAG>
+<ETAG v='5'>
+<TUV xml:lang='en-US'>mol</TUV>
+</ETAG>
+<ETAG v='6'>
+<TUV xml:lang='en-US'>cd</TUV>
+</ETAG>
+</ENUMDEF>
+<UNSDEF id='_000001B1ADA973E0' oid='BD269EFB2FBC41fd96F0FFCAD69FA254' temploid='D8A49906DB024f12B313FFD009E0481D' attrcatref='_000001B18D08EAD0' mayBeReported='0' v='4' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Default length of memory size (in Bytes)</TUV>
+</NAME>
+<QUAL>DefaultLengthOfMemorySize</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA979B0' oid='740B0301B2D94859B36412AB8F4ECA21' temploid='EDC3A5BD52774b1bBD13304CEFE8A3A2' attrcatref='_000001B18D08EAD0' mayBeReported='0' v='4' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Default length of memory address (in Bytes)</TUV>
+</NAME>
+<QUAL>DefaultLengthOfMemoryAddress</QUAL>
+</UNSDEF>
+<ENUMDEF id='_000001B1ADA80230' oid='CABD95EF30844c08883696AD1A96F997' temploid='DAEB134C1025445bAEBE5068542517AF' attrcatref='_000001B18D08E130' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>DDDID check per source ID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Perform checks for session, security and mode dependencies per source DID (in DID range 0xF200 to 0xF3FF), while reading DDDIDs via UDS service 0x22 or 0x2A.</TUV>
+</DESC>
+<QUAL>DDDID_check_per_source_ID</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>false</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>true</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADA80B90' oid='C84CA7A08E4945a29C082FE33F5E6D21' temploid='9CD0828A73A7433b84E207798EC73495' attrcatref='_000001B18D08E130' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>DDDID configuration storage</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Deﬁnes whether DDDID deﬁnition is handled as non-volatile information or not.</TUV>
+</DESC>
+<QUAL>DDDID_configuration_storage</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>volatile</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>non volatile</TUV>
+</ETAG>
+</ENUMDEF>
+<CSTRDEF id='_000001B1ADA9E460' oid='9E921B56C3504254ACAAAFFB6AAA677B' temploid='D917BB78FCB84f29AA74A2506B45A56D' attrcatref='_000001B18D08EAD0'>
+<NAME>
+<TUV xml:lang='en-US'>SynchronizationAttribute</TUV>
+</NAME>
+<QUAL>SynchronizationAttribute</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<ENUMDEF id='_000001B1ADAA4E80' oid='E68321B734774f3cB4A2423B0C1CC848' temploid='F486F5119B70447eA2F29F84EF32B70F' attrcatref='_000001B18D08D2C0' usage='sys' v='1' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>CAN 1</TUV>
+</NAME>
+<QUAL>CAN_1</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>not supported</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>supported</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA3F80' oid='51C0D6B46D7C40f0A0D9E1B940FC0655' temploid='EABA18A9CD0A4d199ED75F25F8798121' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Bus Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Type of transport media</TUV>
+</DESC>
+<QUAL>CAN_1.BusType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>CAN</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA4520' oid='2A77BF65B803434fA5169CC10F3782DC' temploid='A657ECEFE47B4452B7DA487A476A1469' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Transport Protocol Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Type of used Transport Protocol (e.g. ISO15765)</TUV>
+</DESC>
+<QUAL>CAN_1.TransportProtocolType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>ISO15765</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA48E0' oid='044D10AFD5AA434fA5E55990C2F00483' temploid='5C4F6532DF1047318CE826743A945DAF' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Addressing Scheme</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Addressing Scheme used for physical requests and responses.</TUV>
+</DESC>
+<QUAL>CAN_1.AddrScheme</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>Normal</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA4340' oid='B24CFD1E90E645afBA94D8810834E79B' temploid='943B1C09D65E4c5687453BAD01C73481' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>CAN-ID Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>CAN-ID Type used for physical requests and responses</TUV>
+</DESC>
+<QUAL>CAN_1.CanIdType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>11-Bit</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>29-Bit</TUV>
+</ETAG>
+</ENUMDEF>
+<UNSDEF id='_000001B1ADA97D90' oid='F6F00B87094C4bc29DFFBD61309D57EB' temploid='25B3A948D9544e1aB86A0D39CB047534' attrcatref='_000001B18D08E4A0' usage='sys' v='1792' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>Request CAN-ID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The request CAN identifier for physical requests. The hex value not only describes the identifier but also the priority of the message. The higher the number, the lower the priority. </TUV>
+</DESC>
+<QUAL>CAN_1.ReqCanId</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA98F00' oid='80D60BDB1658471f8C98A0AD0D5095B5' temploid='A0F58E2923F44123A1D9795039C00E8A' attrcatref='_000001B18D08E4A0' usage='sys' v='1536' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>Response CAN-ID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The response CAN identifier for physical responses.The response for functional requests is sent via the physical path.</TUV>
+</DESC>
+<QUAL>CAN_1.ResCanId</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA97F80' oid='DB6E827385044023881E48491F06B5E5' temploid='5AFC161561A342169FD97731C3EC1D72' attrcatref='_000001B18D08E550' usage='sys' v='150' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Timeout for the client to wait after the successful transmission of a request message for the start of incoming response messages. In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_1.P2Client</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA977C0' oid='8284FB0C2D17481194A3CDE492691277' temploid='3A876B35C1DD42539B3D1AF43A5DA497' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Performance requirement for the server to start with the response message after the reception of a request message. In UDS this is the timeout for the default session.The tester will also require the P2Server timeout, since in UDS service "DiagnosticSessionControl"returns the P2Server and P2*Server timeouts – the tester has to calculate the offset manually and has to add it to the returned P2Server and P2*Server timeouts.</TUV>
+</DESC>
+<QUAL>CAN_1.P2Server</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA98930' oid='49ADCAB18DA14ce28FC8F9F4C0B9C989' temploid='6F4A11861A0541678A923CF25F714984' attrcatref='_000001B18D08E550' usage='sys' v='2000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2*Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Enhanced timeout for the client to wait after the reception of a negative response message with response code 78 hex for the start of incoming response messages. In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_1.P2ExClient</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA97BA0' oid='D2C82F45FA4949f5A8F1034A354F5C15' temploid='09A827E4A2C644869684485F8997F77F' attrcatref='_000001B18D08E550' usage='sys' v='1950' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2*Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Performance requirement for the server to start with the response message after the transmission of a negative response message with response code 78 hex (enhanced response timing). In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_1.P2ExServer</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA98360' oid='93588AE5BA484feb98D2A263BBC977E1' temploid='4122FB02E62E4ed5B72C662CD0A4C32B' attrcatref='_000001B18D08E550' usage='sys' v='4000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>S3Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time between functionally addressed Tester Present request messages transmitted by the client to keep a diagnostic session other than the defaultSession active in multiple servers (functional communication) or maximum time between physically transmitted request messages to a single server (physical communication).</TUV>
+</DESC>
+<QUAL>CAN_1.S3Client</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA990F0' oid='F7DBE1FD47744840BE25961191E54954' temploid='1F320EA045144f8d8908283E8A11D3A7' attrcatref='_000001B18D08E550' usage='sys' v='5000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>S3Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for the server to keep a diagnostic session other than the defaultSession active while not receiving any diagnostic request message</TUV>
+</DESC>
+<QUAL>CAN_1.S3Server</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA98550' oid='4A9F80F4D3FD43aa8018EE8D9299E457' temploid='D67327D7A5FC4ef1A455330B006EA7B0' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P3ClientPhys</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Minimum time for the client to wait after the successful transmission of a physically addressed request message (indicated via N_USData.con) with no response required before it can transmit the next physically addressed request message.
+Minimum value = P2Server</TUV>
+</DESC>
+<QUAL>CAN_1.P3ClientPhys</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA98740' oid='C37979BB6A0D4cb3AE06C3921FD04D95' temploid='70DC91CF5BFF40f3B29D3E73E6A49A9A' attrcatref='_000001B18D08E4A0' usage='sys' v='15872' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>TesterPresentPhys</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Defines the TesterPresent message for physically addressed requests used to keep a diagnostic session active.</TUV>
+</DESC>
+<QUAL>CAN_1.TesterPresentPhys</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA98B20' oid='C90E00B2BD1240808120FF93400AA517' temploid='314D3C0E3A1A47dc8AF9600565BCE057' attrcatref='_000001B18D08E550' usage='sys' v='20' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>STmin</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>(Separation Time) defines the minimum time gap between consecutive frames.Values from 0x00 to 0x7F (0 – 127) are absolute milliseconds.Values from 0xF1 to 0xF9 are even 100 micro seconds.Every other value range is reserved and should not be used.</TUV>
+</DESC>
+<QUAL>CAN_1.StMin</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADA98D10' oid='20A304E04EF94b688D2F5E166A472D7E' temploid='9B15633F98FB4842B2C073E2E49DC363' attrcatref='_000001B18D08E4A0' usage='sys' v='0' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Blocksize</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The Blocksize parameter indicates, how many consecutive frames shall be sent in a transmission before a flow control frame is sent. The number 0 tells the sender, that no more flow controls should disrupt the sending of the remaining flow controls</TUV>
+</DESC>
+<QUAL>CAN_1.Blocksize</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC2FD0' oid='4D0A1545681C4f2195D8141AC6DF577E' temploid='665A7B3BA6E64c2194CEBD441F4A3FBE' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout As</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for transmission of frame, sender side</TUV>
+</DESC>
+<QUAL>CAN_1.TimeoutAs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC2240' oid='96DEB54BC69447378EE168B480CBF89D' temploid='BD37213F001148029F434F7AC87E947A' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Ar</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for transmission of frame, receiver side</TUV>
+</DESC>
+<QUAL>CAN_1.TimeoutAr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC1E60' oid='20D755EA751747b9B0185D12F48263D4' temploid='5A674C85B80E4450A23E635366A5E584' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Bs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until reception of next flow control</TUV>
+</DESC>
+<QUAL>CAN_1.TimeoutBs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC2430' oid='8B45CD68D40D4507992322FF1D1FA9A2' temploid='346F15B1EB5144b9924D426D39D7BF52' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Time Br</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for next transmission of flow control</TUV>
+</DESC>
+<QUAL>CAN_1.TimeBr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC2810' oid='3FE6015504A041769E33A9792F2D3233' temploid='280E83443D44474cB67A898D3B52607F' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Time Cs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until next transmission of consecutive frame</TUV>
+</DESC>
+<QUAL>CAN_1.TimeCs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC2620' oid='60F8AC4412E64478A16B3A4C832B4CB2' temploid='CA5F1FAD00BE43c88990F5595E0D69B1' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Cr</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until reception of next consecutive frame</TUV>
+</DESC>
+<QUAL>CAN_1.TimeoutCr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC31C0' oid='11849C50044549a997644BBB2F91ABFD' temploid='68659A81624D439dA7639BC903A67C49' attrcatref='_000001B18D08E4A0' usage='sys' v='4095' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Max Length of TP Message</TUV>
+</NAME>
+<QUAL>CAN_1.MaxLengthTpMessage</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC16A0' oid='08B749F0FFD04f2c8581166A0622AD29' temploid='F33C69F553DA4061850D09D835C9E80F' attrcatref='_000001B18D08E4A0' usage='sys' v='500000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Baudrate</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Bus Speed of the used transport media. Caution, the Bus Speed has to be set identical in all ECUs connected to one subnet.</TUV>
+</DESC>
+<QUAL>CAN_1.Baudrate</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC2050' oid='FE3BF713634343aa8C91A794BC6DDD30' temploid='8FD258A559594a06AE9F40BF5940149B' attrcatref='_000001B18D08E4A0' usage='sys' v='0' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>CANFrameFillerByte</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Fill byte used for filling CAN frames to eight byte length.</TUV>
+</DESC>
+<QUAL>CAN_1.CANFrameFillerByte</QUAL>
+</UNSDEF>
+<ENUMDEF id='_000001B1ADAA5060' oid='EA0F16ED815349b29D4DB0EED8987D1A' temploid='F94FC6EFFD254e429C5A26907FBE6732' attrcatref='_000001B18D08E4A0' usage='sys' v='1' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>FillerByteHandling</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Enables use of fill bytes; if "true", fill bytes are used, otherwise DLC may be smaller than 8.</TUV>
+</DESC>
+<QUAL>CAN_1.FillerByteHandling</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>false</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>true</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA3440' oid='6AF4AFCCBF8F46aaAA31B8BBD5FABCE3' temploid='4D99BF3241BA424a972D2AAD8CDB838C' attrcatref='_000001B18D08D2C0' usage='sys' v='1' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>CAN 2</TUV>
+</NAME>
+<QUAL>CAN_2</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>not supported</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>supported</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA3800' oid='C5CBFA53CCA24aa09D75CD96D0E7E455' temploid='87232203CCBC46f3A434C07C17E6321E' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Bus Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Type of transport media</TUV>
+</DESC>
+<QUAL>CAN_2.BusType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>CAN</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA4160' oid='78CDF835CF404f4b99BF8E2B8CA17C19' temploid='25C69ADEA5B746508D567A69392BF6DF' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Transport Protocol Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Type of used Transport Protocol (e.g. ISO15765)</TUV>
+</DESC>
+<QUAL>CAN_2.TransportProtocolType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>ISO15765</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA3620' oid='309D5EB8552645879C002AC34798D626' temploid='F7551EFA2D254bb38730493B7137D71E' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Addressing Scheme</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Addressing Scheme used for physical requests and responses.</TUV>
+</DESC>
+<QUAL>CAN_2.AddrScheme</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>Normal</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA3BC0' oid='F7A10771C4B34ac8B8203E0EFD026F0B' temploid='76744F1CB8D048288D336746AF9DDC52' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>CAN-ID Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>CAN-ID Type used for physical requests and responses</TUV>
+</DESC>
+<QUAL>CAN_2.CanIdType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>11-Bit</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>29-Bit</TUV>
+</ETAG>
+</ENUMDEF>
+<UNSDEF id='_000001B1ADAC14B0' oid='51D06DA91BD24813AAE22A47AE35B2DD' temploid='3583D130D06A4c53B210A6D8CD154E76' attrcatref='_000001B18D08E4A0' usage='sys' v='1792' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>Request CAN-ID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The request CAN identifier for physical requests. The hex value not only describes the identifier but also the priority of the message. The higher the number, the lower the priority. </TUV>
+</DESC>
+<QUAL>CAN_2.ReqCanId</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC2A00' oid='EEF9593EAC6B4e9cB0D5A2DB0E3D83DB' temploid='81DC8F9C673E4df889EABC5580421CAE' attrcatref='_000001B18D08E4A0' usage='sys' v='1536' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>Response CAN-ID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The response CAN identifier for physical responses.The response for functional requests is sent via the physical path.</TUV>
+</DESC>
+<QUAL>CAN_2.ResCanId</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC2BF0' oid='8863BDEF10F246009FFDB7A6ECC7C274' temploid='6DAB5E5BA78B42699CFD5FE7777655B1' attrcatref='_000001B18D08E550' usage='sys' v='150' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Timeout for the client to wait after the successful transmission of a request message for the start of incoming response messages. In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_2.P2Client</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC1890' oid='1EB646B5E67748ae8AC0073115B403AB' temploid='9B99AD5FB5054349ACEEB79A3DC6281B' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Performance requirement for the server to start with the response message after the reception of a request message. In UDS this is the timeout for the default session.The tester will also require the P2Server timeout, since in UDS service "DiagnosticSessionControl"returns the P2Server and P2*Server timeouts – the tester has to calculate the offset manually and has to add it to the returned P2Server and P2*Server timeouts.</TUV>
+</DESC>
+<QUAL>CAN_2.P2Server</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC2DE0' oid='0AFE27F819BE40faAA86AD1D75F990EC' temploid='0028499BE08C4d6498620A85998C2BCF' attrcatref='_000001B18D08E550' usage='sys' v='2000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2*Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Enhanced timeout for the client to wait after the reception of a negative response message with response code 78 hex for the start of incoming response messages. In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_2.P2ExClient</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAC1A80' oid='394C1B224C62448e8D0C03BBC0AD588A' temploid='A1EB2E01860042cd81F224D0BEC77CB6' attrcatref='_000001B18D08E550' usage='sys' v='1950' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2*Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Performance requirement for the server to start with the response message after the transmission of a negative response message with response code 78 hex (enhanced response timing). In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_2.P2ExServer</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACD1F0' oid='B5616E7D4C354bd99D58F66F5D113EE0' temploid='2C14D2686A2D4d70B05A608E2081F0BC' attrcatref='_000001B18D08E550' usage='sys' v='4000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>S3Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time between functionally addressed Tester Present request messages transmitted by the client to keep a diagnostic session other than the defaultSession active in multiple servers (functional communication) or maximum time between physically transmitted request messages to a single server (physical communication).</TUV>
+</DESC>
+<QUAL>CAN_2.S3Client</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACCE10' oid='F26F552C989C411dB51A9F6DD2C60622' temploid='C87CEF61A148426d97D1AACF4B91F305' attrcatref='_000001B18D08E550' usage='sys' v='5000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>S3Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for the server to keep a diagnostic session other than the defaultSession active while not receiving any diagnostic request message</TUV>
+</DESC>
+<QUAL>CAN_2.S3Server</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACB8C0' oid='3C2E9D441576410aAA34921859A22B16' temploid='0E57B80DFCD74efd90FB2A6C9669B541' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P3ClientPhys</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Minimum time for the client to wait after the successful transmission of a physically addressed request message (indicated via N_USData.con) with no response required before it can transmit the next physically addressed request message.
+Minimum value = P2Server</TUV>
+</DESC>
+<QUAL>CAN_2.P3ClientPhys</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACBAB0' oid='CD3555171781463bBB5069CFB1109A91' temploid='1C2080E854804267BC9F53DE325FDB19' attrcatref='_000001B18D08E4A0' usage='sys' v='15872' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>TesterPresentPhys</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Defines the TesterPresent message for physically addressed requests used to keep a diagnostic session active.</TUV>
+</DESC>
+<QUAL>CAN_2.TesterPresentPhys</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACB4E0' oid='2F2F9EBA26CF4608A880F1F5733C0EFB' temploid='8A62D8F8AD9B4229A182C4D9482A5F0D' attrcatref='_000001B18D08E550' usage='sys' v='20' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>STmin</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>(Separation Time) defines the minimum time gap between consecutive frames.Values from 0x00 to 0x7F (0 – 127) are absolute milliseconds.Values from 0xF1 to 0xF9 are even 100 micro seconds.Every other value range is reserved and should not be used.</TUV>
+</DESC>
+<QUAL>CAN_2.StMin</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACCA30' oid='95AA868FE432419d9E9D050D1AD29826' temploid='75DDF28A1B30489eA6D1175988526E43' attrcatref='_000001B18D08E4A0' usage='sys' v='0' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Blocksize</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The Blocksize parameter indicates, how many consecutive frames shall be sent in a transmission before a flow control frame is sent. The number 0 tells the sender, that no more flow controls should disrupt the sending of the remaining flow controls</TUV>
+</DESC>
+<QUAL>CAN_2.Blocksize</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACC270' oid='8927A45EDDAE4352A39672DE9A5B7A1F' temploid='7F705665FDBF4e59ABFB58DC61EBAEA0' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout As</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for transmission of frame, sender side</TUV>
+</DESC>
+<QUAL>CAN_2.TimeoutAs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACC460' oid='94CA348FB9AA492aA9F1D9A2EF7BF89E' temploid='DA47EC4748964883AF6D051ED01BD74C' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Ar</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for transmission of frame, receiver side</TUV>
+</DESC>
+<QUAL>CAN_2.TimeoutAr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACC080' oid='A1AE8C795A9E4f6b9F637C160C67F9C2' temploid='3B25621DEED043a1B2A0CBB0E39206E0' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Bs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until reception of next flow control</TUV>
+</DESC>
+<QUAL>CAN_2.TimeoutBs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACC650' oid='8030C5EF8B1C4d4fA5A6411DCD3E4839' temploid='19649FF8C13C4d648B8DBF9B6FA3126B' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Time Br</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for next transmission of flow control</TUV>
+</DESC>
+<QUAL>CAN_2.TimeBr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACC840' oid='2D8F4192749B46c08C38C3A74B24E021' temploid='45F29A5922B64bb3A35D399CA9D5DED3' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Time Cs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until next transmission of consecutive frame</TUV>
+</DESC>
+<QUAL>CAN_2.TimeCs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACCC20' oid='2B9E3CE1558D4829A3BE3E9FA0A6FFE8' temploid='61CB58CA70294caaB81564ACF4664B8A' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Cr</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until reception of next consecutive frame</TUV>
+</DESC>
+<QUAL>CAN_2.TimeoutCr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACBCA0' oid='4650AA3BA93A4e21A134FFF7B39DEB1C' temploid='965FD11F7CCC47f785B563DA77722C10' attrcatref='_000001B18D08E4A0' usage='sys' v='4095' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Max Length of TP Message</TUV>
+</NAME>
+<QUAL>CAN_2.MaxLengthTpMessage</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACD000' oid='037C4E5C2A274980B52DA6BF922308BE' temploid='B791263FD14645e3BC0AD48B847A8C91' attrcatref='_000001B18D08E4A0' usage='sys' v='500000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Baudrate</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Bus Speed of the used transport media. Caution, the Bus Speed has to be set identical in all ECUs connected to one subnet.</TUV>
+</DESC>
+<QUAL>CAN_2.Baudrate</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADACBE90' oid='FE7236BDBAD14cb5A9E2466299F08AF0' temploid='7F056B50610D49f99A0F52F08F19D2B9' attrcatref='_000001B18D08E4A0' usage='sys' v='0' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>CANFrameFillerByte</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Fill byte used for filling CAN frames to eight byte length.</TUV>
+</DESC>
+<QUAL>CAN_2.CANFrameFillerByte</QUAL>
+</UNSDEF>
+<ENUMDEF id='_000001B1ADAA4CA0' oid='EA7AB3FB90D645c58E23773C5C2724E6' temploid='E017925859D6488f8A97002AD66486AE' attrcatref='_000001B18D08E4A0' usage='sys' v='1' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>FillerByteHandling</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Enables use of fill bytes; if "true", fill bytes are used, otherwise DLC may be smaller than 8.</TUV>
+</DESC>
+<QUAL>CAN_2.FillerByteHandling</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>false</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>true</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA39E0' oid='10C4F178E8064ea1ACC6D780FB757005' temploid='687CF2E29E864045BE6DF1FFFE369D0E' attrcatref='_000001B18D08D2C0' usage='sys' v='1' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>CAN 3</TUV>
+</NAME>
+<QUAL>CAN_3</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>not supported</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>supported</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA3DA0' oid='105FA9FF25B245fd9CF97AFE7EDA8904' temploid='555CB0BF965B4484AEDD0FAF0C851647' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Bus Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Type of transport media</TUV>
+</DESC>
+<QUAL>CAN_3.BusType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>CAN</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA4700' oid='6EEB566928E041efB5AA27A46D6A73FC' temploid='4440F3B7C2F5461eAEC1E52A64406045' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Transport Protocol Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Type of used Transport Protocol (e.g. ISO15765)</TUV>
+</DESC>
+<QUAL>CAN_3.TransportProtocolType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>ISO15765</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADAA4AC0' oid='386E2D9486F7461e9918AA3DE135CFBB' temploid='4C3603CD5A24418cBF301470704ED9F2' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Addressing Scheme</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Addressing Scheme used for physical requests and responses.</TUV>
+</DESC>
+<QUAL>CAN_3.AddrScheme</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>Normal</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADADB700' oid='1A1904ED2AAA496eABE4E0557C8A284E' temploid='EAA8F44E6E194694B7D57E40EA1D1C20' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>CAN-ID Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>CAN-ID Type used for physical requests and responses</TUV>
+</DESC>
+<QUAL>CAN_3.CanIdType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>11-Bit</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>29-Bit</TUV>
+</ETAG>
+</ENUMDEF>
+<UNSDEF id='_000001B1ADAC1C70' oid='189E700F24534f4a831DA4EFE88FE5B9' temploid='68791DDB9DC74722ADE63FC0A499CC4A' attrcatref='_000001B18D08E4A0' usage='sys' v='1792' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>Request CAN-ID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The request CAN identifier for physical requests. The hex value not only describes the identifier but also the priority of the message. The higher the number, the lower the priority. </TUV>
+</DESC>
+<QUAL>CAN_3.ReqCanId</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADE4B0' oid='E74FE4C4FEA244e2BD58DF53D5417089' temploid='9AA841FA07F84efd9F3AD42895761F8F' attrcatref='_000001B18D08E4A0' usage='sys' v='1536' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>Response CAN-ID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The response CAN identifier for physical responses.The response for functional requests is sent via the physical path.</TUV>
+</DESC>
+<QUAL>CAN_3.ResCanId</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADDB00' oid='9A27E2993FAE4220B9ECC2609F42863E' temploid='9F383E5F826E4cf295DD343CCAAA2CA5' attrcatref='_000001B18D08E550' usage='sys' v='150' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Timeout for the client to wait after the successful transmission of a request message for the start of incoming response messages. In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_3.P2Client</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADEC70' oid='6FEDAC6C18494ddbAAAA44B894BCFC6B' temploid='A34C342E84FF45119706F7EF681A8D9B' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Performance requirement for the server to start with the response message after the reception of a request message. In UDS this is the timeout for the default session.The tester will also require the P2Server timeout, since in UDS service "DiagnosticSessionControl"returns the P2Server and P2*Server timeouts – the tester has to calculate the offset manually and has to add it to the returned P2Server and P2*Server timeouts.</TUV>
+</DESC>
+<QUAL>CAN_3.P2Server</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADD720' oid='6B07BC516DEF4752A3C444C662C24357' temploid='E40C8E79C98D411e9D3C0F6F5A78A6B6' attrcatref='_000001B18D08E550' usage='sys' v='2000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2*Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Enhanced timeout for the client to wait after the reception of a negative response message with response code 78 hex for the start of incoming response messages. In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_3.P2ExClient</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADD910' oid='A3663CBE98BD4fcaADFA4F108C7582BA' temploid='48109036C7BD486b8F770CCC32D18DB3' attrcatref='_000001B18D08E550' usage='sys' v='1950' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2*Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Performance requirement for the server to start with the response message after the transmission of a negative response message with response code 78 hex (enhanced response timing). In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_3.P2ExServer</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADE0D0' oid='F1EDB037FE3943ecB463923CBFE5FBDA' temploid='7656196FBDCF4cba9FAB840F97AF79F7' attrcatref='_000001B18D08E550' usage='sys' v='4000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>S3Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time between functionally addressed Tester Present request messages transmitted by the client to keep a diagnostic session other than the defaultSession active in multiple servers (functional communication) or maximum time between physically transmitted request messages to a single server (physical communication).</TUV>
+</DESC>
+<QUAL>CAN_3.S3Client</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADDCF0' oid='0A2C94ABE6AF4fcbA1B6AFB9B4034C9E' temploid='9828CE15A2C747b1AD211B4E4D86CE02' attrcatref='_000001B18D08E550' usage='sys' v='5000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>S3Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for the server to keep a diagnostic session other than the defaultSession active while not receiving any diagnostic request message</TUV>
+</DESC>
+<QUAL>CAN_3.S3Server</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADEE60' oid='EC8E5B761F274556A1481F43A66C3E6F' temploid='38F0EF7FF1944a8d8A900A1AC56D12DF' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P3ClientPhys</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Minimum time for the client to wait after the successful transmission of a physically addressed request message (indicated via N_USData.con) with no response required before it can transmit the next physically addressed request message.
+Minimum value = P2Server</TUV>
+</DESC>
+<QUAL>CAN_3.P3ClientPhys</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADD530' oid='67AC4BD38D6747d6971E00158B2E52C6' temploid='2DB230866CBA4940B72F76AA18CE2C96' attrcatref='_000001B18D08E4A0' usage='sys' v='15872' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>TesterPresentPhys</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Defines the TesterPresent message for physically addressed requests used to keep a diagnostic session active.</TUV>
+</DESC>
+<QUAL>CAN_3.TesterPresentPhys</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADE2C0' oid='C86E13E1DBD0477aBCDE4D645A8BA507' temploid='7BCA12C731554a1dBBEDB771D8FC1721' attrcatref='_000001B18D08E550' usage='sys' v='20' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>STmin</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>(Separation Time) defines the minimum time gap between consecutive frames.Values from 0x00 to 0x7F (0 – 127) are absolute milliseconds.Values from 0xF1 to 0xF9 are even 100 micro seconds.Every other value range is reserved and should not be used.</TUV>
+</DESC>
+<QUAL>CAN_3.StMin</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADE6A0' oid='F59AD96557424da0B3B2A73B270CC07D' temploid='2444F94CC2BB4b968C1DBEF949035485' attrcatref='_000001B18D08E4A0' usage='sys' v='0' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Blocksize</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The Blocksize parameter indicates, how many consecutive frames shall be sent in a transmission before a flow control frame is sent. The number 0 tells the sender, that no more flow controls should disrupt the sending of the remaining flow controls</TUV>
+</DESC>
+<QUAL>CAN_3.Blocksize</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADF240' oid='1BD386ACE6EF4080AB9527CF597BED20' temploid='26E8B2A604384bf5ADFAF2F680ABBBA9' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout As</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for transmission of frame, sender side</TUV>
+</DESC>
+<QUAL>CAN_3.TimeoutAs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADDEE0' oid='54D02F4CFFFE4709AAAA47B48FC882C6' temploid='B931952994D44836BBE882B40B839130' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Ar</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for transmission of frame, receiver side</TUV>
+</DESC>
+<QUAL>CAN_3.TimeoutAr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADE890' oid='6C60CDD3731D49278B51938C736B7E18' temploid='F3B8EC3021F04a39AF28E9E7887D06A2' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Bs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until reception of next flow control</TUV>
+</DESC>
+<QUAL>CAN_3.TimeoutBs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADADEA80' oid='BCC7A67E58AE41b98650CAC87C7A8CEC' temploid='9B6B43BBEF9A4c4c8A9C47967C3C0313' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Time Br</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for next transmission of flow control</TUV>
+</DESC>
+<QUAL>CAN_3.TimeBr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAEE500' oid='4F244B73005F4cf69D220EBE68443170' temploid='A21BEB74F8B1428997F5F2D370B143AE' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Time Cs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until next transmission of consecutive frame</TUV>
+</DESC>
+<QUAL>CAN_3.TimeCs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAEF0A0' oid='CA901450D2D24127A2C84997F5ED26CC' temploid='EB066522B63C4964A9E0096B32662AC6' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Cr</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until reception of next consecutive frame</TUV>
+</DESC>
+<QUAL>CAN_3.TimeoutCr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAEE8E0' oid='1F684ED9ADB945b18ED81B8698255F34' temploid='23D56C2ADE5C4476A1BC70154B1019C4' attrcatref='_000001B18D08E4A0' usage='sys' v='4095' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Max Length of TP Message</TUV>
+</NAME>
+<QUAL>CAN_3.MaxLengthTpMessage</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAEDF30' oid='26F14FDF6D3545cd9CA054ADC52B7AA4' temploid='B315F2EAFA2D40e38DE84C5E9A37F145' attrcatref='_000001B18D08E4A0' usage='sys' v='500000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Baudrate</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Bus Speed of the used transport media. Caution, the Bus Speed has to be set identical in all ECUs connected to one subnet.</TUV>
+</DESC>
+<QUAL>CAN_3.Baudrate</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAEF290' oid='60B9D154F70844488F8C683793106B8A' temploid='C93551EFD94C419393E390FD8582480A' attrcatref='_000001B18D08E4A0' usage='sys' v='0' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>CANFrameFillerByte</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Fill byte used for filling CAN frames to eight byte length.</TUV>
+</DESC>
+<QUAL>CAN_3.CANFrameFillerByte</QUAL>
+</UNSDEF>
+<ENUMDEF id='_000001B1ADADBE80' oid='4ED22B6F487F41ec98728C0520C0CEA4' temploid='D64BE740F2FA4ded8DF315977522515F' attrcatref='_000001B18D08E4A0' usage='sys' v='1' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>FillerByteHandling</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Enables use of fill bytes; if "true", fill bytes are used, otherwise DLC may be smaller than 8.</TUV>
+</DESC>
+<QUAL>CAN_3.FillerByteHandling</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>false</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>true</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADADC060' oid='ECCF3C7DE96D40b8B30CE524958B8E5D' temploid='D7331148953643e9B476EEA6CA0BD897' attrcatref='_000001B18D08D2C0' usage='sys' v='1' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>CAN Extended</TUV>
+</NAME>
+<QUAL>CAN_Extended</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>not supported</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>supported</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADADB8E0' oid='3122188927CB45ebA8A6B5CE2268909B' temploid='CFA8495AE7014324B71AF490CA1501C4' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Bus Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Type of transport media</TUV>
+</DESC>
+<QUAL>CAN_Extended.BusType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>CAN</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADADC7E0' oid='01DA29F9C8314cc1A8F4BA28B3283158' temploid='8FAFE5D910EF42f1A8938826742B8363' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Transport Protocol Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Type of used Transport Protocol (e.g. ISO15765)</TUV>
+</DESC>
+<QUAL>CAN_Extended.TransportProtocolType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>ISO15765</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADADC240' oid='1BA77FF277994cdeA0E530F6DC549D93' temploid='3F93CF4832124c2e8148D584D66F0BB5' attrcatref='_000001B18D08E4A0' usage='sys' v='1' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Addressing Scheme</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Addressing Scheme used for physical requests and responses.</TUV>
+</DESC>
+<QUAL>CAN_Extended.AddrScheme</QUAL>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>Extended</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADADC9C0' oid='1F9D1E7245CB45759A39BF55A18E325E' temploid='382282C95AB144f7B3B919FC14CA6257' attrcatref='_000001B18D08E4A0' usage='sys' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>CAN-ID Type</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>CAN-ID Type used for physical requests and responses</TUV>
+</DESC>
+<QUAL>CAN_Extended.CanIdType</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>11-Bit</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>29-Bit</TUV>
+</ETAG>
+</ENUMDEF>
+<UNSDEF id='_000001B1ADAED580' oid='F45930FCB9A347b2B23CA24DD76AD7A5' temploid='679ABCDCF29E41b9B7FAC99FC7518B44' attrcatref='_000001B18D08E4A0' usage='sys' v='1792' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>Request CAN-ID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The request CAN identifier for physical requests. The hex value not only describes the identifier but also the priority of the message. The higher the number, the lower the priority. </TUV>
+</DESC>
+<QUAL>CAN_Extended.ReqCanId</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAEEAD0' oid='B12D73F58D5942c49430E076E203B352' temploid='464B99FBB0D6481a91148F131811BF0C' attrcatref='_000001B18D08E4A0' usage='sys' v='1536' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>Response CAN-ID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The response CAN identifier for physical responses.The response for functional requests is sent via the physical path.</TUV>
+</DESC>
+<QUAL>CAN_Extended.ResCanId</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAEE120' oid='29D82EC3440941248B010B15BF915FC6' temploid='4DF96B876D1B4d49941D0AE0EFD0DC65' attrcatref='_000001B18D08E4A0' usage='sys' v='1' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>ECU Address</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Physical diagnostic address of the ECU.</TUV>
+</DESC>
+<QUAL>CAN_Extended.EcuAddress</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAEE310' oid='D189E66C2EED40e2B6D8FDBE8C23E386' temploid='1DB218CAC0EB479c9F3040A2F109633B' attrcatref='_000001B18D08E4A0' usage='sys' v='241' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>Tester Address</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Using this Addressing Scheme, the Tester Address can not be determined by the ECU during runtime. Therefore the Tester Address has to be fixed.</TUV>
+</DESC>
+<QUAL>CAN_Extended.TesterAddress</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAEE6F0' oid='85F1148065234c9cABABCC2DAAFA82A9' temploid='FFE8EFC2EFED46fcBF977597184F5449' attrcatref='_000001B18D08E550' usage='sys' v='150' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Timeout for the client to wait after the successful transmission of a request message for the start of incoming response messages. In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_Extended.P2Client</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAEECC0' oid='E0507F1D00D6447a8F81CC917E6E2126' temploid='3BC13D67DB844bddA98B2246B3EE2A54' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Performance requirement for the server to start with the response message after the reception of a request message. In UDS this is the timeout for the default session.The tester will also require the P2Server timeout, since in UDS service "DiagnosticSessionControl"returns the P2Server and P2*Server timeouts – the tester has to calculate the offset manually and has to add it to the returned P2Server and P2*Server timeouts.</TUV>
+</DESC>
+<QUAL>CAN_Extended.P2Server</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAED960' oid='118CB8D033194724AFD70E115908B45F' temploid='2A48D328D728473d92B61C8E2D38DC90' attrcatref='_000001B18D08E550' usage='sys' v='2000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2*Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Enhanced timeout for the client to wait after the reception of a negative response message with response code 78 hex for the start of incoming response messages. In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_Extended.P2ExClient</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAED770' oid='59675F90637A407982529A7129746BDC' temploid='D3433A7ABD1F433a969E4B325E0A97AB' attrcatref='_000001B18D08E550' usage='sys' v='1950' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P2*Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Performance requirement for the server to start with the response message after the transmission of a negative response message with response code 78 hex (enhanced response timing). In UDS this is the timeout for the default session.</TUV>
+</DESC>
+<QUAL>CAN_Extended.P2ExServer</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFC910' oid='262A849A018D44cd86F66BDF828AAC71' temploid='34B8879ED87D493092721E912538011F' attrcatref='_000001B18D08E550' usage='sys' v='4000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>S3Client</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time between functionally addressed Tester Present request messages transmitted by the client to keep a diagnostic session other than the defaultSession active in multiple servers (functional communication) or maximum time between physically transmitted request messages to a single server (physical communication).</TUV>
+</DESC>
+<QUAL>CAN_Extended.S3Client</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFBD70' oid='F73DC6E058BC4c9a88C2DB43C70510D1' temploid='869635C105C542b587D4198DFD0523D3' attrcatref='_000001B18D08E550' usage='sys' v='5000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>S3Server</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for the server to keep a diagnostic session other than the defaultSession active while not receiving any diagnostic request message</TUV>
+</DESC>
+<QUAL>CAN_Extended.S3Server</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFB7A0' oid='878E293244EE45a19C8C7EB33C1CF445' temploid='709359853B5D4307A551AC1699D766B1' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>P3ClientPhys</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Minimum time for the client to wait after the successful transmission of a physically addressed request message (indicated via N_USData.con) with no response required before it can transmit the next physically addressed request message.
+Minimum value = P2Server</TUV>
+</DESC>
+<QUAL>CAN_Extended.P3ClientPhys</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFBF60' oid='4FA357C291ED4f02905D6026C3F6598A' temploid='778282AC3A154bb8965459ECD08761CC' attrcatref='_000001B18D08E4A0' usage='sys' v='15872' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>TesterPresentPhys</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Defines the TesterPresent message for physically addressed requests used to keep a diagnostic session active.</TUV>
+</DESC>
+<QUAL>CAN_Extended.TesterPresentPhys</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFB990' oid='396FF81E95EE41d59421CCAA71F8DFED' temploid='292D9CBB26C44ec88D1C72003EADBEFE' attrcatref='_000001B18D08E550' usage='sys' v='20' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>STmin</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>(Separation Time) defines the minimum time gap between consecutive frames.Values from 0x00 to 0x7F (0 – 127) are absolute milliseconds.Values from 0xF1 to 0xF9 are even 100 micro seconds.Every other value range is reserved and should not be used.</TUV>
+</DESC>
+<QUAL>CAN_Extended.StMin</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFB5B0' oid='D9177A13CC894c7c92834FA1E6930B7D' temploid='89457BC3AE004daaBDA5EA3E017958E6' attrcatref='_000001B18D08E4A0' usage='sys' v='0' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Blocksize</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The Blocksize parameter indicates, how many consecutive frames shall be sent in a transmission before a flow control frame is sent. The number 0 tells the sender, that no more flow controls should disrupt the sending of the remaining flow controls</TUV>
+</DESC>
+<QUAL>CAN_Extended.Blocksize</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFCB00' oid='CCDE2654AD114e6580F0FEA0D51100AA' temploid='75EADA49D1674fb8AEAF7541DDD6581A' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout As</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for transmission of frame, sender side</TUV>
+</DESC>
+<QUAL>CAN_Extended.TimeoutAs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFC150' oid='6DA34ED1DF4E4dabA26B922D1C972157' temploid='D730C536A9B44bb0BE84133981E1822D' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Ar</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for transmission of frame, receiver side</TUV>
+</DESC>
+<QUAL>CAN_Extended.TimeoutAr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFC340' oid='FF25D3123F3D44a7A5A34D462B47B168' temploid='A8EC1653C70740a988CBC1191DD9BD1A' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Bs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until reception of next flow control</TUV>
+</DESC>
+<QUAL>CAN_Extended.TimeoutBs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFCCF0' oid='F5B5F57341384f85A9F07EC9E07D0799' temploid='609A951D466D4d1185EF7DCF69957F27' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Time Br</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time for next transmission of flow control</TUV>
+</DESC>
+<QUAL>CAN_Extended.TimeBr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFC530' oid='5C1EE18BA199414dBF050EF8665CA018' temploid='A6A72E681C6F4dadBFA17698234E9F0A' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Time Cs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until next transmission of consecutive frame</TUV>
+</DESC>
+<QUAL>CAN_Extended.TimeCs</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFCEE0' oid='513696EADF1444eaB2CD9CA99A1D8EFE' temploid='24452FC5F82243a4ACA9281863495183' attrcatref='_000001B18D08E550' usage='sys' v='100' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Timeout Cr</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Time until reception of next consecutive frame</TUV>
+</DESC>
+<QUAL>CAN_Extended.TimeoutCr</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFD2C0' oid='F0D9C9D2CCAF4c95AB44E84CF557C04A' temploid='8A351D248467423390C628DD22402F01' attrcatref='_000001B18D08E4A0' usage='sys' v='4095' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Max Length of TP Message</TUV>
+</NAME>
+<QUAL>CAN_Extended.MaxLengthTpMessage</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFD0D0' oid='185A77A6329D4fc897C1CFBFDF2806AB' temploid='FC1E769241554145A091D8BE8DE60F65' attrcatref='_000001B18D08E4A0' usage='sys' v='500000' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Baudrate</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Bus Speed of the used transport media. Caution, the Bus Speed has to be set identical in all ECUs connected to one subnet.</TUV>
+</DESC>
+<QUAL>CAN_Extended.Baudrate</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAFC720' oid='6F41B7745B644a9c8357EAD049F5302D' temploid='F849FB9BFA224db89B83FFC1C66589AC' attrcatref='_000001B18D08E4A0' usage='sys' v='0' df='hex'>
+<NAME>
+<TUV xml:lang='en-US'>CANFrameFillerByte</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Fill byte used for filling CAN frames to eight byte length.</TUV>
+</DESC>
+<QUAL>CAN_Extended.CANFrameFillerByte</QUAL>
+</UNSDEF>
+<ENUMDEF id='_000001B1ADADBCA0' oid='1EAFC9D8720645ebABB2791D0FCD9C72' temploid='34423F5EA95C47e9B33D01D7C8246CDE' attrcatref='_000001B18D08E4A0' usage='sys' v='1' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>FillerByteHandling</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Enables use of fill bytes; if "true", fill bytes are used, otherwise DLC may be smaller than 8.</TUV>
+</DESC>
+<QUAL>CAN_Extended.FillerByteHandling</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>false</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>true</TUV>
+</ETAG>
+</ENUMDEF>
+</ECUATTS>
+<JOBATTS>
+<ENUMDEF id='_000001B1ADADC420' oid='433195BFB3574a4eAF09529DDFD6C4BD' temploid='{576E708C-C091-4f05-A7F4-75480DB66DB9}' attrcatref='_000001B18D08D8F0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Maturity</TUV>
+</NAME>
+<QUAL>Maturity</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>in progress</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>completed</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>verified</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>released</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADADBAC0' oid='C641146232CA467291EC3AC801FF2419' temploid='FCBCD4001CBE46c08D58A3F3B1031283' attrcatref='_000001B18D08EAD0' xauth='m' mayBeReported='0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Skip deactivation of Job during ODX-Import</TUV>
+</NAME>
+<QUAL>SkipDeactivationOfJobDuringODXImport</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>no</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>yes</TUV>
+</ETAG>
+</ENUMDEF>
+</JOBATTS>
+<JOBCNRATTS>
+<ENUMDEF id='_000001B1ADADC600' oid='654F279E15074ab3ADDC5B1498EF708A' temploid='{1B7B7175-4C38-4a2e-AE6D-57CD5095361D}' attrcatref='_000001B18D08D8F0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Maturity</TUV>
+</NAME>
+<QUAL>Maturity</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>in progress</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>completed</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>verified</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>released</TUV>
+</ETAG>
+</ENUMDEF>
+</JOBCNRATTS>
+<RECORDATTS>
+<ENUMDEF id='_000001B1ADADCF60' oid='D5920EE026A842eeB3565ECF0D03ACFA' temploid='{532FBFB3-950D-4394-A2CB-517F71678CBF}' attrcatref='_000001B18D08D0B0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Status</TUV>
+</NAME>
+<QUAL>Status</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>in progress</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>completed</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>verified</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>released</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADADCBA0' oid='B2C54A2D725B479181A6F6CBFAFC98DC' temploid='916383D28E3E488bBC1C05E116776F08' attrcatref='_000001B18D08EAD0' xauth='m' mayBeReported='0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>DOCTYPE</TUV>
+</NAME>
+<QUAL>DOCTYPE</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>CONTAINER</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>PROTOCOL</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>LAYER</TUV>
+</ETAG>
+</ENUMDEF>
+<CSTRDEF id='_000001B1ADA9D7B0' oid='D1527DFF75F941b0983D41535122137A' temploid='5D8A4CE76FCE4f418304E4374F4DF723' attrcatref='_000001B18D08EAD0' xauth='m' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>DOCREF</TUV>
+</NAME>
+<QUAL>DOCREF</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA9D980' oid='3CD66FC722364e56AC939C7E474A54ED' temploid='E687A987F5EA43fb9F79ED64643752FB' attrcatref='_000001B18D08EAD0' xauth='m' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>ID-REF</TUV>
+</NAME>
+<QUAL>ID_REF</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<UNSDEF id='_000001B1ADAEDD40' oid='5F6906228AF042659128264098B81130' temploid='93EC0986657F40758F2676D6B21BD15F' attrcatref='_000001B18D08EAD0' xauth='r' mayBeReported='0' v='0' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>Source Error Code</TUV>
+</NAME>
+<QUAL>Source_Error_Code</QUAL>
+</UNSDEF>
+<CSTRDEF id='_000001B1ADA9E630' oid='3E1D5397DBF44a91BF763448C5E0E0DC' temploid='052B5FED3EC34a759F9095B14FF76EEF' attrcatref='_000001B18D08EAD0' xauth='r' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>Source Error Text</TUV>
+</NAME>
+<QUAL>Source_Error_Text</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA9E800' oid='FF35529612D342c88254C5B8CDB7EB77' temploid='0EC1F68F1F244e43AA28B23776757818' attrcatref='_000001B18D08D580'>
+<NAME>
+<TUV xml:lang='en-US'>ASR SWC DataElement Ref</TUV>
+</NAME>
+<QUAL>ASR_SWC_DataElement_Ref</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA9E9D0' oid='4A95C859EA274a168EFF5D1C6D313B3C' temploid='F42D03137D0F4b57AAEDCAFAF4BAB060' attrcatref='_000001B18D08D580'>
+<NAME>
+<TUV xml:lang='en-US'>ASR SWC ServiceDependency Ref</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Path to the system description service dependency that is related to the CANdela DTC. It is set by SWC Sync and evaluated by DEXT export.</TUV>
+</DESC>
+<QUAL>ASR_SWC_ServiceDependency_Ref</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA9ED70' oid='EC4DE26E30D7497fB570DF71EF4696D8' temploid='E60C848A0F2B41dcBC7D6FF8F25538DC' attrcatref='_000001B18D08EAD0' listable='1' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>SYNCHELEMENT</TUV>
+</NAME>
+<QUAL>SYNCHELEMENT</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+</RECORDATTS>
+<SERVICEATTS>
+<ENUMDEF id='_000001B1ADADCD80' oid='B4E726EA0133436fA38028349AFE4920' temploid='{58ED6E89-3E0E-4d23-9375-D556F735ECE3}' attrcatref='_000001B18D08D630' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>MainHandlerSupport (on Service Level)</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Provide MainHandler for current service (Service/Subfunction combination). Restriction: Only evaluated if attribute 'MainHandlerSupport (on Protocol Service Level)' of diagnostic class is not set, i.e. equals to 'none'.</TUV>
+</DESC>
+<QUAL>MainHandlerSupport</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>user</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>oem</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>generated</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADADD140' oid='3835442040A4448a9EC3DF87E7B019A4' temploid='{D1C90887-2B71-46cd-91B2-F18383C97D66}' attrcatref='_000001B18D08D630' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>PreHandlerSupport</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Provide type of Service PreServiceHandler for current service (Service/Subfunction combination). The Service PreHandler is executed directly before the main handler. Restriction: Only evaluated if attribute 'MainHandlerSupport (on Protocol Service Level)' of diagnostic class is not set, i.e. equals to 'none'.</TUV>
+</DESC>
+<QUAL>PreHandlerSupport</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>none</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>oem</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>user</TUV>
+</ETAG>
+</ENUMDEF>
+<STRDEF id='_000001B1ADA29810' oid='53BFD983F1D44cfbAF39A942EA6BCEFC' temploid='{206A373F-266C-44f2-A314-456065718B43}' attrcatref='_000001B18D08D630'>
+<NAME>
+<TUV xml:lang='en-US'>PreHandlerOverrideName</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Provide alternative name for Service PreHandler instead of generated one (default prefix + PreHandlerOverrideName). You can reuse one Service PreHandler for different services, if you specify the same override name. Restriction: Only evaluated if attribute 'MainHandlerSupport (on Protocol Service Level)' is not set, i.e. equals to 'none'.</TUV>
+</DESC>
+<QUAL>PreHandlerOverrideName</QUAL>
+<STRING>
+<TUV xml:lang='en-US'></TUV>
+</STRING>
+</STRDEF>
+<ENUMDEF id='_000001B1ADADB520' oid='CF607F9573974c89A253EA679111ABFE' temploid='{D7E3971B-5719-47b8-A7C2-179086D2D468}' attrcatref='_000001B18D08D630' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>PostHandlerSupport</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Provide type of Service PostServiceHandler for current service (Service/Subfunction combination). The Service PostHandler is executed after a positive confirmation of the positive response. Restriction: Only evaluated if attribute 'MainHandlerSupport (on Protocol Service Level)' is not set, i.e. equals to 'none'.</TUV>
+</DESC>
+<QUAL>PostHandlerSupport</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>none</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>oem</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>user</TUV>
+</ETAG>
+</ENUMDEF>
+<STRDEF id='_000001B1ADA299C0' oid='F7E82BC5DA71476aB999B38B7A70801A' temploid='{53782236-7E95-40e6-921C-AAADCB6C406C}' attrcatref='_000001B18D08D630'>
+<NAME>
+<TUV xml:lang='en-US'>PostHandlerOverrideName</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Provide alternative name for Service PostHandler instead of generated one (default prefix + PostHandlerOverrideName). You can reuse one Service PostHandler for different Services, if you specify the same Override Name. Restriction: Only evaluated if attribute 'MainHandlerSupport (on Protocol Service Level)' of diagnostic class is not set, i.e. equals to 'none'.</TUV>
+</DESC>
+<QUAL>PostHandlerOverrideName</QUAL>
+<STRING>
+<TUV xml:lang='en-US'></TUV>
+</STRING>
+</STRDEF>
+<SGNDEF id='_000001B1ADB14150' oid='A2C70C9F33B64d5eBE7099E9B1DBC456' temploid='{C79E93E5-5CAD-4987-8735-2910097EB6BB}' attrcatref='_000001B18D08EA20' v='-2001'>
+<NAME>
+<TUV xml:lang='en-US'>Example of a service attribute</TUV>
+</NAME>
+<QUAL>ExampleOfAServiceAttr</QUAL>
+</SGNDEF>
+<ENUMDEF id='_000001B1ADB146F0' oid='C92BC72777C74dc1824ADD9CEDC4391A' temploid='{DBDAC500-A1C9-4e3f-B15E-50697CADE29A}' attrcatref='_000001B18D08D8F0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Maturity</TUV>
+</NAME>
+<QUAL>Maturity</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>in progress</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>completed</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>verified</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>released</TUV>
+</ETAG>
+</ENUMDEF>
+<ENUMDEF id='_000001B1ADB148D0' oid='9665D93657E84f8cBFFD0A91F2D50881' temploid='852B27286CEF41c6B0A621B757F99A0C' attrcatref='_000001B18D08EAD0' xauth='m' mayBeReported='0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>DIAG-LAYER</TUV>
+</NAME>
+<QUAL>DIAG_LAYER</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>not specified</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>PROTOCOL</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>FUNCTIONAL-GROUP</TUV>
+</ETAG>
+</ENUMDEF>
+<STRDEF id='_000001B1ADA2A230' oid='0CA4F58721974c6aA3CBAACF5587FB68' temploid='42FD183D9A4748ddB6DFFA84C36C1B9A' attrcatref='_000001B18D08EAD0' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>Description</TUV>
+</NAME>
+<QUAL>Description</QUAL>
+<STRING>
+<TUV xml:lang='en-US'></TUV>
+</STRING>
+</STRDEF>
+</SERVICEATTS>
+<VARATTS>
+<ENUMDEF id='_000001B1ADB14E70' oid='7250874F8F6A435bAC9EE8595D20CFD0' temploid='{ED80C6F3-913F-4569-BA58-A8451D97D3C2}' attrcatref='_000001B18D08D8F0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Maturity</TUV>
+</NAME>
+<QUAL>Maturity</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>in progress</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>completed</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>verified</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>released</TUV>
+</ETAG>
+</ENUMDEF>
+</VARATTS>
+<STATEGROUPATTS>
+<CSTRDEF id='_000001B1ADA9D410' oid='B04C268208E749b985AC0C65EBC77F24' temploid='0991BE3AF0E2434c975D4A1897E9E028' attrcatref='_000001B18D08EAD0' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>Semantic</TUV>
+</NAME>
+<QUAL>Semantic</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+</STATEGROUPATTS>
+<DCLTMPLATTS>
+<ENUMDEF id='_000001B1ADB13D90' oid='2F7026FFD920431aB822990D33322CCE' temploid='16EF4EF827AA407f8A39D2130EFC88AC' attrcatref='_000001B18D08EAD0' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>Export as TABLE</TUV>
+</NAME>
+<QUAL>Export_as_TABLE</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>no</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>yes (Dynamic TABLE)</TUV>
+</ETAG>
+<ETAG v='2'>
+<TUV xml:lang='en-US'>yes (Static TABLE)</TUV>
+</ETAG>
+<ETAG v='3'>
+<TUV xml:lang='en-US'>yes (Static TABLE with dynamic POS-RESPONSE)</TUV>
+</ETAG>
+</ENUMDEF>
+<CSTRDEF id='_000001B1ADA9E0C0' oid='DED6C06AE49942cbBE71481CED96D8A1' temploid='A2A164D21BE8461fAE0BAB970166A7FB' attrcatref='_000001B18D08EAD0' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>TABLE.SHORT-NAME</TUV>
+</NAME>
+<QUAL>TABLE_SHORT_NAME</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA9EBA0' oid='81AE13AE25284f7d861DA89E46472AAB' temploid='201C463CA89E4db795EAF260190B59E8' attrcatref='_000001B18D08EAD0' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>TABLE.SEMANTIC</TUV>
+</NAME>
+<QUAL>TABLE_SEMANTIC</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<STRDEF id='_000001B1ADA29B70' oid='3302298A82594400A70C7D4A9B93E3CB' temploid='4E6A2D553AC74732ABDA99D7BAAB7629' attrcatref='_000001B18D08EAD0' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>TABLE.LONG-NAME</TUV>
+</NAME>
+<QUAL>TABLE_LONG_NAME</QUAL>
+<STRING>
+<TUV xml:lang='en-US'></TUV>
+</STRING>
+</STRDEF>
+</DCLTMPLATTS>
+<DCLSRVTMPLATTS>
+<CSTRDEF id='_000001B1ADA9DD20' oid='A82588A3D27F4317A0B782160F1075C1' temploid='64F4C4CFA5AC4f1c8EC7A7575C98A8CC' attrcatref='_000001B18D08EAD0' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>TABLE.SHORT-NAME</TUV>
+</NAME>
+<QUAL>TABLE_SHORT_NAME</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA9DEF0' oid='9D8E4E04AAEC44f98E78178A48AF0666' temploid='54F4474953E64803996B391B5BCCC908' attrcatref='_000001B18D08EAD0' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>TABLE.SEMANTIC</TUV>
+</NAME>
+<QUAL>TABLE_SEMANTIC</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<STRDEF id='_000001B1ADA29D20' oid='0628ADAD37F2467c965F308A7A16FBBB' temploid='97249CB2CA924f358A520488107CDF11' attrcatref='_000001B18D08EAD0' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>TABLE.LONG-NAME</TUV>
+</NAME>
+<QUAL>TABLE_LONG_NAME</QUAL>
+<STRING>
+<TUV xml:lang='en-US'></TUV>
+</STRING>
+</STRDEF>
+<ENUMDEF id='_000001B1ADB15050' oid='5A74029F5B3F44bfA4F5803FAD90B288' temploid='F5C04BFBEBE047b6A1820B1624B30379' attrcatref='_000001B18D08EAD0' xauth='m' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>UsePrimitiveInTableName</TUV>
+</NAME>
+<QUAL>UsePrimitiveInTableName</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>no</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>yes</TUV>
+</ETAG>
+</ENUMDEF>
+</DCLSRVTMPLATTS>
+<SHPROXYATTS>
+<CSTRDEF id='_000001B1ADA9EF40' oid='5AF86C1A695D420194FFAF6ED89EAF88' temploid='5AB63BC4177F4bdc9D0E595BDEF4D462' attrcatref='_000001B18D08EAD0' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>TABLE.SHORT-NAME</TUV>
+</NAME>
+<QUAL>TABLE_SHORT_NAME</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<CSTRDEF id='_000001B1ADA9F110' oid='629BDDA739CE400c930E081626B35AE2' temploid='5F708A2ADBA14cad8A849FE0C2E2BC4C' attrcatref='_000001B18D08EAD0' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>TABLE.SEMANTIC</TUV>
+</NAME>
+<QUAL>TABLE_SEMANTIC</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<STRDEF id='_000001B1ADA29660' oid='53C2764429B346e28B18BDF0188D0B1F' temploid='D8AE2716FF824efa88C06EE32D78E92C' attrcatref='_000001B18D08EAD0' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>TABLE.LONG-NAME</TUV>
+</NAME>
+<QUAL>TABLE_LONG_NAME</QUAL>
+<STRING>
+<TUV xml:lang='en-US'></TUV>
+</STRING>
+</STRDEF>
+</SHPROXYATTS>
+<DIDATTS>
+<CSTRDEF id='_000001B1ADA9D5E0' oid='4F25B202ABD54bb8B2AD20C8B2B94A11' temploid='F49F07E901734489863C7A043F88BE09' attrcatref='_000001B18D08D8F0'>
+<NAME>
+<TUV xml:lang='en-US'>SYNCHELEMENT</TUV>
+</NAME>
+<QUAL>SYNCHELEMENT</QUAL>
+<COMMONSTRING></COMMONSTRING>
+</CSTRDEF>
+<UNSDEF id='_000001B1ADAEEEB0' oid='FE7BF305F0EF48b9A67CE31E7D15BA97' temploid='973C05067E4A4807A4C6AACA3156BD41' attrcatref='_000001B18D08CBE0' v='0' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>ASR3 Legacy Combine DID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>If non-zero, DEXT export creates one element for the entire DID.
+Set this to simplify the port mapping (but the software component must unpack the element to get at the DID data).</TUV>
+</DESC>
+<QUAL>ASR3_Legacy_Combine_DID</QUAL>
+</UNSDEF>
+<UNSDEF id='_000001B1ADAEDB50' oid='5486E9832F0D499cB5C20BDF82E84759' attrcatref='_000001B18D08D840' xauth='m' mayBeReported='0' v='0' df='dec'>
+<NAME>
+<TUV xml:lang='en-US'>DIDNumber81</TUV>
+</NAME>
+<QUAL>DIDNumber81</QUAL>
+</UNSDEF>
+<CSTRDEF id='_000001B1ADB2E6A0' oid='933712F473874c27B4388C8AAD8B50F4' attrcatref='_000001B18D08D8F0' xauth='rm' mayBeReported='0'>
+<NAME>
+<TUV xml:lang='en-US'>Method</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Who
+When
+Why</TUV>
+</DESC>
+<QUAL>Method</QUAL>
+<COMMONSTRING>TbD</COMMONSTRING>
+</CSTRDEF>
+</DIDATTS>
+</DEFATTS>
+<AUTHORS>
+<AUTHOR id='_000001B18D0898D0' obs='0' responsible='1'>
+<LASTNAME>Önür</LASTNAME>
+<FIRSTNAME>Atabey</FIRSTNAME>
+<SHORTNAME>AÖ</SHORTNAME>
+<COMPANY>ME</COMPANY>
+</AUTHOR>
+<AUTHOR id='_000001B18D0894D0' obs='0'>
+<LASTNAME>Reghunath</LASTNAME>
+<FIRSTNAME>Sarath</FIRSTNAME>
+<SHORTNAME>SR</SHORTNAME>
+<COMPANY>ME</COMPANY>
+</AUTHOR>
+<AUTHOR id='_000001B18D089CD0' obs='0'>
+<LASTNAME>Zwirner</LASTNAME>
+<FIRSTNAME>Julius </FIRSTNAME>
+<SHORTNAME>JZ</SHORTNAME>
+<COMPANY>ME</COMPANY>
+</AUTHOR>
+</AUTHORS>
+<HISTITEMS>
+<HISTITEM authorref='_000001B18D0898D0' stid='0' tool='CANdelaStudio 10 ReleasePatch 4  Admin' dt='2021-05-03 10:52:16+02:00'>
+<LABEL>0.1</LABEL>
+<MOD>initial draft</MOD>
+<REASON></REASON>
+</HISTITEM>
+<HISTITEM authorref='_000001B18D0898D0' stid='2' tool='CANdelaStudio 10 ReleasePatch 4  Admin' dt='2021-05-05 11:52:59+02:00'>
+<LABEL>0.2</LABEL>
+<MOD>odx compliance</MOD>
+<REASON></REASON>
+</HISTITEM>
+<HISTITEM authorref='_000001B18D089CD0' stid='0' tool='CANdelaStudio 10 ReleasePatch 2  Admin' dt='2021-11-12 11:21:03+01:00'>
+<LABEL>0.3</LABEL>
+<MOD>Aded state request control for debugging purposes</MOD>
+<REASON>CAN state control not yet implemented</REASON>
+</HISTITEM>
+</HISTITEMS>
+<TARGETGROUPS>
+<TARGETGROUP oid='C30638AD00D044e7B3E0C28244B5E690' temploid='{BB4F40AA-2B43-41b3-AC66-55BA5C9700DC}'>
+<NAME>
+<TUV xml:lang='en-US'>Development</TUV>
+</NAME>
+<QUAL>Development</QUAL>
+</TARGETGROUP>
+<TARGETGROUP oid='998044F03A1745bf893097F5075FFFDF' temploid='{D564A96D-0051-4730-8B4F-BF9A38DD3567}'>
+<NAME>
+<TUV xml:lang='en-US'>Manufacturing</TUV>
+</NAME>
+<QUAL>Manufacturing</QUAL>
+</TARGETGROUP>
+<TARGETGROUP oid='8AA4EE6D8EE4416bA6B723D515986CD8' temploid='{93A9802F-D0CA-4929-99E6-197352197D52}'>
+<NAME>
+<TUV xml:lang='en-US'>Service</TUV>
+</NAME>
+<QUAL>Service</QUAL>
+</TARGETGROUP>
+<TARGETGROUP oid='94267D7D7A49455cBE88CBCCBA978149' temploid='4E61F54727CA4170ACD022162AF9881E'>
+<NAME>
+<TUV xml:lang='en-US'>Legislated</TUV>
+</NAME>
+<QUAL>Legislated</QUAL>
+</TARGETGROUP>
+</TARGETGROUPS>
+<NEGRESCODES bl='8' bo='21' stateGroupDefault='34'>
+<NEGRESCODE id='_000001B1ADB02950' oid='5A5E1B778A584d4bBA9CB077CE9D5753' temploid='{5A212CD7-8053-4225-9AF5-C81256A622CB}' v='16'>
+<NAME>
+<TUV xml:lang='en-US'>General reject</TUV>
+</NAME>
+<QUAL>General_reject</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB02C50' oid='8D6B164ABAB645759B016297E9FB8BFB' temploid='{BD2975AF-378D-4c53-9BF1-C704344BB7DC}' v='17'>
+<NAME>
+<TUV xml:lang='en-US'>Service not supported</TUV>
+</NAME>
+<QUAL>Service_not_supported</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB02A50' oid='FC93F5961D6147b0B26082583608D9F1' temploid='{80C2D695-E8D7-47f3-B00E-99BE5D368CD7}' v='18'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction not supported</TUV>
+</NAME>
+<QUAL>Subfunction_not_supported</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB02DD0' oid='E608DA099C124fabA5BB41A24FBE748F' temploid='{1A51AEF2-AE78-48e6-83C4-B327A82F6B2F}' v='19'>
+<NAME>
+<TUV xml:lang='en-US'>Incorrect message length or invalid format</TUV>
+</NAME>
+<QUAL>Incorrect_message_length_or_invalid_format</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB02E50' oid='725A66A17E964b0e855243308817F74F' temploid='{96F8BF29-BE84-4f1b-8C1A-A89AD0E87A03}' v='20'>
+<NAME>
+<TUV xml:lang='en-US'>Response too long</TUV>
+</NAME>
+<QUAL>Response_too_long</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB032D0' oid='9BB4BB4249F742b98A8186234E5A7E9E' temploid='{D554803F-2F91-42c8-849A-DC5D70A19416}' v='33'>
+<NAME>
+<TUV xml:lang='en-US'>Busy repeat request</TUV>
+</NAME>
+<QUAL>Busy_repeat_request</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB32870' oid='11E51A5C5A2548239C855482666A0C61' temploid='{49B5EF28-B74C-4eb9-A142-415EA5B3DBB6}' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>Conditions not correct</TUV>
+</NAME>
+<QUAL>Conditions_not_correct</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB32BF0' oid='DC402C19EB3A41c09899025198B6DDF0' temploid='{494E1654-2EA0-4752-8D8C-A29CF4700334}' v='36'>
+<NAME>
+<TUV xml:lang='en-US'>Request sequence error</TUV>
+</NAME>
+<QUAL>Request_sequence_error</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB325F0' oid='5D8588D520D948688FB63D6B0C57E762' temploid='{F6CEC3CF-1BD9-42c3-936C-02F00969DD0A}' v='49'>
+<NAME>
+<TUV xml:lang='en-US'>Request out of range</TUV>
+</NAME>
+<QUAL>Request_out_of_range</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB316F0' oid='ABC9C6F0FDB9426d89A5227DC0E3DE75' temploid='{5E1B9F8B-7FE7-4eda-BDB8-C7D0FAB1F9D6}' v='51'>
+<NAME>
+<TUV xml:lang='en-US'>Security access denied</TUV>
+</NAME>
+<QUAL>Security_access_denied</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB33570' oid='71278AF10102440bB6DC41532C99002A' temploid='{A81E9C63-D58E-460d-B255-61CD688B687E}' v='53'>
+<NAME>
+<TUV xml:lang='en-US'>Invalid key</TUV>
+</NAME>
+<QUAL>Invalid_key</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB333F0' oid='8C2AD8DA4E434b3b9AD9C73198348473' temploid='{AC348CC7-A2A6-4fbd-A2C4-DF2C50883B35}' v='54'>
+<NAME>
+<TUV xml:lang='en-US'>Exceed number of attempts</TUV>
+</NAME>
+<QUAL>Exceed_number_of_attempts</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB324F0' oid='8E957C1FE5F3466a9EE155AB8EDB626F' temploid='{714D7B28-3660-4560-B72D-3191FDD7DA29}' v='55'>
+<NAME>
+<TUV xml:lang='en-US'>Required time delay not expired</TUV>
+</NAME>
+<QUAL>Required_time_delay_not_expired</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB31EF0' oid='7D6183A8B3524ad6B3F32D2879DA4E07' temploid='{14B0BA89-73D8-4dae-8590-7ED33468EE49}' v='112'>
+<NAME>
+<TUV xml:lang='en-US'>Upload / Download not accepted</TUV>
+</NAME>
+<QUAL>Upload_Download_not_accepted</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB31970' oid='84977A01F1BC4ccd9844D90FE7640168' temploid='{CF094B6D-9721-4fb7-9DB6-96B37708C3D2}' v='113'>
+<NAME>
+<TUV xml:lang='en-US'>Transfer data suspended</TUV>
+</NAME>
+<QUAL>Transfer_data_suspended</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB319F0' oid='E39FBE8C37124afc8FCB476835A787A2' temploid='{59AEDE24-6CED-481a-999B-E72B1804942F}' v='114'>
+<NAME>
+<TUV xml:lang='en-US'>General programming failure</TUV>
+</NAME>
+<QUAL>General_programming_failure</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB32A70' oid='8E048002C04A4cafAFEDD63209510B79' temploid='{11F7148B-10F1-4e3b-923C-A4F4E629BF8F}' v='115'>
+<NAME>
+<TUV xml:lang='en-US'>Wrong block sequence counter</TUV>
+</NAME>
+<QUAL>Wrong_block_sequence_counter</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB32C70' oid='35746BFF606D41eaBFE22F4494CAF5EB' temploid='{D6DF6702-21FE-43a1-981A-C5514EE7E764}' v='120'>
+<NAME>
+<TUV xml:lang='en-US'>Request correctly received - response pending</TUV>
+</NAME>
+<QUAL>Request_correctly_received_response_pending</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB322F0' oid='738C867FE95C4943AC7BB40DDDA1D422' temploid='{7A789812-B188-463c-BF48-9DA06B9D911B}' v='126'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction not supported in active session</TUV>
+</NAME>
+<QUAL>Subfunction_not_supported_in_active_session</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB330F0' oid='7586AB9EF5DD4687BE8F35460E500177' temploid='{3086D7DA-6702-4cd6-B2A6-5310B08403C5}' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>Service not supported in active session</TUV>
+</NAME>
+<QUAL>Service_not_supported_in_active_session</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB31770' oid='AAEE6222EAC546c68DC6D9EE053A5DE6' temploid='{90AF5957-BF7C-468d-B203-AE79BEB54C01}' v='129'>
+<NAME>
+<TUV xml:lang='en-US'>RPM too high</TUV>
+</NAME>
+<QUAL>RPM_too_high</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB31D70' oid='3FE56BAECCCE4b36A58D8845054644D6' temploid='{E4293909-9126-48a1-ACEB-2469415BEBAB}' v='130'>
+<NAME>
+<TUV xml:lang='en-US'>RPM too low</TUV>
+</NAME>
+<QUAL>RPM_too_low</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB317F0' oid='1A59C26228A846ea905058BCFCD24A12' temploid='{653640F9-1C43-48de-A97D-6EFFAE320CE0}' v='131'>
+<NAME>
+<TUV xml:lang='en-US'>Engine is running</TUV>
+</NAME>
+<QUAL>Engine_is_running</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB32370' oid='9789FB204320450aBA717F02CEECD230' temploid='{01B0BE7D-B121-43ed-AD3A-9153CE3FE1F5}' v='132'>
+<NAME>
+<TUV xml:lang='en-US'>Engine is not running</TUV>
+</NAME>
+<QUAL>Engine_is_not_running</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB31870' oid='FDAFD694AF71406c96D8531F2BB16A7B' temploid='{548F6801-AA02-4405-8E40-C8CFB618D938}' v='133'>
+<NAME>
+<TUV xml:lang='en-US'>Engine runtime too low</TUV>
+</NAME>
+<QUAL>Engine_runtime_too_low</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB32170' oid='9047BA067833490093F9A8CE76C4CC72' temploid='{8EE4BB4D-F856-4e81-9CF9-94A135C479C5}' v='134'>
+<NAME>
+<TUV xml:lang='en-US'>Temperature too high</TUV>
+</NAME>
+<QUAL>Temperature_too_high</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB323F0' oid='E804B4EF735B4196BFDAD20C0F7EB828' temploid='{B30CCC2D-B54A-493f-B1CF-785CE849B507}' v='135'>
+<NAME>
+<TUV xml:lang='en-US'>Temperature too low</TUV>
+</NAME>
+<QUAL>Temperature_too_low</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB318F0' oid='35E8B986D4A64cf48568CD1660CA90F1' temploid='{8C68B7FE-452D-4939-B238-BE386DA3CD63}' v='136'>
+<NAME>
+<TUV xml:lang='en-US'>Vehicle speed too high</TUV>
+</NAME>
+<QUAL>Vehicle_speed_too_high</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB31AF0' oid='E3A29A4D5B5641c98D6C2CBE5E745655' temploid='{761A3222-190D-4004-AE7F-E6C52505B62D}' v='137'>
+<NAME>
+<TUV xml:lang='en-US'>Vehicle speed too low</TUV>
+</NAME>
+<QUAL>Vehicle_speed_too_low</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB32970' oid='2C064E51CD8C4d44BCAD0437071252C4' temploid='{1A496F29-5395-4efd-BC5F-E9F3BFFC678A}' v='138'>
+<NAME>
+<TUV xml:lang='en-US'>Throttle / Pedal too high</TUV>
+</NAME>
+<QUAL>Throttle_Pedal_too_high</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB329F0' oid='25435222225E46c2A5507D10A6983655' temploid='{CFF9A82A-5EB5-4a03-8E77-5CC93610169C}' v='139'>
+<NAME>
+<TUV xml:lang='en-US'>Throttle / Pedal too low</TUV>
+</NAME>
+<QUAL>Throttle_Pedal_too_low</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB32DF0' oid='FE4A2A07E5F84283B2A85FF9DD230134' temploid='{4CFD7387-2697-4f8d-A2EE-15EB05ACF2F4}' v='140'>
+<NAME>
+<TUV xml:lang='en-US'>Transmission range not in neutral</TUV>
+</NAME>
+<QUAL>Transmission_range_not_in_neutral</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB32E70' oid='177B2102EDF9430aB05E02272CEAD5E3' temploid='{85D1358F-B6D4-4202-AE7A-0797FD4902D8}' v='141'>
+<NAME>
+<TUV xml:lang='en-US'>Transmission range not in gear</TUV>
+</NAME>
+<QUAL>Transmission_range_not_in_gear</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB33070' oid='79265A9C019C49ceB9A983E9024C7B3A' temploid='{559B40CA-AC21-4854-8228-D399FBF79CF6}' v='143'>
+<NAME>
+<TUV xml:lang='en-US'>Break switch(es) not closed</TUV>
+</NAME>
+<QUAL>Break_switch_es_not_closed</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB33170' oid='0CD010B34E9847d5875FDA44A6E81F02' temploid='{B56A9488-D4D7-4f43-92E4-8904AB663BC9}' v='144'>
+<NAME>
+<TUV xml:lang='en-US'>Shifter lever not in park</TUV>
+</NAME>
+<QUAL>Shifter_lever_not_in_park</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB31C70' oid='9359A588160341fbB617E53E2A7C4BBD' temploid='{8AF85FBE-4E9E-4a66-AC5E-E77DCFE48B92}' v='145'>
+<NAME>
+<TUV xml:lang='en-US'>Torque converter clutch locked</TUV>
+</NAME>
+<QUAL>Torque_converter_clutch_locked</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB33370' oid='49685E664EF54fd89342DE17EC267910' temploid='{EB0E66D4-4A22-484a-9F4B-6062AAA6D99F}' v='146'>
+<NAME>
+<TUV xml:lang='en-US'>Voltage too high</TUV>
+</NAME>
+<QUAL>Voltage_too_high</QUAL>
+</NEGRESCODE>
+<NEGRESCODE id='_000001B1ADB30470' oid='C22617198CAC4ab69A8149EEADD432FB' temploid='{DF09EF41-0FF1-413e-840E-093A26BDD105}' v='147'>
+<NAME>
+<TUV xml:lang='en-US'>Voltage too low</TUV>
+</NAME>
+<QUAL>Voltage_too_low</QUAL>
+</NEGRESCODE>
+</NEGRESCODES>
+<STATEGROUPS>
+<STATEGROUP oid='CD71121A33D2404fADB43B2DC4E6D5B9' temploid='{79248E0C-ACAC-4b55-B40C-5CB726C21152}' spec='session'>
+<NAME>
+<TUV xml:lang='en-US'>Session</TUV>
+</NAME>
+<QUAL>Session</QUAL>
+<STATE oid='711324EAD3E341b6A00366FE2C204F43' temploid='{800CCB35-12C8-4971-A9D3-4C47BF911EC5}'>
+<NAME>
+<TUV xml:lang='en-US'>Default</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>{P2=50, P2Ex=5000}</TUV>
+</DESC>
+<QUAL>Default</QUAL>
+</STATE>
+<STATE oid='CA117E5EA64D47eeBFCEED564FAD67A3' temploid='{4454F7E7-6CD8-4a7e-8A9F-717437C00161}'>
+<NAME>
+<TUV xml:lang='en-US'>Programming</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>{P2=50, P2Ex=5000}</TUV>
+</DESC>
+<QUAL>Programming</QUAL>
+</STATE>
+<STATE oid='E21C5CDC56F842e9B6EF82A531345801' temploid='{9D13BD42-38B4-430b-B0B4-8D70F4C4FB35}'>
+<NAME>
+<TUV xml:lang='en-US'>Extended</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>{P2=50, P2Ex=5000}</TUV>
+</DESC>
+<QUAL>Extended</QUAL>
+</STATE>
+<STATE oid='1123F78F2125482b93C57F419C23D240'>
+<NAME>
+<TUV xml:lang='en-US'>StandBy</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>{P2 = 20, P2Ex = 2000}</TUV>
+</DESC>
+<QUAL>StandBy</QUAL>
+</STATE>
+<STATE oid='FA6937DEB9844b118CE09EA60E4984A0'>
+<NAME>
+<TUV xml:lang='en-US'>SafetySystem</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>{P2 = 20, P2Ex = 2000}</TUV>
+</DESC>
+<QUAL>SafetySystem</QUAL>
+</STATE>
+<STATE oid='1974C94B9A644b3e816D4F3D9473A420'>
+<NAME>
+<TUV xml:lang='en-US'>ACCU_EOL</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>{P2 = 20, P2Ex = 2000}</TUV>
+</DESC>
+<QUAL>ACCU_EOL</QUAL>
+</STATE>
+<STATE oid='CBA1F15613CA4b2f846231C97056DC4C'>
+<NAME>
+<TUV xml:lang='en-US'>BMS_Supplier_EOL</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>{P2 = 20, P2Ex = 2000}</TUV>
+</DESC>
+<QUAL>BMS_Supplier_EOL</QUAL>
+</STATE>
+<STATE oid='6D607305D9B94f539F19323242149C5B'>
+<NAME>
+<TUV xml:lang='en-US'>Supplier</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>{P2 = 20, P2Ex = 2000}</TUV>
+</DESC>
+<QUAL>Supplier</QUAL>
+</STATE>
+<STATE oid='2F1274051741421a9607264FFBE1F7E6'>
+<NAME>
+<TUV xml:lang='en-US'>DECAT</TUV>
+</NAME>
+<QUAL>DECAT</QUAL>
+</STATE>
+<STATE oid='30BCB2F4DA1F41df8D09BAC0FAB63072'>
+<NAME>
+<TUV xml:lang='en-US'>Update Session</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>{P2 = 20, P2Ex = 2000}</TUV>
+</DESC>
+<QUAL>Update_Session</QUAL>
+</STATE>
+<NEGRESCODEPROXY idref='_000001B1ADB322F0'/>
+</STATEGROUP>
+<STATEGROUP oid='C1AA1D57D1B04b7bA8B34A1CD64B1A19' temploid='F8654B3136DE4283B450781D2E40BEA1' spec='security'>
+<NAME>
+<TUV xml:lang='en-US'>SecurityAccess</TUV>
+</NAME>
+<QUAL>SecurityAccess</QUAL>
+<STATE oid='6BC62E15A9EC4c3dAB29D9C36A73C294' temploid='C5ABF6281C604b35989CB6E3C5205BBE'>
+<NAME>
+<TUV xml:lang='en-US'>Locked</TUV>
+</NAME>
+<QUAL>Locked</QUAL>
+</STATE>
+<STATE oid='7F75989101D441d484DDAD6CC19BF6FE' temploid='1F6144C3936A4b4b939991B96C41CCA2'>
+<NAME>
+<TUV xml:lang='en-US'>Unlocked L1</TUV>
+</NAME>
+<QUAL>UnlockedL1</QUAL>
+</STATE>
+<STATE oid='5BA0782D5BDF4b7cA64272952090841F'>
+<NAME>
+<TUV xml:lang='en-US'>Unlocked Level One</TUV>
+</NAME>
+<QUAL>Unlocked_Level_One</QUAL>
+</STATE>
+<STATE oid='8C0B478192F348f899FFEE8DA31A9553'>
+<NAME>
+<TUV xml:lang='en-US'>Unlocked Level Two</TUV>
+</NAME>
+<QUAL>Unlocked_Level_Two</QUAL>
+</STATE>
+<STATE oid='794FD93937234ac68D0D234614A5A5A0'>
+<NAME>
+<TUV xml:lang='en-US'>Level 1</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only within Level 1 secured and unsecured Services executable.</TUV>
+</DESC>
+<QUAL>Level_1</QUAL>
+</STATE>
+<STATE oid='91DD5308594F456d9AF38AB6EF2D4CFB'>
+<NAME>
+<TUV xml:lang='en-US'>Level B</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only Services with Level B or unsecured Services are executable.</TUV>
+</DESC>
+<QUAL>Level_B</QUAL>
+</STATE>
+<STATE oid='E9BF352F7EEC4c889482F0350538396C'>
+<NAME>
+<TUV xml:lang='en-US'>Level 11</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only Services with Level 11 or unsecured Services are executable.</TUV>
+</DESC>
+<QUAL>Level_11</QUAL>
+</STATE>
+<STATE oid='C2031A34F3E44b13813305AD7C9F8BB6'>
+<NAME>
+<TUV xml:lang='en-US'>Level 61</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>EOL ACCU</TUV>
+</DESC>
+<QUAL>Level_61</QUAL>
+</STATE>
+<STATE oid='7FAA57C8659D4e3b9B1DD4FD2F203805'>
+<NAME>
+<TUV xml:lang='en-US'>Level 63</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>EOL Hella</TUV>
+</DESC>
+<QUAL>Level_63</QUAL>
+</STATE>
+<STATE oid='4C1C1083692A4b1bAAC7DC231ECDB02D'>
+<NAME>
+<TUV xml:lang='en-US'>Level 9</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only Services with Level 9 or unsecured Services are executable.</TUV>
+</DESC>
+<QUAL>Level_9</QUAL>
+</STATE>
+<STATE oid='85E2BD56281648e6B540714639CA9588'>
+<NAME>
+<TUV xml:lang='en-US'>Level 7</TUV>
+</NAME>
+<QUAL>Level_7</QUAL>
+</STATE>
+<STATE oid='E13B8F4FBF0240a3A3AD10B7461651B5'>
+<NAME>
+<TUV xml:lang='en-US'>Level 3</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only Services with Level 3 or unsecured Services are executable.</TUV>
+</DESC>
+<QUAL>Level_3</QUAL>
+</STATE>
+<STATE oid='C45F52973514426b83A7EC7120282D37'>
+<NAME>
+<TUV xml:lang='en-US'>SAR Read</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only Services with Level SAR Read or unsecured Services are executable.</TUV>
+</DESC>
+<QUAL>SAR_Read</QUAL>
+</STATE>
+<STATE oid='13B57F1320154826A3DE62FD4791613F'>
+<NAME>
+<TUV xml:lang='en-US'>SAR Remove</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only Services with Level SAR Remove or unsecured Services are executable.</TUV>
+</DESC>
+<QUAL>SAR_Remove</QUAL>
+</STATE>
+<STATE oid='6BD395429467457f970AA24A4C6E666D'>
+<NAME>
+<TUV xml:lang='en-US'>Level 5F</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only Services with Level 5F or unsecured Services are executable.</TUV>
+</DESC>
+<QUAL>Level_5F</QUAL>
+</STATE>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</STATEGROUP>
+</STATEGROUPS>
+<VCKMGR vckmode='none' vckmin='0' vckmax='0' vcknext='0'/>
+<DATATYPES>
+<IDENT id='_000001B1AD958480' oid='61331A4D01BE402aAA1F868DF44A9499' temploid='{314FFC95-0532-4f9f-B3A5-885EE7EC4636}' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>HexDump (1 Byte)</TUV>
+</NAME>
+<QUAL>HexDump_1Byte</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1AD958EA0' oid='FFA56E3A5DCA477dB0F7FA3272070A20' temploid='{D06EF0D6-509C-49db-8DB7-CD7948BDAA7A}' bm='65535'>
+<NAME>
+<TUV xml:lang='en-US'>HexDump (2 Byte)</TUV>
+</NAME>
+<QUAL>HexDump_2Byte</QUAL>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1AD9590E0' oid='7C0E632246604da0A9DF0071DBEDD5CE' temploid='{D665B1AF-6CFD-4d67-9D6F-8366F05EDE61}' bm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>HexDump (4 Byte)</TUV>
+</NAME>
+<QUAL>HexDump_4Byte</QUAL>
+<CVALUETYPE bl='32' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='32' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B18D02D010' oid='FE6E90B6EFFA46e0BAA7B40D568C67EA' temploid='{59BF6F66-7E74-4fb4-BB41-B6100ED33E03}' bm='255' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Statusbyte</TUV>
+</NAME>
+<QUAL>DtcStatusbyte</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADA15640' oid='0FD783B5D15C44fbB47F5C208F30F107' temploid='{963F865F-370E-4e3c-ABD2-6FD68FBA73A8}' bm='1' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>Test failed</TUV>
+</NAME>
+<QUAL>TestFailed</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADA15770' oid='42C3C30982124316A3364D4882751AC4' temploid='{462A8A5F-AC72-48c9-8E91-6B8872EDDA4F}' bm='1' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>Test failed this monitoring cycle</TUV>
+</NAME>
+<QUAL>TestFailedThisMonitoringCycle</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADA13040' oid='4A85D877F757463aBC20A045B57CC32E' temploid='{4E82C1E0-2D2E-4373-A708-BAC0507427C0}' bm='1' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>Pending DTC</TUV>
+</NAME>
+<QUAL>PendingDtc</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADA13170' oid='D507126BF47A462bA05F3D0CB8AC3913' temploid='{6462A483-CDEE-4a8a-A9D0-3D0AEBC76324}' bm='1' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>Confirmed DTC</TUV>
+</NAME>
+<QUAL>ConfirmedDtc</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADA15B00' oid='C8B40414347B479087122D5C6E7C5269' temploid='{D724A573-CC60-40ee-BC0E-D0BF41CA03E3}' bm='1' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>Test not completed since last clear</TUV>
+</NAME>
+<QUAL>TestNotCompletedSinceLastClear</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADA14340' oid='CCF94C62FC454e52B7135A3A1CEC498C' temploid='{29819C4C-B223-466c-BA5E-BEAAF1BF7FFE}' bm='1' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>Test failed since last clear</TUV>
+</NAME>
+<QUAL>TestFailedSinceLastClear</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADA145A0' oid='C3DFAF9689244881B5EDC9489D9E1589' temploid='{D90278CF-9800-4958-83C2-D76297C5FD10}' bm='1' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>Test not completed this monitoring cycle</TUV>
+</NAME>
+<QUAL>TestNotCompletedThisMonitoringCycle</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADA14B90' oid='2D40191AD588430aA3FFD3B3B5844F01' temploid='{4F753295-C5F6-48ee-B8A9-4078327E3C3F}' bm='1' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>Warning indicator requested</TUV>
+</NAME>
+<QUAL>WarningIndicatorRequested</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ABDEBB00' oid='AE836D1C3B304141B830A147433F805A' temploid='{3F4A937C-220B-40ef-9021-4FEBB8890553}' bm='16777215' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Groups</TUV>
+</NAME>
+<QUAL>DtcGroups</QUAL>
+<CVALUETYPE bl='24' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>Emission-related systems</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1048576' e='1048576'>
+<TEXT>
+<TUV xml:lang='en-US'>Powertrain group</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='4194304' e='4194304'>
+<TEXT>
+<TUV xml:lang='en-US'>Chassis group</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='8388608' e='8388608'>
+<TEXT>
+<TUV xml:lang='en-US'>Body group</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='12582912' e='12582912'>
+<TEXT>
+<TUV xml:lang='en-US'>Network communication group</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='16777215' e='16777215'>
+<TEXT>
+<TUV xml:lang='en-US'>All groups</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADB62A00' oid='B76AD4AB51FF44ed8CA4337D7B2402B9' temploid='{E631619D-F0E9-446a-8602-6B1E19A3E495}' bm='65535'>
+<NAME>
+<TUV xml:lang='en-US'>Bcd (2 Byte)</TUV>
+</NAME>
+<QUAL>Bcd_2_Byte</QUAL>
+<CVALUETYPE bl='16' bo='21' enc='bcd' sig='0' df='dec' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='bcd' sig='0' df='dec' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADB62220' oid='0F43CC5C733C4b70AB699BDFF4466615' temploid='{6A0F397F-3B02-4970-8F1F-84A03D738AF1}' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Part Number ASCII (13 Byte)</TUV>
+</NAME>
+<QUAL>PartNumberSize13</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='asc' sig='0' df='text' qty='field' sz='no' minsz='13' maxsz='13'/>
+<PVALUETYPE bl='8' bo='21' enc='asc' sig='0' df='text' qty='field' sz='no' minsz='13' maxsz='13'/>
+</IDENT>
+<TEXTTBL id='_000001B1ABDEBD60' oid='23D0314ADA764d6e97B945BEA754642F' temploid='{192B8DAE-2AAC-49b1-B291-C608AEA42BE0}' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>ExtendedDataRecordNumber</TUV>
+</NAME>
+<QUAL>ExtendedDataRecordNumber</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>OccurrenceCounter</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>Counts the number of times the DTC have been set.</TUV>
+</ADDINFO>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1AD94E730' oid='47DB70642FBE4fe0AD2CB30F86544572' temploid='{1130C14A-9D03-4472-AADE-65898E9C88E7}' bm='255' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='255'>
+<TEXT>
+<TUV xml:lang='en-US'>Generic Range</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1AD974DB0' oid='C43A364B81BB4e428A8B113AB4CB01F0' temploid='4042E32D63394c9e806558E6BB0D8684' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Short Identifier</TUV>
+</NAME>
+<QUAL>Short_Identifier</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='255'>
+<TEXT>
+<TUV xml:lang='en-US'>Generic Range</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADB65F50' oid='0AFEC52E1C53423a87477DB5761DE81E' temploid='AB8A9B8CAB584738A55A40AC8890A367' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC AllSupportedSnapshotRecordNumbers</TUV>
+</NAME>
+<QUAL>DTC_AllSupportedSnapshotRecordNumbers</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>Snapshot</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADB62B20' oid='CB62D596AAC84817929057081C719601' temploid='38E15FA5A2AA4bf0974A134F6BB2B23C' bm='65535'>
+<NAME>
+<TUV xml:lang='en-US'>DTCCount</TUV>
+</NAME>
+<QUAL>DTCCount</QUAL>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADB61800' oid='218E734855224154AB8D48BF840DD08C' temploid='B3B936445A514de1A9D5D3EE30C616B9' bm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>Serial Number (4 Byte)</TUV>
+</NAME>
+<QUAL>Serial_Number_4_Byte</QUAL>
+<CVALUETYPE bl='32' bo='21' enc='uns' sig='0' df='dec' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='32' bo='21' enc='uns' sig='0' df='dec' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADB65370' oid='414BAE0FB8BE4b8aA359FB1C32E32D35' temploid='540B3E255AA6490cA8D3AB37A7817F52' bm='65535'>
+<NAME>
+<TUV xml:lang='en-US'>DataIdentifier</TUV>
+</NAME>
+<QUAL>DataIdentifier</QUAL>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='1' e='61439'>
+<TEXT>
+<TUV xml:lang='en-US'>VehicleManufacturerSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61440' e='61455'>
+<TEXT>
+<TUV xml:lang='en-US'>networkConfigurationDataForTractorTrailerApplicationDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61456' e='61695'>
+<TEXT>
+<TUV xml:lang='en-US'>vehicleManufacturerSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61696' e='61823'>
+<TEXT>
+<TUV xml:lang='en-US'>identificationOptionVehicleManufacturerSpecificDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61824' e='61824'>
+<TEXT>
+<TUV xml:lang='en-US'>BootSoftwareIdentificationDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61825' e='61825'>
+<TEXT>
+<TUV xml:lang='en-US'>applicationSoftwareIdentificationDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61826' e='61826'>
+<TEXT>
+<TUV xml:lang='en-US'>applicationDataIdentificationDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61827' e='61827'>
+<TEXT>
+<TUV xml:lang='en-US'>bootSoftwareFingerprintDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61828' e='61828'>
+<TEXT>
+<TUV xml:lang='en-US'>applicationSoftwareFingerprintDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61829' e='61829'>
+<TEXT>
+<TUV xml:lang='en-US'>applicationDataFingerprintDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61830' e='61830'>
+<TEXT>
+<TUV xml:lang='en-US'>ActiveDiagnosticSessionDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61831' e='61831'>
+<TEXT>
+<TUV xml:lang='en-US'>vehicleManufacturerSparePartNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61832' e='61832'>
+<TEXT>
+<TUV xml:lang='en-US'>vehicleManufacturerECUSoftwareNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61833' e='61833'>
+<TEXT>
+<TUV xml:lang='en-US'>vehicleManufacturerECUSoftwareVersionNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61834' e='61834'>
+<TEXT>
+<TUV xml:lang='en-US'>systemSupplierIdentifierDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61835' e='61835'>
+<TEXT>
+<TUV xml:lang='en-US'>ECUManufacturingDateDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61836' e='61836'>
+<TEXT>
+<TUV xml:lang='en-US'>ECUSerialNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61837' e='61837'>
+<TEXT>
+<TUV xml:lang='en-US'>supportedFunctionalUnitsDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61838' e='61838'>
+<TEXT>
+<TUV xml:lang='en-US'>VehicleManufacturerKitAssemblyPartNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61840' e='61840'>
+<TEXT>
+<TUV xml:lang='en-US'>VINDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61841' e='61841'>
+<TEXT>
+<TUV xml:lang='en-US'>vehicleManufacturerECUHardwareNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61842' e='61842'>
+<TEXT>
+<TUV xml:lang='en-US'>systemSupplierECUHardwareNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61843' e='61843'>
+<TEXT>
+<TUV xml:lang='en-US'>systemSupplierECUHardwareVersionNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61844' e='61844'>
+<TEXT>
+<TUV xml:lang='en-US'>systemSupplierECUSoftwareNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61845' e='61845'>
+<TEXT>
+<TUV xml:lang='en-US'>systemSupplierECUSoftwareVersionNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61846' e='61846'>
+<TEXT>
+<TUV xml:lang='en-US'>exhaustRegulationOrTypeApprovalNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61847' e='61847'>
+<TEXT>
+<TUV xml:lang='en-US'>systemNameOrEngineTypeDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61848' e='61848'>
+<TEXT>
+<TUV xml:lang='en-US'>repairShopCodeOrTesterSerialNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61849' e='61849'>
+<TEXT>
+<TUV xml:lang='en-US'>programmingDateDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61850' e='61850'>
+<TEXT>
+<TUV xml:lang='en-US'>calibrationRepairShopCodeOrCalibrationEquipmentSerialNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61851' e='61851'>
+<TEXT>
+<TUV xml:lang='en-US'>calibrationDateDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61852' e='61852'>
+<TEXT>
+<TUV xml:lang='en-US'>calibrationEquipmentSoftwareNumberDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61853' e='61853'>
+<TEXT>
+<TUV xml:lang='en-US'>ECUInstallationDateDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61854' e='61854'>
+<TEXT>
+<TUV xml:lang='en-US'>ODXFileDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61855' e='61855'>
+<TEXT>
+<TUV xml:lang='en-US'>EntityDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61856' e='61935'>
+<TEXT>
+<TUV xml:lang='en-US'>identificationOptionVehicleManufacturerSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61936' e='61951'>
+<TEXT>
+<TUV xml:lang='en-US'>identificationOptionSystemSupplierSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61952' e='62207'>
+<TEXT>
+<TUV xml:lang='en-US'>periodicDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='62208' e='62463'>
+<TEXT>
+<TUV xml:lang='en-US'>DynamicallyDefinedDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='62464' e='62719'>
+<TEXT>
+<TUV xml:lang='en-US'>OBDDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='62720' e='62975'>
+<TEXT>
+<TUV xml:lang='en-US'>OBDDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='62976' e='63231'>
+<TEXT>
+<TUV xml:lang='en-US'>OBDMonitorDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='63232' e='63487'>
+<TEXT>
+<TUV xml:lang='en-US'>OBDMonitorDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='63488' e='63743'>
+<TEXT>
+<TUV xml:lang='en-US'>OBDInfoTypeDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='63744' e='63999'>
+<TEXT>
+<TUV xml:lang='en-US'>TachographDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='64000' e='64015'>
+<TEXT>
+<TUV xml:lang='en-US'>AirbagDeploymentDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='64016' e='64255'>
+<TEXT>
+<TUV xml:lang='en-US'>SafetySystemDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='64256' e='64767'>
+<TEXT>
+<TUV xml:lang='en-US'>ReservedForLegislativeUse</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='64768' e='65279'>
+<TEXT>
+<TUV xml:lang='en-US'>SystemSupplierSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADB65E20' oid='546C8D19F310410b8946B7AB618F5E98' temploid='6CB19584134B420cA4257909613E0A86' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction CommunicationControl</TUV>
+</NAME>
+<QUAL>Subfunction_CommunicationControl</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>enableRxAndTx</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>enableRxAndDisableTx</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='2' e='2'>
+<TEXT>
+<TUV xml:lang='en-US'>disableRxAndEnableTx</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='3' e='3'>
+<TEXT>
+<TUV xml:lang='en-US'>disableRxAndTx</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='64' e='95'>
+<TEXT>
+<TUV xml:lang='en-US'>vehicleManufacturerSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='96' e='126'>
+<TEXT>
+<TUV xml:lang='en-US'>systemSupplierSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADB667A0' oid='466F864361B44baaBF1EFF21F9A3BC1B' temploid='3DC91A04A5D146a9AFE2B36A8850FD44' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction DiagnosticSessionControl</TUV>
+</NAME>
+<QUAL>Subfunction_DiagnosticSessionControl</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>defaultSession</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='2' e='2'>
+<TEXT>
+<TUV xml:lang='en-US'>programmingSession</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='3' e='3'>
+<TEXT>
+<TUV xml:lang='en-US'>extendedDiagnosticSession</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='4' e='4'>
+<TEXT>
+<TUV xml:lang='en-US'>safetySystemDiagnosticSession</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='64' e='95'>
+<TEXT>
+<TUV xml:lang='en-US'>vehicleManufacturerSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='96' e='126'>
+<TEXT>
+<TUV xml:lang='en-US'>systemSupplierSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADB67120' oid='373C3A3CA6AA40329FB3E2D0DDCAD7A9' temploid='4A15AFE84D134b83B437B5B4F2A43A92' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction EcuReset</TUV>
+</NAME>
+<QUAL>Subfunction_EcuReset</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>hardReset</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='2' e='2'>
+<TEXT>
+<TUV xml:lang='en-US'>keyOffOnReset</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='3' e='3'>
+<TEXT>
+<TUV xml:lang='en-US'>softReset</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='4' e='4'>
+<TEXT>
+<TUV xml:lang='en-US'>enableRapidPowerShutDown</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='5' e='5'>
+<TEXT>
+<TUV xml:lang='en-US'>disableRapidPowerShutDown</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='64' e='95'>
+<TEXT>
+<TUV xml:lang='en-US'>vehicleManufacturerSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='96' e='126'>
+<TEXT>
+<TUV xml:lang='en-US'>systemSupplierSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADB66C60' oid='5C0D0DA9C6114f768FABE75DDA9737E2' temploid='15ECA5D18600471c91619EB86948EF04' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction SecurityAccess</TUV>
+</NAME>
+<QUAL>Subfunction_SecurityAccess</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>requestSeed</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='2' e='2'>
+<TEXT>
+<TUV xml:lang='en-US'>sendKey</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='3' e='3'>
+<TEXT>
+<TUV xml:lang='en-US'>requestSeed</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='4' e='4'>
+<TEXT>
+<TUV xml:lang='en-US'>sendKey</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='5' e='5'>
+<TEXT>
+<TUV xml:lang='en-US'>requestSeed</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='6' e='6'>
+<TEXT>
+<TUV xml:lang='en-US'>sendKey</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='95' e='95'>
+<TEXT>
+<TUV xml:lang='en-US'>ISOSAEReserved requestSeed values</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='96' e='96'>
+<TEXT>
+<TUV xml:lang='en-US'>ISOSAEReserved sendKey values</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='97' e='126'>
+<TEXT>
+<TUV xml:lang='en-US'>systemSupplierSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADB64B20' oid='056D08DDCC8D4099AE185B33D80067FC' temploid='A941DF501267400280513885858ED35D' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Address and Length Format Identifier</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Examples for addressAndLengthFormatIdentifier parameter values regarding to ISO 14229-1 Annex G.1</TUV>
+</DESC>
+<QUAL>AddressAndLengthFormatIdentifier</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='17' e='17'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 1 byte, memorySize 1 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='18' e='18'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 2 byte, memorySize 1 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='19' e='19'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 3 byte, memorySize 1 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='20' e='20'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 4 byte, memorySize 1 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='33' e='33'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 1 byte, memorySize 2 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='34' e='34'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 2 byte, memorySize 2 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='35' e='35'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 3 byte, memorySize 2 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='36' e='36'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 4 byte, memorySize 2 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='49' e='49'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 1 byte, memorySize 3 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='50' e='50'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 2 byte, memorySize 3 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='51' e='51'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 3 byte, memorySize 3 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='52' e='52'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 4 byte, memorySize 3 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='65' e='65'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 1 byte, memorySize 4 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='66' e='66'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 2 byte, memorySize 4 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='67' e='67'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 3 byte, memorySize 4 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='68' e='68'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 4 byte, memorySize 4 byte</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='69' e='69'>
+<TEXT>
+<TUV xml:lang='en-US'>Length: memoryAddress 5 byte, memorySize 4 byte</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADB62C40' oid='DF590313D35F4ed5879D57BD84669BFA' temploid='C0FC582573FB46ec8B659C731B682B74' bm='16777215'>
+<NAME>
+<TUV xml:lang='en-US'>HexDump (3 Byte)</TUV>
+</NAME>
+<QUAL>HexDump_3Byte</QUAL>
+<CVALUETYPE bl='24' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='24' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADB63300' oid='7C23F85F40FF421d959E020C08A5A2E0' temploid='36892EEE705F44e6ACA74D929B631379' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Memory (1 Byte Size Info)</TUV>
+</NAME>
+<QUAL>Memory_1_Byte_Size_Info</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='lszbyte' minsz='1' maxsz='255'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='lszbyte' minsz='1' maxsz='255'/>
+</IDENT>
+<IDENT id='_000001B1ADB631E0' oid='977EEE310C714b2d8AEB82070EC72F1D' temploid='2B44EDA0ADD14607BCB701E79A0B82A5' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Memory (2 Byte Size Info)</TUV>
+</NAME>
+<QUAL>Memory_2_Byte_Size_Info</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='lsz2bytes' minsz='1' maxsz='65530'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='lsz2bytes' minsz='1' maxsz='65530'/>
+</IDENT>
+<IDENT id='_000001B1ADB627C0' oid='F6BB99EBBF684cdcB43F57D8EEEF7B4E' temploid='B23628DC5E1448c0BB8EE85208F60F6C' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Memory (3 Byte Size Info)</TUV>
+</NAME>
+<QUAL>Memory_3_Byte_Size_Info</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='lsz3bytes' minsz='1' maxsz='65529'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='lsz3bytes' minsz='1' maxsz='65529'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADB64400' oid='1DE68F04EC4A482c836993F171A339C9' temploid='E8496FDAFEEB4e44894E0FA96D89C5E1' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFormatIdentifier</TUV>
+</NAME>
+<QUAL>DTCFormatIdentifier</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>SAE_J2012-DA_DTCFormat</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO_14229-1DTCFormat</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='2' e='2'>
+<TEXT>
+<TUV xml:lang='en-US'>SAE_J1939-73_DTCFormat</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='3' e='3'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO_11992-4_DTCFormat</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='4' e='4'>
+<TEXT>
+<TUV xml:lang='en-US'>SAE_J2012-DA_WWHOBD_DTCFormat</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADB64790' oid='A1B7410375C34f73ACF621DF2FABD897' temploid='9821B55277C0488c913CCEFBC4736297' bm='65535'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineIdentifier</TUV>
+</NAME>
+<QUAL>RoutineIdentifier</QUAL>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='256' e='511'>
+<TEXT>
+<TUV xml:lang='en-US'>TachographTestIds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='512' e='57343'>
+<TEXT>
+<TUV xml:lang='en-US'>vehicleManufacturerSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='57344' e='57855'>
+<TEXT>
+<TUV xml:lang='en-US'>OBDTestIds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='57856' e='57856'>
+<TEXT>
+<TUV xml:lang='en-US'>DeployLoopRoutineID</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='57857' e='58111'>
+<TEXT>
+<TUV xml:lang='en-US'>SafetySystemsRoutineIDs</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61440' e='65279'>
+<TEXT>
+<TUV xml:lang='en-US'>systemSupplierSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='65280' e='65280'>
+<TEXT>
+<TUV xml:lang='en-US'>eraseMemory</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='65281' e='65281'>
+<TEXT>
+<TUV xml:lang='en-US'>checkProgrammingDependencies</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='65282' e='65282'>
+<TEXT>
+<TUV xml:lang='en-US'>eraseMemoryDTCs</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADB61DA0' oid='BBE903DF30EC4f30AA6107FC73911D74' temploid='D35AB6E0D8524e6e9B01D31812D5FDBA' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>HexDump (5 Byte)</TUV>
+</NAME>
+<QUAL>HexDump_5_Byte</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='5' maxsz='5'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='5' maxsz='5'/>
+</IDENT>
+<IDENT id='_000001B1ADB62D60' oid='F90385C6A7B5410881F684A9FDE3A5B1' temploid='02EF5301367C44b6AF2EF130F6BB2148' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Memory (4 Byte Size Info)</TUV>
+</NAME>
+<QUAL>Memory_4_Byte_Size_Info</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='lsz4bytes' minsz='1' maxsz='65527'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='lsz4bytes' minsz='1' maxsz='65527'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADB64D80' oid='4961949898A34ff38CA930EBC3B7935D' temploid='738D499CABCE453286B1E83C7767F3C8' bm='65535' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RecordDataIdentifier</QUAL>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='65535'>
+<TEXT>
+<TUV xml:lang='en-US'>Generic Range</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADB64FE0' oid='965A2BE9BF024386BBBE9CE3CFBBC246' temploid='6E2ADDE9F4794db5BF30F92E34D80C60' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>ResponseOnEvent - EventWindowTime</TUV>
+</NAME>
+<QUAL>ResponseOnEvent_EventWindowTime</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<EXCL s='0' e='0' inv='invalidSignal'>
+</EXCL>
+<EXCL s='1' e='1' inv='invalidSignal'>
+</EXCL>
+<EXCL s='128' e='255' inv='invalidSignal'>
+</EXCL>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='2' e='2'>
+<TEXT>
+<TUV xml:lang='en-US'>InfiniteTimeToResponse</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='3' e='3'>
+<TEXT>
+<TUV xml:lang='en-US'>30 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='4' e='4'>
+<TEXT>
+<TUV xml:lang='en-US'>40 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='5' e='5'>
+<TEXT>
+<TUV xml:lang='en-US'>50 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='6' e='6'>
+<TEXT>
+<TUV xml:lang='en-US'>60 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='7' e='7'>
+<TEXT>
+<TUV xml:lang='en-US'>70 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='8' e='8'>
+<TEXT>
+<TUV xml:lang='en-US'>80 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='9' e='9'>
+<TEXT>
+<TUV xml:lang='en-US'>90 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='10' e='10'>
+<TEXT>
+<TUV xml:lang='en-US'>100 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='11' e='11'>
+<TEXT>
+<TUV xml:lang='en-US'>110 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='12' e='12'>
+<TEXT>
+<TUV xml:lang='en-US'>120 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='13' e='13'>
+<TEXT>
+<TUV xml:lang='en-US'>130 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='14' e='14'>
+<TEXT>
+<TUV xml:lang='en-US'>140 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='15' e='15'>
+<TEXT>
+<TUV xml:lang='en-US'>150 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='16' e='16'>
+<TEXT>
+<TUV xml:lang='en-US'>160 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='17' e='17'>
+<TEXT>
+<TUV xml:lang='en-US'>170 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='18' e='18'>
+<TEXT>
+<TUV xml:lang='en-US'>180 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='19' e='19'>
+<TEXT>
+<TUV xml:lang='en-US'>190 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='20' e='20'>
+<TEXT>
+<TUV xml:lang='en-US'>200 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='21' e='21'>
+<TEXT>
+<TUV xml:lang='en-US'>210 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='22' e='22'>
+<TEXT>
+<TUV xml:lang='en-US'>220 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='23' e='23'>
+<TEXT>
+<TUV xml:lang='en-US'>230 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='24' e='24'>
+<TEXT>
+<TUV xml:lang='en-US'>240 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='25' e='25'>
+<TEXT>
+<TUV xml:lang='en-US'>250 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='26' e='26'>
+<TEXT>
+<TUV xml:lang='en-US'>260 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='27' e='27'>
+<TEXT>
+<TUV xml:lang='en-US'>270 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='28' e='28'>
+<TEXT>
+<TUV xml:lang='en-US'>280 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='29' e='29'>
+<TEXT>
+<TUV xml:lang='en-US'>290 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='30' e='30'>
+<TEXT>
+<TUV xml:lang='en-US'>300 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='31' e='31'>
+<TEXT>
+<TUV xml:lang='en-US'>310 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='32' e='32'>
+<TEXT>
+<TUV xml:lang='en-US'>320 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='33' e='33'>
+<TEXT>
+<TUV xml:lang='en-US'>330 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='34' e='34'>
+<TEXT>
+<TUV xml:lang='en-US'>340 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='35' e='35'>
+<TEXT>
+<TUV xml:lang='en-US'>350 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='36' e='36'>
+<TEXT>
+<TUV xml:lang='en-US'>360 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='37' e='37'>
+<TEXT>
+<TUV xml:lang='en-US'>370 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='38' e='38'>
+<TEXT>
+<TUV xml:lang='en-US'>380 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='39' e='39'>
+<TEXT>
+<TUV xml:lang='en-US'>390 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='40' e='40'>
+<TEXT>
+<TUV xml:lang='en-US'>400 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='41' e='41'>
+<TEXT>
+<TUV xml:lang='en-US'>410 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='42' e='42'>
+<TEXT>
+<TUV xml:lang='en-US'>420 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='43' e='43'>
+<TEXT>
+<TUV xml:lang='en-US'>430 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='44' e='44'>
+<TEXT>
+<TUV xml:lang='en-US'>440 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='45' e='45'>
+<TEXT>
+<TUV xml:lang='en-US'>450 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='46' e='46'>
+<TEXT>
+<TUV xml:lang='en-US'>460 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='47' e='47'>
+<TEXT>
+<TUV xml:lang='en-US'>470 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='48' e='48'>
+<TEXT>
+<TUV xml:lang='en-US'>480 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='49' e='49'>
+<TEXT>
+<TUV xml:lang='en-US'>490 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='50' e='50'>
+<TEXT>
+<TUV xml:lang='en-US'>500 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='51' e='51'>
+<TEXT>
+<TUV xml:lang='en-US'>510 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='52' e='52'>
+<TEXT>
+<TUV xml:lang='en-US'>520 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='53' e='53'>
+<TEXT>
+<TUV xml:lang='en-US'>530 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='54' e='54'>
+<TEXT>
+<TUV xml:lang='en-US'>540 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='55' e='55'>
+<TEXT>
+<TUV xml:lang='en-US'>550 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='56' e='56'>
+<TEXT>
+<TUV xml:lang='en-US'>560 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='57' e='57'>
+<TEXT>
+<TUV xml:lang='en-US'>570 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='58' e='58'>
+<TEXT>
+<TUV xml:lang='en-US'>580 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='59' e='59'>
+<TEXT>
+<TUV xml:lang='en-US'>590 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='60' e='60'>
+<TEXT>
+<TUV xml:lang='en-US'>600 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='61' e='61'>
+<TEXT>
+<TUV xml:lang='en-US'>610 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='62' e='62'>
+<TEXT>
+<TUV xml:lang='en-US'>620 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='63' e='63'>
+<TEXT>
+<TUV xml:lang='en-US'>630 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='64' e='64'>
+<TEXT>
+<TUV xml:lang='en-US'>640 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='65' e='65'>
+<TEXT>
+<TUV xml:lang='en-US'>650 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='66' e='66'>
+<TEXT>
+<TUV xml:lang='en-US'>660 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='67' e='67'>
+<TEXT>
+<TUV xml:lang='en-US'>670 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='68' e='68'>
+<TEXT>
+<TUV xml:lang='en-US'>680 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='69' e='69'>
+<TEXT>
+<TUV xml:lang='en-US'>690 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='70' e='70'>
+<TEXT>
+<TUV xml:lang='en-US'>700 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='71' e='71'>
+<TEXT>
+<TUV xml:lang='en-US'>710 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='72' e='72'>
+<TEXT>
+<TUV xml:lang='en-US'>720 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='73' e='73'>
+<TEXT>
+<TUV xml:lang='en-US'>730 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='74' e='74'>
+<TEXT>
+<TUV xml:lang='en-US'>740 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='75' e='75'>
+<TEXT>
+<TUV xml:lang='en-US'>750 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='76' e='76'>
+<TEXT>
+<TUV xml:lang='en-US'>760 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='77' e='77'>
+<TEXT>
+<TUV xml:lang='en-US'>770 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='78' e='78'>
+<TEXT>
+<TUV xml:lang='en-US'>780 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='79' e='79'>
+<TEXT>
+<TUV xml:lang='en-US'>790 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='80' e='80'>
+<TEXT>
+<TUV xml:lang='en-US'>800 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='81' e='81'>
+<TEXT>
+<TUV xml:lang='en-US'>810 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='82' e='82'>
+<TEXT>
+<TUV xml:lang='en-US'>820 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='83' e='83'>
+<TEXT>
+<TUV xml:lang='en-US'>830 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='84' e='84'>
+<TEXT>
+<TUV xml:lang='en-US'>840 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='85' e='85'>
+<TEXT>
+<TUV xml:lang='en-US'>850 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='86' e='86'>
+<TEXT>
+<TUV xml:lang='en-US'>860 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='87' e='87'>
+<TEXT>
+<TUV xml:lang='en-US'>870 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='88' e='88'>
+<TEXT>
+<TUV xml:lang='en-US'>880 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='89' e='89'>
+<TEXT>
+<TUV xml:lang='en-US'>890 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='90' e='90'>
+<TEXT>
+<TUV xml:lang='en-US'>900 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='91' e='91'>
+<TEXT>
+<TUV xml:lang='en-US'>910 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='92' e='92'>
+<TEXT>
+<TUV xml:lang='en-US'>920 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='93' e='93'>
+<TEXT>
+<TUV xml:lang='en-US'>930 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='94' e='94'>
+<TEXT>
+<TUV xml:lang='en-US'>940 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='95' e='95'>
+<TEXT>
+<TUV xml:lang='en-US'>950 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='96' e='96'>
+<TEXT>
+<TUV xml:lang='en-US'>960 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='97' e='97'>
+<TEXT>
+<TUV xml:lang='en-US'>970 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='98' e='98'>
+<TEXT>
+<TUV xml:lang='en-US'>980 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='99' e='99'>
+<TEXT>
+<TUV xml:lang='en-US'>990 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='100' e='100'>
+<TEXT>
+<TUV xml:lang='en-US'>1000 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='101' e='101'>
+<TEXT>
+<TUV xml:lang='en-US'>1010 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='102' e='102'>
+<TEXT>
+<TUV xml:lang='en-US'>1020 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='103' e='103'>
+<TEXT>
+<TUV xml:lang='en-US'>1030 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='104' e='104'>
+<TEXT>
+<TUV xml:lang='en-US'>1040 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='105' e='105'>
+<TEXT>
+<TUV xml:lang='en-US'>1050 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='106' e='106'>
+<TEXT>
+<TUV xml:lang='en-US'>1060 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='107' e='107'>
+<TEXT>
+<TUV xml:lang='en-US'>1070 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='108' e='108'>
+<TEXT>
+<TUV xml:lang='en-US'>1080 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='109' e='109'>
+<TEXT>
+<TUV xml:lang='en-US'>1090 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='110' e='110'>
+<TEXT>
+<TUV xml:lang='en-US'>1100 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='111' e='111'>
+<TEXT>
+<TUV xml:lang='en-US'>1110 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='112' e='112'>
+<TEXT>
+<TUV xml:lang='en-US'>1120 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='113' e='113'>
+<TEXT>
+<TUV xml:lang='en-US'>1130 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='114' e='114'>
+<TEXT>
+<TUV xml:lang='en-US'>1140 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='115' e='115'>
+<TEXT>
+<TUV xml:lang='en-US'>1150 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='116' e='116'>
+<TEXT>
+<TUV xml:lang='en-US'>1160 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='117' e='117'>
+<TEXT>
+<TUV xml:lang='en-US'>1170 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='118' e='118'>
+<TEXT>
+<TUV xml:lang='en-US'>1180 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='119' e='119'>
+<TEXT>
+<TUV xml:lang='en-US'>1190 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='120' e='120'>
+<TEXT>
+<TUV xml:lang='en-US'>1200 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='121' e='121'>
+<TEXT>
+<TUV xml:lang='en-US'>1210 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='122' e='122'>
+<TEXT>
+<TUV xml:lang='en-US'>1220 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='123' e='123'>
+<TEXT>
+<TUV xml:lang='en-US'>1230 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='124' e='124'>
+<TEXT>
+<TUV xml:lang='en-US'>1240 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='125' e='125'>
+<TEXT>
+<TUV xml:lang='en-US'>1250 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='126' e='126'>
+<TEXT>
+<TUV xml:lang='en-US'>1260 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='127' e='127'>
+<TEXT>
+<TUV xml:lang='en-US'>1270 Seconds</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADB65960' oid='1F21FC129A704ec48ECCC600DFA690AD' temploid='16EF94883B884130B61922E9D090E20E' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>LinkControl Supported Baudrates</TUV>
+</NAME>
+<QUAL>LinkControl_Supported_Baudrates</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='17' e='17'>
+<TEXT>
+<TUV xml:lang='en-US'>CAN250000Baud</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='18' e='18'>
+<TEXT>
+<TUV xml:lang='en-US'>CAN500000Baud</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='19' e='19'>
+<TEXT>
+<TUV xml:lang='en-US'>CAN1000000Baud</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADBDEF40' oid='701C03AF23194fb3923024E58AFB98DF' temploid='820437D6B8B04b93967A4A456B37A41E' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction CommunicationControl EnhancedAddressInformation</TUV>
+</NAME>
+<QUAL>Subfunction_CommunicationControl_EnhancedAddressInformation</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='4' e='4'>
+<TEXT>
+<TUV xml:lang='en-US'>EnableRxAndDisableTxWithEnhancedAddressInformation</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='5' e='5'>
+<TEXT>
+<TUV xml:lang='en-US'>EnableRxAndTxWithEnhancedAddressInformation</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADBDCBA0' oid='C229269550CA4ed2B3A96CFA23A528B3' temploid='CD68C0164F384c6c95CD52FEE55C8832' bm='255' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='255'>
+<TEXT>
+<TUV xml:lang='en-US'>Generic Range</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADBDDFD0' oid='9A07FAE0FB9C489082E7182542E73EE9' temploid='C9A9FB4DED5D4d619F3ED48A0F08A332' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>User Defined Fault Memories</TUV>
+</NAME>
+<QUAL>User_Defined_Fault_Memories</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>User Defined Fault Memory 0</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>User Defined Fault Memory 1</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='2' e='2'>
+<TEXT>
+<TUV xml:lang='en-US'>User Defined Fault Memory 2</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='3' e='3'>
+<TEXT>
+<TUV xml:lang='en-US'>User Defined Fault Memory 3</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='4' e='4'>
+<TEXT>
+<TUV xml:lang='en-US'>User Defined Fault Memory 4</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='5' e='5'>
+<TEXT>
+<TUV xml:lang='en-US'>User Defined Fault Memory 5</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADBDD060' oid='EE58733BF7664b75B4ED3DD5EB20765F' temploid='30A7D6F68B3648998C01DC45732269B1' bm='255' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>SnapshotRecordsPlusFF</TUV>
+</NAME>
+<QUAL>SnapshotRecordsPlusFF</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<EXCL s='0' e='15' inv='notImplemented'>
+<TEXT>
+<TUV xml:lang='en-US'>Not implemented</TUV>
+</TEXT>
+</EXCL>
+<EXCL s='17' e='31' inv='notImplemented'>
+<TEXT>
+<TUV xml:lang='en-US'>Not implemented</TUV>
+</TEXT>
+</EXCL>
+<EXCL s='33' e='254' inv='notImplemented'>
+<TEXT>
+<TUV xml:lang='en-US'>Not implemented</TUV>
+</TEXT>
+</EXCL>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='16' e='16'>
+<TEXT>
+<TUV xml:lang='en-US'>First Occurence</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>DEM_TRIGGER_ON_CONFIRMED</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='32' e='32'>
+<TEXT>
+<TUV xml:lang='en-US'>Last Occurence</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>DEM_TRIGGER_ON_TEST_FAILED</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='255' e='255'>
+<TEXT>
+<TUV xml:lang='en-US'>All Snapshot Records</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADBDBE90' oid='80B9919D088F425cB649C4055D1508A4' temploid='87FE6AEB3FED4a1d9EB1FBDE9B2719F7' bm='255' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>SnapshotRecords</TUV>
+</NAME>
+<QUAL>SnapshotRecords</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<EXCL s='0' e='15' inv='notImplemented'>
+<TEXT>
+<TUV xml:lang='en-US'>Not implemented</TUV>
+</TEXT>
+</EXCL>
+<EXCL s='17' e='31' inv='notImplemented'>
+<TEXT>
+<TUV xml:lang='en-US'>Not implemented</TUV>
+</TEXT>
+</EXCL>
+<EXCL s='33' e='255' inv='notImplemented'>
+<TEXT>
+<TUV xml:lang='en-US'>Not implemented</TUV>
+</TEXT>
+</EXCL>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='16' e='16'>
+<TEXT>
+<TUV xml:lang='en-US'>First Occurence</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>DEM_TRIGGER_ON_CONFIRMED</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='32' e='32'>
+<TEXT>
+<TUV xml:lang='en-US'>Last Occurence</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>DEM_TRIGGER_ON_TEST_FAILED</TUV>
+</ADDINFO>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADB61FE0' oid='E8E94BFFD323414c8D6B5D8531F6E4E2' temploid='2564AB0BFE04434a8177FDB1CD2B79F8' bm='255' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>Unsigned Dec (1 Byte)</TUV>
+</NAME>
+<QUAL>Unsigned_1Byte</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='dec' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='dec' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADBDC6E0' oid='63D9F600840747119E9E90466A8B0B56' temploid='5E5A495C9559490b9FE55AECB2207BD7' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTCExtendedDataRecordNumber (1Byte)</TUV>
+</NAME>
+<QUAL>DTCExtendedDataRecordNumber_1Byte</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<EXCL s='0' e='0' inv='undef'>
+</EXCL>
+<EXCL s='255' e='255' inv='noSignal'>
+</EXCL>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>StandardEnvironmentData</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADB62580' oid='B0E7F69A4A40469dB87C8B962ED426E9' temploid='812AAD292B5D47e590F2DE38D6A74FBB' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>VIN (17 Byte)</TUV>
+</NAME>
+<QUAL>VIN_17_Byte</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='asc' sig='0' df='text' qty='field' sz='no' minsz='17' maxsz='17'/>
+<PVALUETYPE bl='8' bo='21' enc='asc' sig='0' df='text' qty='field' sz='no' minsz='17' maxsz='17'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADBDD520' oid='CEAFF6ADC7064761AE56AB5ED1FE591E' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineStatus</TUV>
+</NAME>
+<QUAL>RoutineStatus</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>Not ok</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>Ok</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADBDE820' oid='BFA677D80F19402cA7B9F3D7F729A620' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Lock Status</TUV>
+</NAME>
+<QUAL>Lock_Status</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<EXCL s='2' e='255' inv='undef'>
+<TEXT>
+<TUV xml:lang='en-US'>Undefined</TUV>
+</TEXT>
+</EXCL>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>unlocked</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>locked</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADB61A40' oid='717754569F0F4704A1B4DF3448CF5A65' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier (1 Byte)</TUV>
+</NAME>
+<QUAL>Identifier_1_Byte</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADBDEA80' oid='37086B244EE84173844A225610BE67D1' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>off/on/invalid</TUV>
+</NAME>
+<QUAL>off_on_invalid</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>off</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>on</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='2' e='2'>
+<TEXT>
+<TUV xml:lang='en-US'>invalid</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADB626A0' oid='3DE2566B68D847e988013C8F426FF24C' temploid='0F957D495C51484a8D5D1699E649CEBD' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Number of Tested Operation Cycles since last Fail</TUV>
+</NAME>
+<QUAL>DTC_Number_of_Tested_Operation_Cycles_since_last_Fail</QUAL>
+<ENUM oid='1319682EB457424c9D1DBB9EF4DC5714' temploid='D573D53256404aafB4B66827C00EA202' attrref='_000001B18CF21D90' v='33'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADB630C0' oid='2E16C59CAFFE49739911A29CD57F6495' temploid='CE22AA58E348478797B8AD00C3F94283' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Healing Counter (Counting Downwards)</TUV>
+</NAME>
+<QUAL>DTC_Healing_Counter_Counting_Downwards</QUAL>
+<ENUM oid='39D60451F1464b19BD46B27099915C08' temploid='22F405C1D9284fbaB805E7BC6DFA81C3' attrref='_000001B18CF21D90' v='32'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADB61B60' oid='63F198D0C1E344c5A8C93E44E306D4CB' temploid='A621307CA74C48328A93173A543EBB7B' bm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>DTC OBD Ratio</TUV>
+</NAME>
+<QUAL>DTC_OBD_Ratio</QUAL>
+<ENUM oid='726CAE90EEAD4cf59AC1740B78CBA8E6' temploid='EBB6055D6433486cBDD131DDC3A08F91' attrref='_000001B18CF21D90' v='31'/>
+<CVALUETYPE bl='32' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='32' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC00FA0' oid='7E53268D71374c0d987BD4B0E392AB1B' temploid='1BD08842DD694b3292CE93B9FACA074E' bm='16777215'>
+<NAME>
+<TUV xml:lang='en-US'>DTC OBD (3 Byte)</TUV>
+</NAME>
+<QUAL>DTC_OBD_3_Byte</QUAL>
+<ENUM oid='8C5D61A5CCFF4252BEC1291ED15CD5FA' temploid='73A82E49D4FD47bfA61F9D969CC99907' attrref='_000001B18CF21D90' v='30'/>
+<CVALUETYPE bl='24' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='24' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADBDCA70' oid='280CC3F5D9134d67B2E2188A8B9F2B46' temploid='DBA6E23189D348f4BF0818A5C2B52359' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>SAE J2012 Failure Type Byte</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>FTB is defined as the Failure Type Byte in extended DTCs most commonly used in CAN networks. The FTB is used with a base DTC made of two bytes designating the DTC number and B,C,P or U type. The base DTC will not specify a failure type such as an open or short circuit condition. Instead the failure type is specified by the FTB and is reported by an ECU with the base DTC. In effect then a reported DTC is made of the total of the three bytes.
+
+The DTC annexes of SAE J2012 and ISO 15031-6 documents define many two byte DTCs with failure type information. If such a standard DTC is already defined for a component / system and that DTC description already comprehends the DTC Failure Type information, then the standard DTC number can be used and the DTC Failure Type Byte shall be set to a value of 00 hex. A DTC Failure Type Byte value of 00 hex indicates that no additional sub type information is contained in the DTC Failure Type Byte.</TUV>
+</DESC>
+<QUAL>SAE_J2012_Failure_Type_Byte</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>No Sub Type Information</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the base DTC text string provides the complete description of the failure itself (no Category and no Sub Type information used, e.g. emissions-related DTC (012700 hex): P0127 Intake Air Temperature Too High).</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>General Electrical Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for General Electrical Failures that cannot be assigned to a specific sub type (Category information and no Sub Type information, e.g. DTC (803901): B0039-01 Second Row Right Frontal Stage 1 Deployment Control - General Electrical Failure).</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='2' e='2'>
+<TEXT>
+<TUV xml:lang='en-US'>General Signal Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for General Signal Failures that cannot be assigned to a specific sub type (Category information and no Sub Type information, e.g. DTC (403002): C0030 Left Front Tone Wheel - General Signal Failure).</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='3' e='3'>
+<TEXT>
+<TUV xml:lang='en-US'>FM (Frequency Modulated) / PWM (Pulse Width Modulated) Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for FM / PWM Failures that cannot be assigned to a specific sub type.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='4' e='4'>
+<TEXT>
+<TUV xml:lang='en-US'>System Internal Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for control module Internal Failures that cannot be assigned to a specific sub type.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='5' e='5'>
+<TEXT>
+<TUV xml:lang='en-US'>System Programming Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for System Programming Failures that cannot be assigned to a specific sub type.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='6' e='6'>
+<TEXT>
+<TUV xml:lang='en-US'>Algorithm Based Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for Algorithm Based Failures that cannot be assigned to a specific sub type.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='7' e='7'>
+<TEXT>
+<TUV xml:lang='en-US'>Mechanical Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for Mechanical Failures that cannot be assigned to a specific sub type.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='8' e='8'>
+<TEXT>
+<TUV xml:lang='en-US'>Bus Signal / Message Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for Bus Signal / Message Failures that cannot be assigned to a specific sub type.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='9' e='9'>
+<TEXT>
+<TUV xml:lang='en-US'>Component Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for Component Failures that cannot be assigned to a specific sub type.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='10' e='10'>
+<TEXT>
+<TUV xml:lang='en-US'>General Electrical Failures - 2</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This range specifies the standard wiring failure modes (i.e., shorts and opens), and direct current (DC) quantities related by Ohm's Law.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='11' e='11'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='12' e='12'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='13' e='13'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='14' e='14'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='15' e='15'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='16' e='16'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='17' e='17'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Short To Ground</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module measures ground (battery negative) potential for greater than a specified time period or when some other value less than the low voltage limit DTC Sub Type is measured.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='18' e='18'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Short To Battery</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module measures vehicle system (battery positive) potential for greater than a specified time period or when some other value higher than the high voltage limit  DTC Sub Type is measured.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='19' e='19'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Open</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module determines an open circuit via lack of bias voltage, low current flow, no change in the state of an input in response to an output, etc.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='20' e='20'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Short To Ground or Open</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the condition detected by the control module is the same for either indicated failure mode.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='21' e='21'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Short To Battery or Open</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the condition detected by the control module is the same for either indicated failure mode.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='22' e='22'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Voltage Below Threshold</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module measures a voltage below a specified range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='23' e='23'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Voltage Above Threshold</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where, the control module measures a voltage above a specified range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='24' e='24'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Current Below Threshold</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module measures current flow below a specified range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='25' e='25'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Current Above Threshold</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module measures current flow above a specified range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='26' e='26'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Resistance Below Threshold</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module infers a circuit resistance below a specified range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='27' e='27'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Resistance Above Threshold</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module infers a circuit resistance above a specified range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='28' e='28'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Voltage Out of Range</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module measures a voltage outside the expected range but not identified as too high or too low.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='29' e='29'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Current Out of Range</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module measures a current outside the expected range but not identified as too high or too low.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='30' e='30'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Resistance Out of Range</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module measures a resistance outside the expected range but not identified as too high or too low.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='31' e='31'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit Intermittent</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module momentarily detects one of the conditions defined above, but not long enough to set a specific sub type.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='32' e='32'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='33' e='33'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Amplitude &#60; Minimum</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module measures a signal voltage amplitude below a specified range (e.g., low gain).</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='34' e='34'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Amplitude &#62; Maximum</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module measures a signal voltage amplitude above a specified range (e.g., gain too high).</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='35' e='35'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Stuck Low</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module measures a signal that remains low when transitions are expected.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='36' e='36'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Stuck High</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module measures a signal that remains high when transitions are expected.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='37' e='37'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Shape / Waveform Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the shape of the signal (plot of the amplitude with respect to time) is not correct, e.g., improper circuit impedance.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='38' e='38'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Rate of Change Below Threshold</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the signal transitions more slowly than the specified limit.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='39' e='39'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Rate of Change Above Threshold</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the signal transitions more quickly than the specified limit.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='40' e='40'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Bias Level Out of Range / Zero Adjustment Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module applies a bias voltage or a zero signal level to a circuit upon which is superimposed a signal voltage (e.g., bias voltage to an Oxygen Sensor circuit, or a filtered digital m/sec2 signal while vehicle stands still for a lateral accelerator sensor module.)</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='41' e='41'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Invalid</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the value of the signal is not plausible given the operating conditions.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='42' e='42'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Stuck In Range</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the value of the signal is in the normal operating range, but not correct for current operating conditions.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='43' e='43'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Cross Coupled</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used when a signal is found to be incorrectly correlated to another signal that the control module is also monitoring, indicating that the signals are shorted together</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='44' e='44'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='45' e='45'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='46' e='46'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='47' e='47'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Erratic</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the signal is momentarily implausible (not long enough for "signal invalid") or discontinuous.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='48' e='48'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='49' e='49'>
+<TEXT>
+<TUV xml:lang='en-US'>No Signal</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module does not detect a signal which ought to be present (e.g., wheel speed signals present for three of the four wheels and brakes not applied.)</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='50' e='50'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Low Time &#60; Minimum</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects the low pulse is too narrow with respect to time.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='51' e='51'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Low Time &#62; Maximum</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects the low pulse is too wide with respect to time.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='52' e='52'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal High Time &#60; Minimum</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects the high pulse is too narrow with respect to time.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='53' e='53'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal High Time &#62; Maximum</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects the high pulse is too wide with respect to time.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='54' e='54'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Frequency Too Low</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects excessive duration for one cycle of the output across a specified sample size.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='55' e='55'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Frequency Too High</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects insufficient duration for one cycle of the output across a specified sample size.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='56' e='56'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Frequency Incorrect</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module measures an incorrect number of cycles in a given time period.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='57' e='57'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Has Too Few Pulses</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module measures too few pulses (e.g., position is calibrated in counts from one extreme to the other).</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='58' e='58'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Has Too Many Pulses</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module measures too many pulses (e.g., position is calibrated in counts from one extreme to the other).</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='59' e='59'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='60' e='60'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='61' e='61'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='62' e='62'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='63' e='63'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='64' e='64'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='65' e='65'>
+<TEXT>
+<TUV xml:lang='en-US'>General Checksum Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate an incorrect checksum calculation where memory type is not specified.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='66' e='66'>
+<TEXT>
+<TUV xml:lang='en-US'>General Memory Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate a memory failure where memory type is not specified.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='67' e='67'>
+<TEXT>
+<TUV xml:lang='en-US'>Special Memory Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate a memory failure where the specific memory type is not defined in this category.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='68' e='68'>
+<TEXT>
+<TUV xml:lang='en-US'>Data Memory Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate a data (or working) memory failure for embedded systems using FLASH memory. This is equivalent to RAM in RAM/ROM/EEPROM embedded systems.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='69' e='69'>
+<TEXT>
+<TUV xml:lang='en-US'>Program Memory Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate a program memory failure for embedded systems using FLASH memory. This is equivalent to ROM in RAM/ROM/EEPROM embedded systems.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='70' e='70'>
+<TEXT>
+<TUV xml:lang='en-US'>Calibration / Parameter Memory Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate a calibration / parameter memory failure for embedded systems using FLASH memory. This is equivalent to EEPROM in RAM/ROM/EEPROM embedded systems.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='71' e='71'>
+<TEXT>
+<TUV xml:lang='en-US'>Watchdog / Safety µC Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate a watchdog / safety µC failure, or a failure in the execution of operational software.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='72' e='72'>
+<TEXT>
+<TUV xml:lang='en-US'>Supervision Software Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate a supervision software failure.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='73' e='73'>
+<TEXT>
+<TUV xml:lang='en-US'>Internal Electronic Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate the detection of an internal circuit failure.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='74' e='74'>
+<TEXT>
+<TUV xml:lang='en-US'>Incorrect Component Installed</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate a mismatch between the hardware connected to the control module and the hardware expected by the control module.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='75' e='75'>
+<TEXT>
+<TUV xml:lang='en-US'>Over Temperature</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate the detection of an internal temperature above the expected range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='76' e='76'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='77' e='77'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='78' e='78'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='79' e='79'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='80' e='80'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='81' e='81'>
+<TEXT>
+<TUV xml:lang='en-US'>Not Programmed</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate that programming is required.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='82' e='82'>
+<TEXT>
+<TUV xml:lang='en-US'>Not Activated</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate that some portion of the program has not been enabled.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='83' e='83'>
+<TEXT>
+<TUV xml:lang='en-US'>Deactivated</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate that that some portion of the program has been disabled.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='84' e='84'>
+<TEXT>
+<TUV xml:lang='en-US'>Missing Calibration</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate that an operational range, etc., for a sensor or actuator must be taught to the control module, e.g. by programming or learning.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='85' e='85'>
+<TEXT>
+<TUV xml:lang='en-US'>Not Configured</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate the need to enter (program) the sub system option content or the vehicle option content.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='86' e='86'>
+<TEXT>
+<TUV xml:lang='en-US'>Invalid / Incompatible Configuration</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type indicates a control module or system configuration that cannot be valid, e.g. to have mutually exclusive options set on at the same time, or a set up that is not supported by the currently installed hardware/software.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='87' e='87'>
+<TEXT>
+<TUV xml:lang='en-US'>Invalid / Incompatible Software Component </TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate that a software component (calibration or program) has been identified as invalid for the control module or incompatible with other hardware or software identified by the control module, e.g. a downloaded calibration software component is incompatible with a permanent or downloaded strategy software component.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='88' e='88'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='89' e='89'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='90' e='90'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='91' e='91'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='92' e='92'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='93' e='93'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='94' e='94'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='95' e='95'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='96' e='96'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='97' e='97'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Calculation Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for algorithm based calculation failures where the calculated value is outside the expected range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='98' e='98'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Compare Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module compares two or more input parameters for plausibility but cannot specifically identify the component that is faulted.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='99' e='99'>
+<TEXT>
+<TUV xml:lang='en-US'>Circuit / Component Protection Time-Out</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects a function is active for greater than a specified time period.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='100' e='100'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Plausibility Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects a single input parameter is operating outside the plausible range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='101' e='101'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Has Too Few Transitions / Events</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module monitors a parameter over time within specified limits and detects fewer than the expected number of transitions.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='102' e='102'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Has Too Many Transitions / Events</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module monitors a parameter over time within specified limits and detects more than the expected number of transitions.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='103' e='103'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Incorrect After Event</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module does not see the correct change of a parameter or group of parameters in response to a particular event.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='104' e='104'>
+<TEXT>
+<TUV xml:lang='en-US'>Event Information</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate the detection of a system event that was not caused by the control module itself but forces the control module to store a DTC (e.g. missing functionality from another system/control module).</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='105' e='105'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='106' e='106'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='107' e='107'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='108' e='108'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='109' e='109'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='110' e='110'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='111' e='111'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='112' e='112'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='113' e='113'>
+<TEXT>
+<TUV xml:lang='en-US'>Actuator Stuck</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module does not detect any mechanical motion in response to energizing a motor, solenoid, relay, etc.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='114' e='114'>
+<TEXT>
+<TUV xml:lang='en-US'>Actuator Stuck Open</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module does not detect any mechanical motion upon commanding the operation of a motor, solenoid, relay, etc., to close some piece of equipment.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='115' e='115'>
+<TEXT>
+<TUV xml:lang='en-US'>Actuator Stuck Closed</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module does not detect any mechanical motion upon commanding the operation of a motor, solenoid, relay, etc., to open some piece of equipment.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='116' e='116'>
+<TEXT>
+<TUV xml:lang='en-US'>Actuator Slipping</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects excessive duration to command a motor, solenoid, relay, etc., to move a piece of equipment to a desired position.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='117' e='117'>
+<TEXT>
+<TUV xml:lang='en-US'>Emergency Position Not Reachable</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module is unable to command a motor, solenoid, relay, etc., to move a piece of equipment to the emergency position.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='118' e='118'>
+<TEXT>
+<TUV xml:lang='en-US'>Wrong Mounting Position</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects incorrectly mounted components, e.g., acceleration sensor showing a position error of 90°.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='119' e='119'>
+<TEXT>
+<TUV xml:lang='en-US'>Commanded Position Not Reachable</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module is unable to command a motor, solenoid, relay, etc., to move a piece of equipment to the commanded position either due to a failure in the actuator or its mechanical environment.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='120' e='120'>
+<TEXT>
+<TUV xml:lang='en-US'>Alignment or Adjustment Incorrect</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects incorrectly adjusted or aligned components.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='121' e='121'>
+<TEXT>
+<TUV xml:lang='en-US'>Mechanical Linkage Failure </TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects that the actuator is operational but the driven device is not operating, e.g., drive cable for power sliding door broken.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='122' e='122'>
+<TEXT>
+<TUV xml:lang='en-US'>Fluid Leak or Seal Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects that a mechanical component has an unexpected gas or liquid flow in, out, or through the component.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='123' e='123'>
+<TEXT>
+<TUV xml:lang='en-US'>Low Fluid Level</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects that a fluid level is too low for proper operation of the system.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='124' e='124'>
+<TEXT>
+<TUV xml:lang='en-US'>Slow Response</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used where control module has detected a response that is longer than expected or a degraded rate of change in the monitored component or system. </TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='125' e='125'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='126' e='126'>
+<TEXT>
+<TUV xml:lang='en-US'>Actuator Stuck On</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects the actuator mechanical function is fixed in the ON / applied state</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='127' e='127'>
+<TEXT>
+<TUV xml:lang='en-US'>Actuator Stuck Off</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects the actuator mechanical function is fixed in the OFF / Released state</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='128' e='128'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='129' e='129'>
+<TEXT>
+<TUV xml:lang='en-US'>Invalid Serial Data Received</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate a signal was received with the corresponding validity bit equal to "invalid" or post processing of the signal determines it is invalid.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='130' e='130'>
+<TEXT>
+<TUV xml:lang='en-US'>Alive / Sequence Counter Incorrect / Not Updated</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate that a signal was received without the corresponding rolling count value being properly updated.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='131' e='131'>
+<TEXT>
+<TUV xml:lang='en-US'>Value of Signal Protection Calculation Incorrect</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used by the control module to indicate, that a message was processed with an incorrect protection (checksum) calculation.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='132' e='132'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Below Allowable Range</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where some circuit quantity, reported via serial data, is below a specified range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='133' e='133'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Above Allowable Range</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where some circuit quantity, reported via serial data, is above a specified range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='134' e='134'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal Invalid</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where some circuit quantity, reported via serial data, is not plausible given the operating conditions.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='135' e='135'>
+<TEXT>
+<TUV xml:lang='en-US'>Missing Message</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where one (or more) expected message(s) is not received, e.g., periodic transmission where the repetition time is too high, or message not received as a result of unforeseen reset events of the concerning component (e.g. engine control unit communicating with ABS).</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='136' e='136'>
+<TEXT>
+<TUV xml:lang='en-US'>Bus off</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where a data bus is not available.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='137' e='137'>
+<TEXT>
+<TUV xml:lang='en-US'>Data Transfer Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This subtype is for failures where an ECU requests a data transfer from an external source (off-board, on-board, or another ECU) and the data transfer initiates but fails to complete.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='138' e='138'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='139' e='139'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='140' e='140'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='141' e='141'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='142' e='142'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='143' e='143'>
+<TEXT>
+<TUV xml:lang='en-US'>Erratic</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the signal, reported via serial data, is momentarily implausible or discontinuous.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='144' e='144'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='145' e='145'>
+<TEXT>
+<TUV xml:lang='en-US'>Parametric</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has detected that a component parameter (e.g., capacitance or inductance) is outside its expected range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='146' e='146'>
+<TEXT>
+<TUV xml:lang='en-US'>Performance or Incorrect Operation</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has detected that the component performance is outside its expected range or operating in an incorrect way.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='147' e='147'>
+<TEXT>
+<TUV xml:lang='en-US'>No Operation</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has detected that the component is not operating.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='148' e='148'>
+<TEXT>
+<TUV xml:lang='en-US'>Unexpected Operation</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has detected that the component is operating in a way or at a time that it has not been commanded to operate.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='149' e='149'>
+<TEXT>
+<TUV xml:lang='en-US'>Incorrect Assembly</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has detected that the component has been incorrectly installed (e.g., hydraulic pipes crossed over, circuits cross wired) or polarity errors.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='150' e='150'>
+<TEXT>
+<TUV xml:lang='en-US'>Component Internal Failure</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has received an indication about the component that indicates a failure (e.g., an intelligent actuator or sensor) is indicating an internal fault.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='151' e='151'>
+<TEXT>
+<TUV xml:lang='en-US'>Component or System Operation Obstructed or Blocked</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has detected that the operation of a component is prevented by an obstruction, e.g., advanced cruise system radar beam obstructed.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='152' e='152'>
+<TEXT>
+<TUV xml:lang='en-US'>Component or System Over Temperature</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has detected that the temperature is too high for the correct operation of the component or system.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='153' e='153'>
+<TEXT>
+<TUV xml:lang='en-US'>Exceeded Learning Limit</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has detected that the component or system has exceeded the expected range allowed for learning component tolerances.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='154' e='154'>
+<TEXT>
+<TUV xml:lang='en-US'>Component or System Operating Conditions</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has detected that environmental or other operating conditions are either temporarily or permanently outside the design limits for correct operation such that all or part of a component function is inhibited or fails, e.g. a radio is disabled because its LCD display or its CD mechanism cannot operate at a low ambient temperature.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='155' e='155'>
+<TEXT>
+<TUV xml:lang='en-US'>High/Excessive Flow</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has detected that the component or system is operating above the expected flow range flow, e.g. too much EGR at idle.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='156' e='156'>
+<TEXT>
+<TUV xml:lang='en-US'>Low/Insufficient Flow</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module has detected that the component or system is operating below the expected flow range flow, e.g. too little EGR at part throttle.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='157' e='157'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='158' e='158'>
+<TEXT>
+<TUV xml:lang='en-US'>Stuck On</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects the electrical circuit or switch is fixed in the ON / Applied state</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='159' e='159'>
+<TEXT>
+<TUV xml:lang='en-US'>Stuck Off</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module detects the electrical circuit or switch is fixed in the OFF / Released state.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='160' e='160'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='161' e='161'>
+<TEXT>
+<TUV xml:lang='en-US'>System Voltage</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures, where the control module system voltage is outside the expected range but not identified as too high or too low.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='162' e='162'>
+<TEXT>
+<TUV xml:lang='en-US'>System Voltage Low</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module system voltage is below a specified range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='163' e='163'>
+<TEXT>
+<TUV xml:lang='en-US'>System Voltage High</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This sub type is used for failures where the control module system voltage is above a specified range.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='164' e='164'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='165' e='165'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='166' e='166'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='167' e='167'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='168' e='168'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='169' e='169'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='170' e='170'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='171' e='171'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='172' e='172'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='173' e='173'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='174' e='174'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='175' e='175'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='176' e='176'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='177' e='177'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='178' e='178'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='179' e='179'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='180' e='180'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='181' e='181'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='182' e='182'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='183' e='183'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='184' e='184'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='185' e='185'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='186' e='186'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='187' e='187'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='188' e='188'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='189' e='189'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='190' e='190'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='191' e='191'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='192' e='192'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='193' e='193'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='194' e='194'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='195' e='195'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='196' e='196'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='197' e='197'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='198' e='198'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='199' e='199'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='200' e='200'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='201' e='201'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='202' e='202'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='203' e='203'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='204' e='204'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='205' e='205'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='206' e='206'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='207' e='207'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='208' e='208'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='209' e='209'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='210' e='210'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='211' e='211'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='212' e='212'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='213' e='213'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='214' e='214'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='215' e='215'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='216' e='216'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='217' e='217'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='218' e='218'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='219' e='219'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='220' e='220'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='221' e='221'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='222' e='222'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='223' e='223'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='224' e='224'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='225' e='225'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='226' e='226'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='227' e='227'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='228' e='228'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='229' e='229'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='230' e='230'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='231' e='231'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='232' e='232'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='233' e='233'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='234' e='234'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='235' e='235'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='236' e='236'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='237' e='237'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='238' e='238'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='239' e='239'>
+<TEXT>
+<TUV xml:lang='en-US'>ISO/SAE Reserved</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved by the document for future expansion.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='240' e='240'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='241' e='241'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='242' e='242'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='243' e='243'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='244' e='244'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='245' e='245'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='246' e='246'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='247' e='247'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='248' e='248'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='249' e='249'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='250' e='250'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='251' e='251'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='252' e='252'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='253' e='253'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='254' e='254'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='255' e='255'>
+<TEXT>
+<TUV xml:lang='en-US'>Manufacturer Defined</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>This value is reserved for vehicle manufacturer/system supplier use.</TUV>
+</ADDINFO>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADC59AE0' oid='12159041D0E449b0A4FE56913A9145FA' temploid='11BA497CE1EA486eB27CEB6A827DAFF2' bm='1' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>Warning indicator requested (1Bit)</TUV>
+</NAME>
+<QUAL>Warning_indicator_requested_1Bit</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADC59C10' oid='7DBA4E3FA02845f590B57347BA4F8613' temploid='A0CE6DB6519E4018A3ABB533BC338729' bm='1' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>Test not completed this operation cycle (1Bit)</TUV>
+</NAME>
+<QUAL>TestNotCompletedThisOperationCycle</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADC58F00' oid='50D4B765792647448C08D11361450B82' temploid='CB930689F6E84142AF72AC95F9D82B11' bm='1' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>Test failed since last clear (1Bit)</TUV>
+</NAME>
+<QUAL>Test_failed_since_last_clear_1Bit</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADC56570' oid='6DD983D25A3C47d1AC3FDC605BD6A205' temploid='875242DB1629499bA79CBEE195DCBEAF' bm='1' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>Test not completed since last clear (1Bit)</TUV>
+</NAME>
+<QUAL>Test_not_completed_since_last_clear_1Bit</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADC59750' oid='24AB1C9DF6D741c0B3C1A0413D5AA99D' temploid='F26154E25F80472cAC8C3877BBB4B5B1' bm='1' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>Confirmed DTC (1Bit)</TUV>
+</NAME>
+<QUAL>ConfirmedDTC</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADC56440' oid='B16504E72E554478A2C48596C2919CD3' temploid='523896FBAE4D4245993AE1041A70F7A4' bm='1' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>Pending DTC (1Bit)</TUV>
+</NAME>
+<QUAL>PendingDTC</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADC59160' oid='33D231A181DC4d5eBF7F83EA9728E7A3' temploid='767E5863F1CA402d9238DF6EE6545BA0' bm='1' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>TestFailedThisOperationCycle (1Bit)</TUV>
+</NAME>
+<QUAL>TestFailedThisOperationCycle</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADC59880' oid='556F0EAE781C487a8AE019A25C1BF78D' temploid='FA563844960D44528D7059A880C62244' bm='1' xauth='m'>
+<NAME>
+<TUV xml:lang='en-US'>TestFailed (1Bit)</TUV>
+</NAME>
+<QUAL>TestFailed_1Bit</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>false</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>true</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADC00460' oid='3BA6076111A84683A1CCDA6C9CC164F7' temploid='05E538DACA0B4d399BD96247CA0C38E6' bm='65535'>
+<NAME>
+<TUV xml:lang='en-US'>DTC OBD</TUV>
+</NAME>
+<QUAL>DTC_OBD</QUAL>
+<ENUM oid='AE8D2A187F304935990393DCFB90E5B3' temploid='17BE1991FFFC4e5eAE5ED0DA168CF27E' attrref='_000001B18CF21D90' v='29'/>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC00100' oid='62E1513A745842a992183F25A76F4984' temploid='36334FA2F7E849c7BF53382D21419FC9' bm='65535'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Root Cause EventId</TUV>
+</NAME>
+<QUAL>DTC_Root_Cause_EventId</QUAL>
+<ENUM oid='77365D65B1F745c084531BB3A87496D1' temploid='477C4219B5164fe1A1DF1E7937E5537C' attrref='_000001B18CF21D90' v='28'/>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC00580' oid='ABFBB79FE13E49b4878040883E0FA452' temploid='1CF90C79CFDF4614B36858FEEAE0F38A' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Number of Tested Operation Cycles since first Fail</TUV>
+</NAME>
+<QUAL>DTC_Number_of_Tested_Operation_Cycles_since_first_Fail</QUAL>
+<ENUM oid='0B090B12F4AF46d7A8FC3EC4216BD236' temploid='20EDF39F2BCB47bb9A129E55B3DEA20A' attrref='_000001B18CF21D90' v='27'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC006A0' oid='CFF1327F39F84dfeBC50658970592CB4' temploid='06559E67975C4eb6A18069AEEB3BEA7F' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Number of Consecutive Operation Cycles with Failed Test</TUV>
+</NAME>
+<QUAL>DTC_Number_of_Consecutive_Operation_Cycles_with_Failed_Test</QUAL>
+<ENUM oid='0E647E9281FA44fc8E01C57E0F2A236A' temploid='6DFAFEAA99E0480181775C82D0EF291D' attrref='_000001B18CF21D90' v='26'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC01540' oid='AEF624BB607846c698B9414D74612D84' temploid='4E38CC7B55224ec083034BF8684337A9' bm='65535'>
+<NAME>
+<TUV xml:lang='en-US'>DTC OccurrenceCounter (2 Byte)</TUV>
+</NAME>
+<QUAL>DTC_OccurrenceCounter_2_Byte</QUAL>
+<ENUM oid='895855AB68DE485c940BF24E1E8C3AE7' temploid='3A6E53825DC1448cA47CE1343B30A803' attrref='_000001B18CF21D90' v='25'/>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC010C0' oid='D719A8BEE4384db5BE9C86073F574272' temploid='576326D2B0DF41bd988D89780807776B' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Number of Operation Cycles with Failed Test</TUV>
+</NAME>
+<QUAL>DTC_Number_of_Operation_Cycles_with_Failed_Test</QUAL>
+<ENUM oid='B113C207D62F48eeBA011EA95B6E6166' temploid='7B7190EE7CF142a49439D11AB30045D0' attrref='_000001B18CF21D90' v='12'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC01420' oid='95B2D230015246ddAE5E3F7F67C3769F' temploid='C1283A4FAB884010B338842F75B932F8' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Number of Operation Cycles since last Fail</TUV>
+</NAME>
+<QUAL>DTC_Number_of_Operation_Cycles_since_last_Fail</QUAL>
+<ENUM oid='42594A0BAF59475d859D45F28B867558' temploid='C04DBE7C297142208D5C686E25A1A942' attrref='_000001B18CF21D90' v='10'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC01780' oid='2AD72D401CFE404cAD4648BEF2776E25' temploid='69D37BDB7DE143bcAEB4887BFEDE0170' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Number of Operation Cycles since first Fail</TUV>
+</NAME>
+<QUAL>DTC_Number_of_Operation_Cycles_since_first_Fail</QUAL>
+<ENUM oid='5295F79930C94ceeAFAAACB75157A1B2' temploid='A087D5ED9A8A485aA72595D14D7A0EC7' attrref='_000001B18CF21D90' v='11'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADC58320' oid='D2791505F64145e2866D790B8811D6F9' temploid='13B76B1055134c8fAA3373355DE9F12D' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC FaultDetectionCounter - Maximum this Operation Cycle</TUV>
+</NAME>
+<QUAL>DTC_FaultDetectionCounter_Maximum_this_Operation_Cycle</QUAL>
+<ENUM oid='B117265002B74900A10B275DCE663C6E' temploid='28A508CCC4144b62B29E59D859750164' attrref='_000001B18CF21D90' v='9'/>
+<CVALUETYPE bl='8' bo='21' enc='sgn' sig='0' df='dec' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='-128' e='-128'>
+<TEXT>
+<TUV xml:lang='en-US'>Test passed this operation cycle</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='-127' e='-1'>
+<TEXT>
+<TUV xml:lang='en-US'>Test never completed - was passing</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>Test never run</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='126'>
+<TEXT>
+<TUV xml:lang='en-US'>Test never completed - was failing</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='127' e='127'>
+<TEXT>
+<TUV xml:lang='en-US'>Test failed this operation cycle</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADC59290' oid='F59526A85F2440bfB6034ECE97D6830D' temploid='467ED6051F4C4c1aB626426E74DEA3BF' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC FaultDetectionCounter - Maximum since last DTC clear</TUV>
+</NAME>
+<QUAL>DTC_FaultDetectionCounter_Maximum_since_last_DTC_clear</QUAL>
+<ENUM oid='235474CF32E04333A35C8DCC844D8FF6' temploid='045042EBD50A42deA613464535CFA279' attrref='_000001B18CF21D90' v='8'/>
+<CVALUETYPE bl='8' bo='21' enc='sgn' sig='0' df='dec' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='-128' e='-128'>
+<TEXT>
+<TUV xml:lang='en-US'>Test passed since last DTC clear</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='-127' e='-1'>
+<TEXT>
+<TUV xml:lang='en-US'>Test never completed - was passing</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>Test never run</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='126'>
+<TEXT>
+<TUV xml:lang='en-US'>Test never completed - was failing</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='127' e='127'>
+<TEXT>
+<TUV xml:lang='en-US'>Test failed since last DTC clear</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADC593C0' oid='99D791A1B50B490985992D04E161C424' temploid='E9FAC8AE7C0E4c54A4CAB2D35D6FD0D0' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC FaultDetectionCounter</TUV>
+</NAME>
+<QUAL>DTC_FaultDetectionCounter</QUAL>
+<ENUM oid='C89C22F9BB67442e8A25C992B6C8C066' temploid='80D6CD5096DF45808B979F07B6327A24' attrref='_000001B18CF21D90' v='7'/>
+<CVALUETYPE bl='8' bo='21' enc='sgn' sig='0' df='dec' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='-128' e='-128'>
+<TEXT>
+<TUV xml:lang='en-US'>Test Passed</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='-127' e='-1'>
+<TEXT>
+<TUV xml:lang='en-US'>Unqualified (passing)</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>Unqualified</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='126'>
+<TEXT>
+<TUV xml:lang='en-US'>Unqualified (failing)</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='127' e='127'>
+<TEXT>
+<TUV xml:lang='en-US'>Test Failed</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADC007C0' oid='CBD8CA5FA5B14a32A8090630FC1F64E7' temploid='9F9FD3EAA65A4f69B1E36F7646DFE6CC' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Aging Counter (Counting Downwards)</TUV>
+</NAME>
+<QUAL>DTC_Aging_Counter_Counting_Downwards</QUAL>
+<ENUM oid='BF18F9F8D9B04d5aA3A0ADD0D54D2A05' temploid='D09C910D087E472eBEE27B70541EA779' attrref='_000001B18CF21D90' v='6'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC019C0' oid='B2C7CA50E8794f8b8DCF50612D0591B3' temploid='D598B525595C4ef89FCE46B411A9BCFE' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Aging Counter (Counting Upwards)</TUV>
+</NAME>
+<QUAL>DTC_Aging_Counter_Counting_Upwards</QUAL>
+<ENUM oid='B4CEA07791A44ac885D3534E07549787' temploid='0C033F5A4F7E4cb3A618B48319B5B6EB' attrref='_000001B18CF21D90' v='2'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC00220' oid='587ACE32491146d2B9076A1A63F4F9B7' temploid='1996474C4EC24c7487264A0FCF74CC18' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Static Priority</TUV>
+</NAME>
+<QUAL>DTC_Static_Priority</QUAL>
+<ENUM oid='89572A9639A54cbaAEDD4D1611919D54' temploid='B1A779C930B8437fA11876AC9D2008E5' attrref='_000001B18CF21D90' v='5'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADCA0B40' oid='43939D1D873B4906AD1F051091A7C168' temploid='D0BDE2B68C88490b909073ECABE25F6B' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Significance</TUV>
+</NAME>
+<QUAL>DTC_Significance</QUAL>
+<ENUM oid='E2F98491B6714da0B7DBD6C8153D8AE5' temploid='AD8069D5490A4bd8AAF9B72E4A94607E' attrref='_000001B18CF21D90' v='4'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<EXCL s='2' e='255' inv='noSignal'>
+<TEXT>
+<TUV xml:lang='en-US'>Reserved</TUV>
+</TEXT>
+</EXCL>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>Fault</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>Occurrence</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA28F0' oid='67FEC47DFA824b669078D8141EBD16C7' temploid='413AAE926836435688A13C9F71563F3D' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>MemoryOverflowIndication</TUV>
+</NAME>
+<QUAL>MemoryOverflowIndication</QUAL>
+<ENUM oid='E375CAAF7940412494D4C0C544763894' temploid='A254E636B7964d31983373BBB825EE72' attrref='_000001B18CF21D90' v='3'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<EXCL s='2' e='255' inv='unexpectedResult'>
+<TEXT>
+<TUV xml:lang='en-US'>Invalid</TUV>
+</TEXT>
+</EXCL>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>No Memory Overflow</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>Memory Overflow detected</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA47D0' oid='5D7DADA72B714a8f9F01071AFFCDC199' temploid='6B6DF4C034E94e598104DC92172347C6' bm='255' xauth='me'>
+<NAME>
+<TUV xml:lang='en-US'>ExtendedDataRecordNumber Group A</TUV>
+</NAME>
+<QUAL>ExtendedDataRecordNumber_Group_A</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>OccurrenceCounter</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>Counts the number of times the DTC have been set.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='255' e='255'>
+<TEXT>
+<TUV xml:lang='en-US'>All Records</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA3860' oid='926EAA7BF96049479D62832FF61FA8FB' temploid='244F1A44DB454505BB1FD161C18136B8' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>ExtendedDataRecordNumber with FF</TUV>
+</NAME>
+<QUAL>ExtendedDataRecordNumber_with_FF</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>OccurrenceCounter</TUV>
+</TEXT>
+<ADDINFO>
+<TUV xml:lang='en-US'>Counts the number of times the DTC have been set.</TUV>
+</ADDINFO>
+</TEXTMAP>
+<TEXTMAP s='255' e='255'>
+<TEXT>
+<TUV xml:lang='en-US'>ReadAllRecords</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA07B0' oid='43B39296E5E8466b866CAC7ADE2E55D7' temploid='E828552B401F42118684A920905FF64C' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC SnapshotRecordNumbers only FF</TUV>
+</NAME>
+<QUAL>DTC_SnapshotRecordNumbers_only_FF</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='255' e='255'>
+<TEXT>
+<TUV xml:lang='en-US'>All Records (0xFF)</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADC00A00' oid='5152851F7C5D4efdAFC1C2A3642007B5' temploid='CDA830EEFDF64a468DC56BC5613FC866' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC OccurrenceCounter</TUV>
+</NAME>
+<QUAL>OccurrenceCounter</QUAL>
+<ENUM oid='EDB2252F1C2C4f28A3FB10BB75769130' temploid='8044B13A12D74dc4A6498272DEC35483' attrref='_000001B18CF21D90' v='1'/>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADCA14C0' oid='EF81CF21AADC48e9A6408F21846A3F07' temploid='0A82EFE5266149a5B2E51F562DF3A7A9' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>Example</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADC00B20' oid='CD2EA1CBD37D4b86A30C99B76E4C86D5' temploid='1775ECC34C7E42a08F2CC26A87F37BE4' bm='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity-DTC Class_4  (Bit 4)</TUV>
+</NAME>
+<QUAL>DTCSeverity_DTC_Class_4_Bit_4</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC01AE0' oid='B0E46509BE7548838F6D264936FBEC85' temploid='1E9E10200AE348deAAD915ABD352D5B2' bm='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity-DTC Class_2  (Bit 2)</TUV>
+</NAME>
+<QUAL>DTCSeverity_DTC_Class_2_Bit_2</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC00C40' oid='9B96C10736C345219F9725A2C887CC29' temploid='71F7BB46386744d0897A4A3C8F3E9607' bm='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity-DTC Class_3  (Bit 3)</TUV>
+</NAME>
+<QUAL>DTCSeverity_DTC_Class_3_Bit_3</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADC018A0' oid='8322C5AD69104483BD099F7E56E06396' temploid='C934C88B83D046108D80D265D78E2476' bm='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity-DTC Class_1  (Bit 1)</TUV>
+</NAME>
+<QUAL>DTCSeverity_DTC_Class_1_Bit_1</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<IDENT id='_000001B1ADBFFC80' oid='D1AE705CDA274812B6987AA483143E7D' temploid='51E3A10F044841b4B9B307065B047A1A' bm='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity-DTC Class_0 (Bit 0)</TUV>
+</NAME>
+<QUAL>DTCSeverity_DTC_Class_0_Bit_0</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADCA0A10' oid='8AF18A4F45414290B9A4D14B71A10753' temploid='248CACD8FA7649f89C492DB4CD2A889A' bm='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity-checkImmediately (Bit 7)</TUV>
+</NAME>
+<QUAL>DTCSeverity_checkImmediately_Bit_7</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>do not checkImmediately</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>checkImmediately</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA4570' oid='DB67F7BF3ADE43878EB7FA7990DCDF3D' temploid='C292CEE82F0F42f388F4FEAB672CCB32' bm='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity-checkAtNextHalt (Bit 6)</TUV>
+</NAME>
+<QUAL>DTCSeverity_checkAtNextHalt_Bit_6</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>do not checkAtNextHalt</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>checkAtNextHalt</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA2B50' oid='A14E627BF98040d990580E8364F6780E' temploid='6AD42C451BB4489dB5A9FFE1FC7D0412' bm='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity-maintenanceOnly (Bit 5)</TUV>
+</NAME>
+<QUAL>DTCSeverity_maintenanceOnly_Bit_5</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>no maintenanceOnly severity</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>maintenanceOnly severity</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<IDENT id='_000001B1ADCB9BA0' oid='22548DC44FF8463bA1695F532FA32671' temploid='AA3EBD1A183B418583218C2A493CB395' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Hex Dump (1..65536 Bytes)</TUV>
+</NAME>
+<QUAL>Hex_Dump_1_65536_Bytes</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='1' maxsz='65536'/>
+<PVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='1' maxsz='65536'/>
+</IDENT>
+<TEXTTBL id='_000001B1ADCA1390' oid='C450FBDEF09B47ff816816990CC36966' temploid='1A07506D3E1F4a96806C4D433A1EB8EF' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>FunctionalGroupID</TUV>
+</NAME>
+<QUAL>FunctionalGroupID</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='51' e='51'>
+<TEXT>
+<TUV xml:lang='en-US'>Emission-system group</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='254' e='254'>
+<TEXT>
+<TUV xml:lang='en-US'>V-OBD system</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='255' e='255'>
+<TEXT>
+<TUV xml:lang='en-US'>All functional system groups</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA0550' oid='D61608EEA61A44148240AE8B70A0B91A' temploid='765CCBC9B784439399EA00947E0B5C05' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>SnapshotRecordNumber 10 and 20</TUV>
+</NAME>
+<QUAL>SnapshotRecordNumber_10_and_20</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<EXCL s='0' e='15' inv='invalidSignal'>
+</EXCL>
+<EXCL s='17' e='31' inv='invalidSignal'>
+</EXCL>
+<EXCL s='33' e='255' inv='invalidSignal'>
+</EXCL>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='16' e='16'>
+<TEXT>
+<TUV xml:lang='en-US'>Snapshot Record 10</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='32' e='32'>
+<TEXT>
+<TUV xml:lang='en-US'>Snapshot Record 20</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA2C80' oid='C5B694FAC27C4fc5B1D4B3E7615B3840' temploid='3AD7E6CD406E4610A91C09DDB27BF26D' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>SnapshotRecordNumber 00 and 10</TUV>
+</NAME>
+<QUAL>SnapshotRecordNumber_00_and_10</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<EXCL s='1' e='15' inv='invalidSignal'>
+</EXCL>
+<EXCL s='17' e='254' inv='invalidSignal'>
+</EXCL>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>FreezeFrame</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='16' e='16'>
+<TEXT>
+<TUV xml:lang='en-US'>Snapshot Record 10</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA21D0' oid='B7B4F106E6F749ec81C062396E3F4703' temploid='857543D4F4034c46AB9F7C849D0721A7' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DTC AllSupportedSnapshotRecordNumbers with FF</TUV>
+</NAME>
+<QUAL>DTC_AllSupportedSnapshotRecordNumbers_with_FF</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>Snapshot</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='255' e='255'>
+<TEXT>
+<TUV xml:lang='en-US'>All Records (0xFF)</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA2300' oid='077A538D6F764bf88863AEFDE4B26DF5' temploid='3E2845CFCE964c838C7952A2B5573A1C' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction EventType (Set up)</TUV>
+</NAME>
+<QUAL>Subfunction_EventType_Set_up</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>OnDTCStatusChange (do not store event)</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='2' e='2'>
+<TEXT>
+<TUV xml:lang='en-US'>OnTimerInterrupt</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='3' e='3'>
+<TEXT>
+<TUV xml:lang='en-US'>OnChangeOfDataIdentifier</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='7' e='7'>
+<TEXT>
+<TUV xml:lang='en-US'>OnComparisonOfValues</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='32' e='47'>
+<TEXT>
+<TUV xml:lang='en-US'>VehicleManufacturerSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='48' e='62'>
+<TEXT>
+<TUV xml:lang='en-US'>SystemSupplierSpecific</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='65' e='65'>
+<TEXT>
+<TUV xml:lang='en-US'>OnDTCStatusChange (storeEvent)</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='66' e='66'>
+<TEXT>
+<TUV xml:lang='en-US'>OnTimerInterrupt (storeEvent)</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='67' e='67'>
+<TEXT>
+<TUV xml:lang='en-US'>OnChangeOfDataIdentifier (storeEvent)</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='71' e='71'>
+<TEXT>
+<TUV xml:lang='en-US'>OnComparisonOfValues (storeEvent)</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='96' e='111'>
+<TEXT>
+<TUV xml:lang='en-US'>VehicleManufacturerSpecific (storeEvent)</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='112' e='126'>
+<TEXT>
+<TUV xml:lang='en-US'>SystemSupplierSpecific (storeEvent)</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA34D0' oid='3A334091831E414b858067C51F11CEDC' temploid='D567853C7A804402A04E79EE9CD2DF6C' bm='15'>
+<NAME>
+<TUV xml:lang='en-US'>CommunicationTypeNetworks</TUV>
+</NAME>
+<QUAL>CommunicationTypeNetworks</QUAL>
+<CVALUETYPE bl='4' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>allNetworks</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='15' e='15'>
+<TEXT>
+<TUV xml:lang='en-US'>receivingNetworks</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<LINCOMP id='_000001B1ADC19E70' oid='3E63043CCAF44057A3144CDC03CA07B3' temploid='016CF576AEA9494086A810D623CE70E3' bm='65535'>
+<NAME>
+<TUV xml:lang='en-US'>P2Ex</TUV>
+</NAME>
+<QUAL>P2Ex</QUAL>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='0' maxsz='255'/>
+<PVALUETYPE bl='64' bo='21' enc='dbl' sig='0' df='dec' qty='atom' sz='no' minsz='0' maxsz='255'>
+<UNIT>ms</UNIT>
+</PVALUETYPE>
+<COMP f='10' o='0'>
+</COMP>
+</LINCOMP>
+<IDENT id='_000001B1ADCB8640' oid='5327556765B84618890B6648433B138F' temploid='DE7405E5787845bf95533B43B4C93C84' bm='65535'>
+<NAME>
+<TUV xml:lang='en-US'>P2</TUV>
+</NAME>
+<QUAL>P2</QUAL>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='dec' qty='atom' sz='no' minsz='1' maxsz='1'>
+<UNIT>ms</UNIT>
+</CVALUETYPE>
+<PVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='dec' qty='atom' sz='no' minsz='1' maxsz='1'>
+<UNIT>ms</UNIT>
+</PVALUETYPE>
+</IDENT>
+<TEXTTBL id='_000001B1ADCA4EF0' oid='FF423FBC036C4d198B7BEA8367E22D6B' temploid='{87D9E8FC-B4B9-46e5-88BF-39B28422102E}' bm='1'>
+<NAME>
+<TUV xml:lang='en-US'>off/on (1 Bit)</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>0=off; 1=on</TUV>
+</DESC>
+<QUAL>offOn_1Bit</QUAL>
+<CVALUETYPE bl='1' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>off</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>on</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<LINCOMP id='_000001B1ADC18A70' oid='A9371AD7BE43456bBFB0F6488594C5E1' bm='65535'>
+<NAME>
+<TUV xml:lang='en-US'>LowVoltage_u16</TUV>
+</NAME>
+<QUAL>LowVoltage_u16</QUAL>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='0' maxsz='255'/>
+<EXCL s='65535' e='65535' inv='noSignal'>
+<TEXT>
+<TUV xml:lang='en-US'>Signal not available</TUV>
+</TEXT>
+</EXCL>
+<PVALUETYPE bl='64' bo='21' enc='dbl' sig='2' df='flt' qty='atom' sz='no' minsz='0' maxsz='255'>
+<UNIT>V</UNIT>
+</PVALUETYPE>
+<COMP e='65534' f='0.001' o='0'>
+</COMP>
+</LINCOMP>
+<TEXTTBL id='_000001B1ADCA79B0' oid='FDA4681851CC42388601B7ECBF6AECD2' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DIO State</TUV>
+</NAME>
+<QUAL>DIO_State</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>DIO_LOW</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>DIO_HIGH</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<TEXTTBL id='_000001B1ADCA7750' oid='3D07CB4C556E48308225EF97723C4AE5' bm='255'>
+<NAME>
+<TUV xml:lang='en-US'>DIO Write State</TUV>
+</NAME>
+<QUAL>DIO_Write_State</QUAL>
+<CVALUETYPE bl='8' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TEXTMAP s='0' e='0'>
+<TEXT>
+<TUV xml:lang='en-US'>DIO_LOW</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='1' e='1'>
+<TEXT>
+<TUV xml:lang='en-US'>DIO_HIGH</TUV>
+</TEXT>
+</TEXTMAP>
+<TEXTMAP s='2' e='2'>
+<TEXT>
+<TUV xml:lang='en-US'>DIO_FLIP</TUV>
+</TEXT>
+</TEXTMAP>
+</TEXTTBL>
+<MUXDT id='_000001B1ADC1A860' oid='9B9827C4628D4c93AE42366DCFE0A8AA' temploid='687200808B2C4c81AA8867A522256D76' bm='4294967295' dtref='_000001B1ADB64B20'>
+<NAME>
+<TUV xml:lang='en-US'>Memory Address and Size</TUV>
+</NAME>
+<QUAL>Memory_Address_and_Size</QUAL>
+<CVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='9'/>
+<PVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='9'/>
+<STRUCTURE>
+<DATAOBJ oid='E72800D4159C434792D38AF74F781B27' temploid='16885161C7924820B5090D6B0F76A47D' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='B9A55DEF3F0F48dcBCA544EB340B8493' temploid='B927B739BED34bf889F7457B338DCFA5' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+<CASE oid='6C7298495BCD4094ACCA2FD53D861977' temploid='E302C31E2CB148cfA6321A8EEFB0E831' s='17' e='17'>
+<STRUCTURE>
+<DATAOBJ oid='7AC8C8CF00254b2dAE543E8CE7374AA1' temploid='72AD7DF884C94740B97040483C3DEFE2' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='C240FB9534EC4753A36629CDE7CE03C5' temploid='05DEF97AE2904382B27BD967DA3094B9' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='42D97487A3634810949EA6CCA72858AE' temploid='139F68E5F4504bb59FB1EF74831AD24A' s='18' e='18'>
+<STRUCTURE>
+<DATAOBJ oid='5FA92E86E1404f3488BDD73DD5B6417C' temploid='E71C27FB0628466f8009FD99AA0BECC4' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='5E5DA0B0B3B940e4B6708ABACEBDFD8F' temploid='D410F68F51AF4c50AB561125541A3FEE' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='E6D7994F9BA046478CA08F4EA1E814BD' temploid='6E4F0098FA894d13804E5D5891128068' s='19' e='19'>
+<STRUCTURE>
+<DATAOBJ oid='7567B1B2C632449191F6DDE70A27BE69' temploid='53A79DB6F8C74e388C6790C1C3F0455D' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='B0DA8E56BEA944f7B0CB5DA8D9BAC20F' temploid='C647563DE4D74fdfB55C933340FA692B' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='E7B85FDAEF444508B8B8686B90944AAC' temploid='0B4597C2A6874080B111AC322E3A5B4E' s='33' e='33'>
+<STRUCTURE>
+<DATAOBJ oid='7D3A92686E0D4a25B5F462A2AED04442' temploid='71C8DEA811D3460eA0D1A845E92B5CF9' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='EB977DEEDAA84e48B48D9BB3070BBEDA' temploid='0D4709E54C074ccd93724EC0492D2493' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='C971B558EAF14d068BD234CCCFC3C688' temploid='481364C203104c4987FC7B60BAB4DB68' s='34' e='34'>
+<STRUCTURE>
+<DATAOBJ oid='1F011004A5D04739B34EFFC2B28F7A5B' temploid='1D7D6AD4B3E24c3c805C95FF237CC9AD' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='E327F03B713C419fA55417CA8C195A6D' temploid='BC6E5CCEC08749fcA397A42E73C6B0B0' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='4D02E7C7F90A4f6b9C70DA17847B1E53' temploid='D8A2F0D2F0EB45708AE661F8B5BC283B' s='35' e='35'>
+<STRUCTURE>
+<DATAOBJ oid='4DAF767D7B7443b8A6C0D37E1EED1DAC' temploid='B4745B4AEA5B4ffeBC42ED100DFF0D21' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='BC3C0EB624D14e8684151493DAFE66B7' temploid='B51FEC8E6EEE4575B3D6FF4309C70D65' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='0008238A18CE408a89AFA0472D94E8FF' temploid='0AC14208708147358CA32299FB560F8E' s='49' e='49'>
+<STRUCTURE>
+<DATAOBJ oid='9C4915BA87D14f55B222D26951E3F83C' temploid='9872D2B6234B4c9b91F7196E3BF77679' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='FF25A86982A5492c93D3666744E6C41A' temploid='FB5D810DFEA440e5AA0AAFBD201F169C' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='2387A135B88A4acf91F9FE903733E015' temploid='4AB73359A6F24fbd9D28541E5DB13E8B' s='50' e='50'>
+<STRUCTURE>
+<DATAOBJ oid='DFD891A1899F47d0B9DBFCE3429044C6' temploid='5EBD44B9EC764c69BE40A8A5C70B1CAB' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='E8830F24CAA74c77B3B3F2D326F3301C' temploid='F14B9BA3DFD148469865779CE1CBAAFA' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='A8AA888AC87A4150AC31D2F39FCBDEEB' temploid='BC422047677B427c911F28C067A065DF' s='51' e='51'>
+<STRUCTURE>
+<DATAOBJ oid='EAE3DAABF85B40358218DDDC27CB1D49' temploid='6DDD82B7C6284ac3B87E82C44F6B84DA' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='787CD65954014b1bB9EBC9F3FB7D9FB0' temploid='0D64390260CC463fA66DE1E607FF2C48' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='F2FAE6A3BD1E49b09CD7E3E93C11D617' temploid='73779A86155844abA3872E01FF6A6C09' s='65' e='65'>
+<STRUCTURE>
+<DATAOBJ oid='E2DE00D0DFD64d549710A89ACB2F840B' temploid='F224E51FA50C491d8EF67D54CCB2D083' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='6C629A859D4B4d86B702B1CA80EB95B0' temploid='1A89FE111EEA40f89834CDB3553F9FB2' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='A49A5D255E354bfb9F548E8C81C89DC3' temploid='0DC8D9543978432cAEBC395045D6F378' s='66' e='66'>
+<STRUCTURE>
+<DATAOBJ oid='C07D5AF992BD49e29666B0B7D74B8E6A' temploid='2239006896314b1c947FFDC914CE3AD3' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='12DD9FFBA1DF49b085D4DB42FBDBD05A' temploid='BAC7CAC136064f2cB027E1ACC57563C6' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='FF8DEAA694CD4324A7E63D7B4A8BCE61' temploid='E2F655ADE0064bdd94D16AE9D998F98F' s='67' e='67'>
+<STRUCTURE>
+<DATAOBJ oid='5E6C90447E6B441c87FAB01CFB7A7B43' temploid='6A1C6C35324F431691298D44F9CA205B' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='EBC452AD8B654b92ABD033B583E2D28F' temploid='9155F235497D41e687C740CAD8E12D2D' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='DE857E9D112544e3B166E4B177BBA13E' temploid='EC7DC0B977C84c5aAA91D98902E51AB5' s='52' e='52'>
+<STRUCTURE>
+<DATAOBJ oid='283103456A8C44d59F49780847EA09EC' temploid='9389CE50E7234534BF5DA19B9776084F' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='4466A9853DCA46f38B27AE38B65DD14F' temploid='593C678D63754108B4CC1EFCD150CCFB' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='E90CC1D53232472e8EA09ACCE987AE61' temploid='872437ACA0FB45888095B151636F1A36' s='20' e='20'>
+<STRUCTURE>
+<DATAOBJ oid='9E201C87D3A34922A414AF66F1C3CDA1' temploid='0B25E2ABB99B40c889AC2C16C7902BCA' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='2D97BB715238482594BEC81BBF0E3FB5' temploid='3CDFC9152A0B4d0d85CC1EEB361E193F' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='00B7B7E87A634e76A362C56652E9CC07' temploid='ADA65866A96B49ef87DED6CA0D696ED6' s='36' e='36'>
+<STRUCTURE>
+<DATAOBJ oid='C44A8B0C95C54666859980A2859736EB' temploid='D132045B0FB44fae893B03B4AEBD0BFD' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='9EC74675FDBE4ecaB21C21FE0029779E' temploid='27558A51F20B4ef59B47BDE3394074B7' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='D964A29C27CF4febB465F04815B15E43' temploid='CF2A279766374162BA895071467FC2A8' s='68' e='68'>
+<STRUCTURE>
+<DATAOBJ oid='8DE04B3040D44283ADD48ED14F9723E1' temploid='9EDFCCE0378643faA1E621C834A76A4F' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='720F55CE20A54ca08C5331AD1C147954' temploid='7B97333AF8404d2bB0F97F2C9E89E2F2' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='78A18B5415154c60885EEF644A135EFB' temploid='46C092925FA443d19DC7D348467647BA' s='69' e='69'>
+<STRUCTURE>
+<DATAOBJ oid='4A7198DA038E4b8eA7478F69CE6F2EB8' temploid='A0EDC344325949d88CE99BF305812D51' spec='no' dtref='_000001B1ADB61DA0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='1C2BA9A2BE2A486bA7E77217B40089D1' temploid='C49296D84AF642b98A1D8B0229B91021' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Size</TUV>
+</NAME>
+<QUAL>Size</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+</MUXDT>
+<MUXDT id='_000001B1ADC1B6D0' oid='95A7F631D1A6485096B570AB8F13A378' temploid='5251DFD7DFC0426aB8C276291B2C34E2' bm='4294967295' dtref='_000001B1ADB64B20'>
+<NAME>
+<TUV xml:lang='en-US'>Memory Address, Size and Data</TUV>
+</NAME>
+<QUAL>Memory_Address_Size_and_Data</QUAL>
+<CVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='3' maxsz='65536'/>
+<PVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='3' maxsz='65536'/>
+<STRUCTURE>
+<DATAOBJ oid='B84E9965AFCD440a825EA44FA451C8C2' temploid='49589A916E564f4d9AF8DBC7E267E803' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='76C4AD8D7AAC4469A390ED866AB981E3' temploid='EBCE729EB8F544fc802D13E75CCE4212' spec='no' dtref='_000001B1ADB63300'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+<CASE oid='C930361491E54659BE001F9E62804D52' temploid='D859D3B08E2E4e6c94A51815A79AD32B' s='17' e='17'>
+<STRUCTURE>
+<DATAOBJ oid='7B829D0071F5477dBAA8AD13D609FBA8' temploid='90E34F978ECD4ac6BA0D9DF4BBA19AE7' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='A4D1C5D5F9EE4b599CA737E056116BDA' temploid='9463ABDD97EE4b498A08EC0CAE174645' spec='no' dtref='_000001B1ADB63300'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='14AF27DC56694803B3F0F9A27D1DB7CA' temploid='28894B1BD1E9411e810CDBD704B7FCDD' s='18' e='18'>
+<STRUCTURE>
+<DATAOBJ oid='82BFB46D2FF344849D7691AD9F319ED5' temploid='D4E55535C4A3411c9154665A15570160' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='FE91C20F68A64b9988AF3E3B4A6AD24A' temploid='8EF6B88F81F24e199ADCC1CF9CAD199A' spec='no' dtref='_000001B1ADB63300'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='A2BF24030AE2413dBFE2DEA065E9D4F2' temploid='34D866FE86DF4eebB555E48C143CCAA9' s='19' e='19'>
+<STRUCTURE>
+<DATAOBJ oid='AD6D0AE32F144da48E304965EF738A7F' temploid='9BC444286C704d1bBB2C7F19E612EF42' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='A171873F5E71440eB9633CE267081644' temploid='91A97D552E2845059EBED919FC1B5C6F' spec='no' dtref='_000001B1ADB63300'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='961CEE237C384a1bBA6BED89B79D4358' temploid='11D5434AFD1E44c5A307B78F93FFE72C' s='33' e='33'>
+<STRUCTURE>
+<DATAOBJ oid='965D2E5D867A4361861141D96DDA669D' temploid='F2147DFFEA2F42e9A6AFF700F5395EDB' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='E21BDB5749524ac2A3BDF27D66A4D14D' temploid='C66E9183FAFF4b8894B6823ED5E9A558' spec='no' dtref='_000001B1ADB631E0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='2D7B9FEBC4B440d09E9F539A1D9D91F2' temploid='DB31E69957D14a3e8633BFC98BB10A4A' s='34' e='34'>
+<STRUCTURE>
+<DATAOBJ oid='5950FCE0E1924386B1F40603C84F286E' temploid='947D53CDACF545b8BFF5F0E104B5A3B2' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='2F8A5C9B09BC4ccc8B61511BC33705AD' temploid='3A2ED39F06894b07AF59C81E1EB00440' spec='no' dtref='_000001B1ADB631E0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='B458265C0C6345bc9D230A28762F93AB' temploid='E6F7F25E5FDB4145A85EB7A7AF5D9E06' s='35' e='35'>
+<STRUCTURE>
+<DATAOBJ oid='C42A93B8B0174dd6A584815DB15454D5' temploid='5A178CDC27934d5286FE20BE4FF55B68' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='AB366CD6FDDA46b5A2EBBDF27CDE7B62' temploid='003FE4D3516A4869B3964FBB7DBD449C' spec='no' dtref='_000001B1ADB631E0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='2A59946D8FA347bbA66C7D81E0440869' temploid='89B68AB0C4414a6bA5F8EF54B2B65AFA' s='49' e='49'>
+<STRUCTURE>
+<DATAOBJ oid='B8719B983D1C4509A9FA4A6EBB6C3308' temploid='D5585DB5A1BD4f4bA4775C664AC1B392' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='526CD83D58E14241B0B8CF7881EAB804' temploid='043097E9B9E3404eA35B0C25DCCADB5F' spec='no' dtref='_000001B1ADB627C0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='E40B9BDE7B7546d3BD5A592390B66414' temploid='1907536B569F4635952F1B46230D1DA7' s='50' e='50'>
+<STRUCTURE>
+<DATAOBJ oid='A32B5811047D4cf2B37FCA5AE9D19A43' temploid='67472F8CC2E0448fA6D6CD9C18AF9076' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='2CAA597ACE9E4946A3CBAEF6F25F59BD' temploid='ECA275949B924705A14D3218214635F2' spec='no' dtref='_000001B1ADB627C0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='3E4EBA7B802A48be99BE903261E1AD40' temploid='DECF32D7264A4929AFFE794F23367428' s='51' e='51'>
+<STRUCTURE>
+<DATAOBJ oid='6634239243A541ffAC78B1D5F42353AB' temploid='1BAC37F894594caf9092B69128A379B2' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='7A6520241B244f0c9507C2A78345BE30' temploid='E5199B6B09DD494aB5E9AC632E88A450' spec='no' dtref='_000001B1ADB627C0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='35C283FD505D4499AB792CA7B4C567CB' temploid='F79D9112A5CD4f27813924C7614DFD4D' s='65' e='65'>
+<STRUCTURE>
+<DATAOBJ oid='D2D4D64AC54C449eBAB4D97C01152DC5' temploid='F9B033A28AFF4487A439369F537EECD3' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='F138F8B127434d648C8BA776908BB8C7' temploid='1237AE06765F4a30BC4283B86F6271D7' spec='no' dtref='_000001B1ADB62D60'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='D50671ABC8944293B17DA554BFAECFCD' temploid='81F51DB424B743e48E7C92166C415499' s='66' e='66'>
+<STRUCTURE>
+<DATAOBJ oid='6CD3C284FB1741d6983F81046E5A7D3D' temploid='A7E4B62D72D64668A73F6CAEA6FFEE03' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='F98C1096D26746409D4A9BF386935AC3' temploid='FE40161CBFD64c9c854C500ECA4C24DF' spec='no' dtref='_000001B1ADB62D60'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='AEEB5182E12C4a91A74F6CE0AC8CD28C' temploid='BFBECA13CC10487094EBCC3D0EE3C1EF' s='67' e='67'>
+<STRUCTURE>
+<DATAOBJ oid='B6C38E6ED09C4a77B632230748595EBF' temploid='20C782D589A84d7cA2C91FD653213090' spec='no' dtref='_000001B1ADB62C40'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='D5C040009D2940faB896D4E2FB65EB7D' temploid='68CCD2A8831A4c8b95C830A0D3383E81' spec='no' dtref='_000001B1ADB62D60'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='03FC8F730A134061A5EBB42AC6B02E3C' temploid='537C241B0E454bcf87C39756E715EDA3' s='52' e='52'>
+<STRUCTURE>
+<DATAOBJ oid='58A0DB629D024ed080E0F419A727D5A1' temploid='8FBE0A7BBB4C4d97BA86A2D8E9B6EE00' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='E011D8802047463eA72118A85AC536EC' temploid='600618A5FE694bceAA47D183C105585F' spec='no' dtref='_000001B1ADB627C0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='440089FEC54E444dB207FE6F96DB1B1D' temploid='D17D9219CF8C414aAB0BF73F84BBF667' s='20' e='20'>
+<STRUCTURE>
+<DATAOBJ oid='14FCF957C50A4e6eBB9A8B9D744D9BF4' temploid='614F2042C3604e37B32A337BA924C992' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='E0A3D2543C344da28C08E568F1552A6C' temploid='BF06B51D8C5A46488E37AD1401CBB036' spec='no' dtref='_000001B1ADB63300'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='2A0D11970D2A40b7AB2C281520AAD422' temploid='A2F15B14A7F746c292A31CCF7C49C38A' s='36' e='36'>
+<STRUCTURE>
+<DATAOBJ oid='C52E52970F9C4c6c904068A40771AF54' temploid='64DBC1C8B6BF473cA24F6F910728A3D1' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='75BA34B94AF14bd396A33B1225D0AC24' temploid='6AE3922A3AE0423dB937E6282BD39DD6' spec='no' dtref='_000001B1ADB631E0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='A1072A336F9A459f92A2F93BC8423DB5' temploid='FD95B94324DE4134A2FA6750BD4A3379' s='68' e='68'>
+<STRUCTURE>
+<DATAOBJ oid='40EEE919F9D44a4dAEC9059ADFA1A398' temploid='EE74FC6B51DB4a1a811DCAC517A08E8B' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='A8ACEC386BA644eb8E672EF5ACD2774B' temploid='327FAB78E4494c109C67B9670444B4D3' spec='no' dtref='_000001B1ADB62D60'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='3389F11EC0E84e8e92BA7B5C5F3D2352' temploid='F4A4120F86A84d6884D55C11F0A2F133' s='69' e='69'>
+<STRUCTURE>
+<DATAOBJ oid='C8A6D0FA359A47009F175FD0CC8E91E7' temploid='D218181E51BF408798EBC081676E6EFB' spec='no' dtref='_000001B1ADB61DA0'>
+<NAME>
+<TUV xml:lang='en-US'>Address</TUV>
+</NAME>
+<QUAL>Address</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='FB03B03F63FC4e75B0559C0FD169A5A8' temploid='5C0BC46EEA2C49b7A26CBD2F61736080' spec='no' dtref='_000001B1ADB62D60'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+</MUXDT>
+<STRUCTDT id='_000001B1ADC19830' oid='0373B4FC8E4B425b974AE2B89A77F902' temploid='B754C96CB27B4d7fAB5A6DAC3851D49F' bm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>Communication Type</TUV>
+</NAME>
+<QUAL>Communication_Type</QUAL>
+<CVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='1' maxsz='1'/>
+<PVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='1' maxsz='1'/>
+<STRUCT oid='09E1FE6EFC024c7b9C0954D976B06562' temploid='DCA770697F834bb38015CDC0A3A8308C' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Communciation Type</TUV>
+</NAME>
+<QUAL>Communciation_Type</QUAL>
+<DATAOBJ oid='571BD7134902409990BCE11ACDA39A3C' temploid='7A4382BAA71D4c03BAAA8ABFC203928D' spec='no' def='1' dtref='_000001B1ADCA4EF0'>
+<NAME>
+<TUV xml:lang='en-US'>normalCommunicationMessages</TUV>
+</NAME>
+<QUAL>normalCommunicationMessages</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='5761FF4839D54a459816912BA2A57254' temploid='8288943195FC406682726E0B291DBE57' spec='no' def='1' dtref='_000001B1ADCA4EF0'>
+<NAME>
+<TUV xml:lang='en-US'>networkManagementCommunicationMessages</TUV>
+</NAME>
+<QUAL>networkManagementCommunicationMessages</QUAL>
+</DATAOBJ>
+<GAPDATAOBJ oid='1BBAF26140044867A471D5DC0DB0C5D2' temploid='3835B474FEE94e9190F2E4BA36A406AF' bl='2'>
+<NAME>
+<TUV xml:lang='en-US'>(reserved)</TUV>
+</NAME>
+<QUAL>_reserved</QUAL>
+</GAPDATAOBJ>
+<DATAOBJ oid='0A86734469C04309B415F11D991787FF' temploid='1DFE5E313E3443feB0C5112530BAC960' spec='no' def='0' dtref='_000001B1ADCA34D0'>
+<NAME>
+<TUV xml:lang='en-US'>communicationTypeNetworks</TUV>
+</NAME>
+<QUAL>communicationTypeNetworks</QUAL>
+</DATAOBJ>
+</STRUCT>
+</STRUCTDT>
+<STRUCTDT id='_000001B1ADC195B0' oid='19831F78E9D24bbaAF24B5A26B663A75' temploid='9A3354EE958142d6B802C22F3AFD3603' bm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>DID 0xF410</TUV>
+</NAME>
+<QUAL>DID_0xF410</QUAL>
+<CVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='2'/>
+<PVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='2'/>
+<DATAOBJ oid='E1393F196ABB462eA223B8D07573BD3F' temploid='164201868CFA413e92E7F853B7885CF7' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID Data</TUV>
+</NAME>
+<QUAL>DID_Data</QUAL>
+</DATAOBJ>
+</STRUCTDT>
+<STRUCTDT id='_000001B1ADC19970' oid='079B63EF6F234fdb80C6C697CB2E927A' temploid='1813390AF8A44633A8119AD69A943258' bm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>DID 0xF412</TUV>
+</NAME>
+<QUAL>DID_0xF412</QUAL>
+<CVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='2'/>
+<PVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='2'/>
+<DATAOBJ oid='55414D6A36DC44a7AB94EB71E5C44D42' temploid='B05E7017E9DC41008B88F8C025188E4E' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID Data</TUV>
+</NAME>
+<QUAL>DID_Data</QUAL>
+</DATAOBJ>
+</STRUCTDT>
+<STRUCTDT id='_000001B1ADC18570' oid='EBE4ADC048224d68846E6A4131022B20' temploid='B5056EEFEDAB47caB57ABC676274BCA2' bm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>DID 0xF413</TUV>
+</NAME>
+<QUAL>DID_0xF413</QUAL>
+<CVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='2'/>
+<PVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='2'/>
+<DATAOBJ oid='6E14E0643DBE43f0A68858F7E9A3F85C' temploid='3D30811FE1D543328C6C8274307B0CF0' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID Data</TUV>
+</NAME>
+<QUAL>DID_Data</QUAL>
+</DATAOBJ>
+</STRUCTDT>
+<STRUCTDT id='_000001B1ADC18CF0' oid='C4F4D4C0B30440cbB7CFA37164803265' temploid='F2751ADCAE8E4a0fAE17C55600BC6B49' bm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>DID 0xF411</TUV>
+</NAME>
+<QUAL>DID_0xF411</QUAL>
+<CVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='2'/>
+<PVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='2'/>
+<DATAOBJ oid='3797A7B7F4A44edc93109CE74B8BF926' temploid='6D1E586B4FCC48ff82F3FAC060A28CC4' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID Data</TUV>
+</NAME>
+<QUAL>DID_Data</QUAL>
+</DATAOBJ>
+</STRUCTDT>
+<MUXDT id='_000001B1ADC1BC10' oid='457FBDE5E3B9485b93A380249AC4FAD1' temploid='1D29972D44434976B15264490B17DD51' bm='4294967295' dtref='_000001B1ADCA2C80'>
+<NAME>
+<TUV xml:lang='en-US'>SnapshotRecord DTC P000002</TUV>
+</NAME>
+<QUAL>SnapshotRecord_DTC_P000002</QUAL>
+<CVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='1' maxsz='12'/>
+<PVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='1' maxsz='12'/>
+<STRUCTURE>
+<GAPDATAOBJ oid='D2791F781BB84a80B562DECAB78EF4E4' temploid='F2E58DF62EE7495c8DC126DFACFABBFA' bl='8'>
+<NAME>
+<TUV xml:lang='en-US'>(reserved)</TUV>
+</NAME>
+<QUAL>_reserved</QUAL>
+</GAPDATAOBJ>
+</STRUCTURE>
+<CASE oid='86CB4D8F0AD448328C3421F7E6386A4C' temploid='F32436BAEBFE47c5B116123E1D9C4A85' s='0' e='0'>
+<STRUCTURE>
+<DATAOBJ oid='C4DD1E079A1C4548893DC286B5554C8A' temploid='C79E9D83A1C64a04A309AEAA1C447AF9' spec='no' v='62480' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_ID_0</TUV>
+</NAME>
+<QUAL>DID_ID_0</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='E233A5C42C584fc38B37B647AEC5234D' temploid='561BE274090742bcA8B761C40FEF2DED' spec='no' dtref='_000001B1ADC195B0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_DATA_0</TUV>
+</NAME>
+<QUAL>DID_DATA_0</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='45B2A7B2E79B413aA08FD9411CE9C955' temploid='2E9BDAC4BACA4a17A725B6A3226AFE1D' spec='no' v='62482' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_ID_1_1</TUV>
+</NAME>
+<QUAL>DID_ID_1_1</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='FB3A73383EF647c297C94540F156155F' temploid='EDF9751784F34a9582C5A21C1A962613' spec='no' dtref='_000001B1ADC19970'>
+<NAME>
+<TUV xml:lang='en-US'>DID_DATA_1</TUV>
+</NAME>
+<QUAL>DID_DATA_1</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='54DA3D890C71475384B4FE9664AD2B66' temploid='FF720C8D1B68498dABBA853BFB452CEB' spec='no' v='62483' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_ID_2</TUV>
+</NAME>
+<QUAL>DID_ID_2</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='8E78835EDF5D4269A557FF5CFE1C2688' temploid='5E44B78BF38647bd8F16226815971266' spec='no' dtref='_000001B1ADC18570'>
+<NAME>
+<TUV xml:lang='en-US'>DID_DATA_2</TUV>
+</NAME>
+<QUAL>DID_DATA_2</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='0EEABE45D25046b894CCBCAE17BB793F' temploid='0D1DF3BB27BC458aACCE8F18E2FE63CB' s='16' e='16'>
+<STRUCTURE>
+<DATAOBJ oid='44171C284FDE4482A65143F920BD264E' temploid='58A7AA11C1FE4796B8D3F8486963834B' spec='no' v='62481' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_ID_1</TUV>
+</NAME>
+<QUAL>DID_ID_1</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='F2AD528E45134f2e87B8C6841EA6A27F' temploid='B79674B87A214f309CBB81E34C32441E' spec='no' dtref='_000001B1ADC18CF0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_DATA_1</TUV>
+</NAME>
+<QUAL>DID_DATA_1</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+</MUXDT>
+<MUXDT id='_000001B1ADC1B820' oid='F77EDB16AFE54105A24F1EC35CB6D54A' temploid='9E83FC0E78AB4284883C4E903C658552' bm='4294967295' dtref='_000001B1ADCA0550'>
+<NAME>
+<TUV xml:lang='en-US'>SnapshotRecord DTC P000003</TUV>
+</NAME>
+<QUAL>SnapshotRecord_DTC_P000003</QUAL>
+<CVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='1' maxsz='12'/>
+<PVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='1' maxsz='12'/>
+<STRUCTURE>
+<GAPDATAOBJ oid='3749A2743F894f78809D5A5CF1A86965' temploid='AA4D75BC692B4307AC98A28F0CC52794' bl='8'>
+<NAME>
+<TUV xml:lang='en-US'>(reserved)</TUV>
+</NAME>
+<QUAL>_reserved</QUAL>
+</GAPDATAOBJ>
+</STRUCTURE>
+<CASE oid='94C02996BC8D4acd9AB090EFAABC41C4' temploid='CBDDF8A193244b89BDA38CA08D084191' s='16' e='16'>
+<STRUCTURE>
+<DATAOBJ oid='E667D65DD69B4ebd94F71A522DB89BE5' temploid='9DE1645AD4BA4c9c9E94FF9B912AF7EF' spec='no' v='62482' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_ID_1_1</TUV>
+</NAME>
+<QUAL>DID_ID_1_1</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='DEA3263C988846f98FB2145583FB8FF0' temploid='F3BFD8E670614341903EE293DB98677B' spec='no' dtref='_000001B1ADC19970'>
+<NAME>
+<TUV xml:lang='en-US'>DID_DATA_1 1</TUV>
+</NAME>
+<QUAL>DID_DATA_1_1</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='1388D73B8BA64e448A8A1E226619AB51' temploid='8852F739A968440dAA57FAC729EA2075' spec='no' v='62483' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_ID_2 1</TUV>
+</NAME>
+<QUAL>DID_ID_2</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='3196D9D5DB6D4ba587C026D716E7328E' temploid='0DDCE065A60B4397B77CDC8E5F54911D' spec='no' dtref='_000001B1ADC18570'>
+<NAME>
+<TUV xml:lang='en-US'>DID_DATA_2 1</TUV>
+</NAME>
+<QUAL>DID_DATA_2_1</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+<CASE oid='AE92283A05E04a6b9CF98CFA61CAA215' temploid='7B25EF8F625C4e8481FA37DD1E374D52' s='32' e='32'>
+<STRUCTURE>
+<DATAOBJ oid='8A5CAC53D3034615823FAE09DFCD6754' temploid='055EED4D4939461f9554830EB5444198' spec='no' v='62480' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_ID_0</TUV>
+</NAME>
+<QUAL>DID_ID_0</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='00CC35194AEE4375B3CF7EE08AAE3E54' temploid='37F20C9818E04868A09B7C86D8274863' spec='no' dtref='_000001B1ADC195B0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_DATA_0</TUV>
+</NAME>
+<QUAL>DID_DATA_0</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='F964AEF2176B45a7BE292DCE12028D73' temploid='A76DFA74522E4ab897DCC875BA7DABC6' spec='no' v='62481' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_ID_1_1</TUV>
+</NAME>
+<QUAL>DID_ID_1_1</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='0050AA1101F14cde841258735072A1AE' temploid='DADFC9C2767D44f69A1CC2DAE94E7E20' spec='no' dtref='_000001B1ADC18CF0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_DATA_1</TUV>
+</NAME>
+<QUAL>DID_DATA_1</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='57E875909E7446ca813B4E39176EE4E2' temploid='39AB37C861624a4f90CC3AF0ABA34E34' spec='no' v='62483' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID_ID_2</TUV>
+</NAME>
+<QUAL>DID_ID_2</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='7AC1D31F701C4b1aA3B639EE99D705C1' temploid='BFBAC76A74C94ec5940940B1FADF8CD7' spec='no' dtref='_000001B1ADC18570'>
+<NAME>
+<TUV xml:lang='en-US'>DID_DATA_2</TUV>
+</NAME>
+<QUAL>DID_DATA_2</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</CASE>
+</MUXDT>
+<STRUCTDT id='_000001B1ADC19AB0' oid='31DFCBACD2AC451f9CF7CA2EF917B6FE' temploid='12ED3E9B94DB4679A275DB275F85D0FA' bm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>DID 0xF414</TUV>
+</NAME>
+<QUAL>DID_0xF414</QUAL>
+<CVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='2'/>
+<PVALUETYPE bl='8' bo='12' enc='uns' sig='0' df='hex' qty='field' sz='no' minsz='2' maxsz='2'/>
+<DATAOBJ oid='AB2D43A23B6A4a3bBA3A2B3D604FA480' temploid='803EDA6CEBE149d68ABF163A9F84C597' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID Data</TUV>
+</NAME>
+<QUAL>DID_Data</QUAL>
+</DATAOBJ>
+</STRUCTDT>
+</DATATYPES>
+<DOCTMPL oid='C2B6D04A0FCE4eb0B2219D3AB16A5A05' saveno='11'>
+<NAME>
+<TUV xml:lang='en-US'>Vector Reference</TUV>
+</NAME>
+<QUAL>Vector_Reference</QUAL>
+<LABEL>2.3.1</LABEL>
+</DOCTMPL>
+<RECORDTMPLS>
+<RECORDTMPL spec='faultMemory'>
+<CVALUETYPE bl='24' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='0' maxsz='255'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TRRECORDITEMTMPL id='_000001B1AD9EA290' oid='C41E40C0BE264b83B7C1A0412DBCD96A' temploid='7AF7382E25744419A60F179B154C1FA4' mayBeDup='1' conv='opt'>
+<NAME>
+<TUV xml:lang='en-US'>Component / System</TUV>
+</NAME>
+<QUAL>Component_System</QUAL>
+</TRRECORDITEMTMPL>
+<UNSRECORDITEMTMPL id='_000001B1ADAAE570' oid='FCC90AD1AF9C4f7aA85E537F54707EC7' temploid='54D97A8FFBE44911B5F6EA62EC18EBB8' mayBeDup='1' conv='opt' df='dec' v='0'>
+<NAME>
+<TUV xml:lang='en-US'>Number of trips</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Number of operation cycles needed to confirm the event
+
+The value 0 is the standard UDS behavior of confirming the event (ConfirmedDTC status bit becomes set) with the first qualified FAILED result. A value of 1 means the event becomes confirmed if it fails again in the next operation cycle.
+Larger values represent confirmation in the n-th cycle e.g. 2 is confirmation in cycle after the next cycle, etc.</TUV>
+</DESC>
+<QUAL>NUMBER_OF_TRIPS_ACTIVE</QUAL>
+</UNSRECORDITEMTMPL>
+<TRRECORDITEMTMPL id='_000001B1AD9E91B0' oid='A6F926711C0F49779D0A89363C2398A8' temploid='96FDCF92905E46848F5540E1AB05AF59' mayBeDup='1' conv='opt'>
+<NAME>
+<TUV xml:lang='en-US'>Enable Conditions</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>An event status report ((Pre)Failed or (Pre)Passed) will only have an effect if all EnableConditions belonging to the DTC are met at the time of report. Otherwise the result will be discarded.
+Multiple C-Qualifier separated by a comma can be added here</TUV>
+</DESC>
+<QUAL>Enable_Conditions</QUAL>
+</TRRECORDITEMTMPL>
+<TRRECORDITEMTMPL id='_000001B1AD9E9930' oid='30B80821BAD749b091248602A2D7EA57' temploid='5F23EBBADFDA4c3dBD48DCB2D4E75068' mayBeDup='1' conv='opt'>
+<NAME>
+<TUV xml:lang='en-US'>Mature Time</TUV>
+</NAME>
+<QUAL>Mature_Time</QUAL>
+</TRRECORDITEMTMPL>
+<ENUMRECORDITEMTMPL id='_000001B1ADCB8880' oid='FD67169B7E9248f188DAAB4D1B338182' temploid='F6232193E7D0416a9AFCDF298B103B09' mayBeDup='1' conv='opt' v='0' sort='id'>
+<NAME>
+<TUV xml:lang='en-US'>OBD relevant</TUV>
+</NAME>
+<QUAL>OBD_relevant</QUAL>
+<ETAG v='0'>
+<TUV xml:lang='en-US'>No</TUV>
+</ETAG>
+<ETAG v='1'>
+<TUV xml:lang='en-US'>Yes</TUV>
+</ETAG>
+</ENUMRECORDITEMTMPL>
+<TRRECORDITEMTMPL id='_000001B1AD9E92A0' oid='DF964EC038EE4a4b9A257627C30EDF53' temploid='D6B310043F2D4ca496DEA685BAF23F18' mayBeDup='1' conv='opt'>
+<NAME>
+<TUV xml:lang='en-US'>Mature Threshold</TUV>
+</NAME>
+<QUAL>Mature_Threshold</QUAL>
+</TRRECORDITEMTMPL>
+<TRRECORDITEMTMPL id='_000001B1AD9EA380' oid='63558B59219141c98AD6E4A856C0448B' temploid='8E202BF51AEA4a929D835F3322352465' mayBeDup='1' conv='opt'>
+<NAME>
+<TUV xml:lang='en-US'>Monitoring Method</TUV>
+</NAME>
+<QUAL>Monitoring_Method</QUAL>
+</TRRECORDITEMTMPL>
+<TRRECORDITEMTMPL id='_000001B1AD9E8A30' oid='494E37D9A94E4c11AA83B110C7F74321' temploid='26BA6A0824E14ffaB5A637BE746BA837' mayBeDup='1' conv='opt'>
+<NAME>
+<TUV xml:lang='en-US'>Monitoring parameter</TUV>
+</NAME>
+<QUAL>Monitoring_parameter</QUAL>
+</TRRECORDITEMTMPL>
+<TRRECORDITEMTMPL id='_000001B1AD9E9CF0' oid='88633EF5D9EF4fa59E15B282775CAEB2' temploid='B823C0DC7BF1449397A080F065AE8D5A' mayBeDup='1' conv='opt'>
+<NAME>
+<TUV xml:lang='en-US'>Monitor Type</TUV>
+</NAME>
+<QUAL>Monitor_Type</QUAL>
+</TRRECORDITEMTMPL>
+</RECORDTMPL>
+<RECORDTMPL spec='obdFaultMemory'>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='0' maxsz='255'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+<TRRECORDITEMTMPL id='_000001B1AD9EA560' oid='C0178AEF42C84baaA58238253F9F8A8F' temploid='373416C5435B4225A27DB3151EBDB4E1' mayBeDup='1' conv='opt'>
+<NAME>
+<TUV xml:lang='en-US'>UDS DTC Reference</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Defines the UDS DTC which shall be linked to the OBD DTC. It is also possible to link several UDS DTCs to one single OBD DTC.
+The supported format is as follows:
+- 3 Byte Hexadecimal DTC number [0x123456 | 123456]
+- If more than one DTC is entered separate them with a comma (",")</TUV>
+</DESC>
+<QUAL>UDS_DTC_Reference</QUAL>
+</TRRECORDITEMTMPL>
+</RECORDTMPL>
+</RECORDTMPLS>
+<DTCSTATUSMASK dtref='_000001B18D02D010'>
+<DTCSTATUSBITGROUP conv='optno' dtref='_000001B1ADA15640'/>
+<DTCSTATUSBITGROUP conv='optno' dtref='_000001B1ADA15770'/>
+<DTCSTATUSBITGROUP conv='optno' dtref='_000001B1ADA13040'/>
+<DTCSTATUSBITGROUP conv='optno' dtref='_000001B1ADA13170'/>
+<DTCSTATUSBITGROUP conv='optno' dtref='_000001B1ADA15B00'/>
+<DTCSTATUSBITGROUP conv='optno' dtref='_000001B1ADA14340'/>
+<DTCSTATUSBITGROUP conv='optno' dtref='_000001B1ADA145A0'/>
+<DTCSTATUSBITGROUP conv='optno' dtref='_000001B1ADA14B90'/>
+</DTCSTATUSMASK>
+<UNSUPPSRVNEG oid='9D5298A54EB64fbe9F75AADE88CAB706' temploid='{372C73D4-FA9B-4def-8043-9AB124BA7B04}'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response Codes for unsupported services</TUV>
+</NAME>
+<QUAL>UNSUPPORTED_SERVICE_NR</QUAL>
+<CONSTCOMP id='_000001B1ADCE4250' oid='4D0045D61E57478cBE671FA121BEE784' temploid='{317B82F6-6296-44d0-B514-46F6764DFB93}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93AC40' oid='0DC545ACD23E42f3845FEAF231B0FF0C' temploid='{33FD419C-1BEB-43b4-8AA2-102BA8963D8C}' must='1' spec='id' dtref='_000001B1AD94E730'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</STATICCOMP>
+<CONTENTCOMP id='_000001B1AD92A900' oid='9804E5651D8B48f1B079A4C9CE17A238' temploid='{A1F80F4F-AC0F-4752-B21A-9657CD53C072}' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE TABLE</TUV>
+</NAME>
+<QUAL>RESPONSE_CODE_TABLE</QUAL>
+<SIMPLECOMPCONT oid='A5D0792556AD40a0A460801659078639' temploid='{E25D7AC9-205E-48ac-B5A7-3D54121F7149}'>
+<SPECDATAOBJ oid='CA301F1FCC724105BB7F34BB1EC913E7' temploid='{B0843B09-4F92-427e-AED9-6865A5C09AE4}'>
+<NAME>
+<TUV xml:lang='en-US'>NEGATIVE RESPONSE CODES</TUV>
+</NAME>
+<QUAL>NRC</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02C50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</UNSUPPSRVNEG>
+<DIDS>
+<DID id='_000001B1ADAAE070' oid='DAB69F6E959C4be9869D61A71F57D634' temploid='5736263E72DD4c80993FDA3732CBD78A' n='512'>
+<NAME>
+<TUV xml:lang='en-US'>DID 0x0200</TUV>
+</NAME>
+<QUAL>DID_0x0200</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='963301785EB644f583884F8E7536E34C' temploid='116BC9AC4ADE4187B39003BD4322E7B5' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>Test</TUV>
+</NAME>
+<QUAL>Test</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAB0070' oid='9605660FA8D04689B309907958B0EA9C' temploid='215B06EB4EA24c52B5E2FC91985CFCE6' n='1024'>
+<NAME>
+<TUV xml:lang='en-US'>DID 0x0400</TUV>
+</NAME>
+<QUAL>DID_0x0400</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='25C6FAE970FF4534B74C5CF0B6F841CF' temploid='95A14187398D4ef09C584E15396B4C33' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DID Data</TUV>
+</NAME>
+<QUAL>DID_Data</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAB0A70' oid='231CC3CED4DD4bc69C4E5C5B47F76E3E' temploid='F992FD698FF84c479D8B8F19F6390C57' n='768'>
+<NAME>
+<TUV xml:lang='en-US'>DID 0x0300</TUV>
+</NAME>
+<QUAL>DID_0x0300</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='43CAA3A5DD1F424eB85D737CC756A15B' temploid='A203A2804CB94b58AD3D8D3672945FED' spec='no' def='0' dtref='_000001B1ADCA7750'>
+<NAME>
+<TUV xml:lang='en-US'>IO State</TUV>
+</NAME>
+<QUAL>IO_State</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='7D3DF383AFAC429091D09787172BD455' spec='no' def='0' dtref='_000001B1ADB61A40'>
+<NAME>
+<TUV xml:lang='en-US'>Pin ID</TUV>
+</NAME>
+<QUAL>Pin_ID</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAB0B70' oid='E159798037D34df6A38C548CE20929D2' temploid='82F6F1829D4F4f608BA4E2302A383584' n='257'>
+<NAME>
+<TUV xml:lang='en-US'>DataDiagnosticIdentifier DDI</TUV>
+</NAME>
+<QUAL>DataDiagnosticIdentifier_DDI</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='404F2198908442f093C860844B7B3862' temploid='D0B4743DC8854f07B5222CE295EC7AE1' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>DataDiagnosticIdentifier</TUV>
+</NAME>
+<QUAL>DataDiagnosticIdentifier</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAAD870' oid='0877FE72E5EA4e1c9A5DE4CF40B45456' temploid='F3C60C1C54D84c1c9BE7C58200C74646' n='256'>
+<NAME>
+<TUV xml:lang='en-US'>Development Data</TUV>
+</NAME>
+<QUAL>Development_Data</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='915367DE2A944773A60C5CF74B395ACE' temploid='D9DC86D6DE6141d9AA47E7AAA4D918AB' spec='no' dtref='_000001B1ADB62A00'>
+<NAME>
+<TUV xml:lang='en-US'>Operating System (Version)</TUV>
+</NAME>
+<QUAL>OperatingSystemVersion</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='15ACA828F66E4e98BA0DBD8AD1D1810D' temploid='EF9788FF95D548a88C1EC23AE74A7621' spec='no' dtref='_000001B1ADB62A00'>
+<NAME>
+<TUV xml:lang='en-US'>CAN Driver (Version)</TUV>
+</NAME>
+<QUAL>CanDriverVersion</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='D2AC18CF239E48c1A2E2B2E2968310BC' temploid='4288847B203C461d98EC89C20844FC3D' spec='no' dtref='_000001B1ADB62A00'>
+<NAME>
+<TUV xml:lang='en-US'>NM (Version)</TUV>
+</NAME>
+<QUAL>NmVersion</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='2C5EC154D0844b309C0675EC1C44A0DD' temploid='9A85809969584f7dB309EDFA3589DB1D' spec='no' dtref='_000001B1ADB62A00'>
+<NAME>
+<TUV xml:lang='en-US'>Diagnostic Module (Version)</TUV>
+</NAME>
+<QUAL>DiagnosticModuleVersion</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='6C03F97C06A24370A9825E2114D11EA4' temploid='731949E2712C47cc85901F578291F508' spec='no' dtref='_000001B1ADB62A00'>
+<NAME>
+<TUV xml:lang='en-US'>Transport Layer (Version)</TUV>
+</NAME>
+<QUAL>TransportLayerVersion</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAAE170' oid='9F0A67DB2761448b95D434A005969243' temploid='93B3CE0212044a8cAEA9BF9E0B4AD2DC' n='61824'>
+<NAME>
+<TUV xml:lang='en-US'>Boot Software</TUV>
+</NAME>
+<QUAL>Boot_Software</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='5B2D7EAD18164e859AC0CEA0C7978B1B' temploid='C94464698D8741979A7D19D129E08CF1' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>NumberOfModules</TUV>
+</NAME>
+<QUAL>NumberOfModules</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='401D17A7ADD941bd80C1FAB93D9C888E' temploid='512034F39C5D422bA288AB0BBF7F7B10' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Boot Software Identification</TUV>
+</NAME>
+<QUAL>Boot_Software_Identification</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAADD70' oid='8E3A9F583B6B41c5802B6AB9591B1EB9' temploid='123B43D9901B4a929BA0DC0283D27BE6' n='61831'>
+<NAME>
+<TUV xml:lang='en-US'>Spare Part Number</TUV>
+</NAME>
+<QUAL>Spare_Part_Number</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='99B0B6AD988445b2AA6BF63A2EFF8363' temploid='89255724C148407c93F55CDA53C12765' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Spare Part Number</TUV>
+</NAME>
+<QUAL>Spare_Part_Number</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAAE370' oid='8938EC59F2D048e48F7F7DF86A71AFA8' temploid='2D12532D0283482f94A4E12FE0BFF6DC' n='61836'>
+<NAME>
+<TUV xml:lang='en-US'>Serial Number</TUV>
+</NAME>
+<QUAL>Serial_Number</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='E647C84AFF384a5fB74C10237553B31C' temploid='780966D7123A4ec4ACD9D3CBA0801A40' spec='no' dtref='_000001B1ADB61800'>
+<NAME>
+<TUV xml:lang='en-US'>SerialNumber</TUV>
+</NAME>
+<QUAL>SerialNumber</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAADC70' oid='8FA6BCEDE109478dBE06FE8B1400F2F8' temploid='3D29B46C089B426e83525215CB96BE64' n='61833'>
+<NAME>
+<TUV xml:lang='en-US'>Ecu Identification</TUV>
+</NAME>
+<QUAL>Ecu_Identification</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='E0BD05C5BA714613AC393264192FE9D2' temploid='0597AC19C4814688B4297306C70C7A01' spec='no' dtref='_000001B1ADB62220'>
+<NAME>
+<TUV xml:lang='en-US'>Part Number</TUV>
+</NAME>
+<QUAL>Part_Number</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAB0170' oid='FAD6A774D7A44c19BE873AF03EBBA55C' temploid='D3882E4A8DFD4dd6A33C3AE3EE8CEE74' n='61843'>
+<NAME>
+<TUV xml:lang='en-US'>Hardware Version</TUV>
+</NAME>
+<QUAL>Hardware_Version</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='DC74B55D0209464a829D000B624A0E6E' temploid='D7C1656873FE4bc3B9438BA06A98D075' spec='no' dtref='_000001B1AD9590E0'>
+<NAME>
+<TUV xml:lang='en-US'>Hardware Version Number</TUV>
+</NAME>
+<QUAL>Hardware_Version_Number</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAB0370' oid='82FC30B5821D497388032631CE186506' temploid='A0C4F0E974114d9b8624552C1307987F' n='61840'>
+<NAME>
+<TUV xml:lang='en-US'>Vehicle Identification</TUV>
+</NAME>
+<QUAL>Vehicle_Identification</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='83D18D3D6A4A4231A13F69E6B114835A' temploid='7804295AF8C64980B9106B123A7F4982' spec='no' dtref='_000001B1ADB62580'>
+<NAME>
+<TUV xml:lang='en-US'>VIN</TUV>
+</NAME>
+<QUAL>VIN</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAAE870' oid='C53917ED24784e81B950BE91064DEFC9' temploid='C59C8470154B4bc09617B6EF66E02926' n='1280'>
+<NAME>
+<TUV xml:lang='en-US'>DID 0x0500</TUV>
+</NAME>
+<QUAL>DID_0x0500</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='1AC5BDBAE0684ced83F5CA33AACCCF78' temploid='708644A71E8049b5A4105C1A5DDF56F1' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>New Data Object</TUV>
+</NAME>
+<QUAL>New_Data_Object</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAAFE70' oid='86A653B0DA6F4d8698E6330FBAA53C0E' n='300'>
+<NAME>
+<TUV xml:lang='en-US'>HV Lock</TUV>
+</NAME>
+<QUAL>HV_Lock</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='E6CE34D56E6E47f79E7AA273E1DAEA1E' spec='no' def='1' dtref='_000001B1ADBDE820'>
+<NAME>
+<TUV xml:lang='en-US'>High Voltage Lock</TUV>
+</NAME>
+<QUAL>High_Voltage_Lock</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAADE70' oid='A919D4B35155409181CC6BA692247262' n='769'>
+<NAME>
+<TUV xml:lang='en-US'>DID 0x0301</TUV>
+</NAME>
+<QUAL>DID_0x0301</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='378737E128AB4ff2BC26D71982530116' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>PWM Duty Cycle</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Duty cycle in percentage, Valid [0-100]</TUV>
+</DESC>
+<QUAL>PWM_Duty_Cycle</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+<DID id='_000001B1ADAB1170' oid='CE3235EEA6EC49d29072495A5A121ECB' n='770'>
+<NAME>
+<TUV xml:lang='en-US'>DID 0x0302</TUV>
+</NAME>
+<QUAL>DID_0x0302</QUAL>
+<STRUCTURE>
+<DATAOBJ oid='173E13E04174436cA352AB3418FB37E0' spec='no' dtref='_000001B1ADBDEA80'>
+<NAME>
+<TUV xml:lang='en-US'>StateRequest</TUV>
+</NAME>
+<QUAL>StateRequest</QUAL>
+</DATAOBJ>
+</STRUCTURE>
+</DID>
+</DIDS>
+<PROTOCOLSERVICES>
+<PROTOCOLSERVICE id='_000001B1ABFA3530' oid='65E01FB73B0F455aB9ED2C6D0A85DC70' temploid='{983175F8-D5F7-4ead-8D51-AE6FB12B7D23}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($10) DiagnosticSessionControl</TUV>
+</NAME>
+<QUAL>DSC</QUAL>
+<REQ oid='EEBE5F4B299341d38E22788F9ABD94D0' temploid='{12AA22DC-7C5B-4345-A31C-933ED0834AD9}'>
+<NAME>
+<TUV xml:lang='en-US'>STDS-RQ</TUV>
+</NAME>
+<QUAL>STDS_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD59000' oid='EBD21971B85C40bdB40211F93072A687' temploid='{94036327-73F2-4991-8143-4D5E6D533CD4}' must='1' spec='sid' bl='8' v='16'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93B7F0' oid='8DEF8EBC59AC488e8429763BFC38D2C9' temploid='{581A5D03-08C7-48de-823B-561ADC8C2C4B}' must='1' spec='sub' dtref='_000001B1ADB667A0' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>DiagSessionType</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='16D0DAA2A6104903995FD456718E304D' temploid='{F41A6B89-B219-448c-BAE3-D5954780A1FC}'>
+<NAME>
+<TUV xml:lang='en-US'>STDS-PR</TUV>
+</NAME>
+<QUAL>STDS_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD5A560' oid='F549A7654A1B4005B080EA8EAD3259F2' temploid='{3D3AFC30-328D-4c99-A237-5A5CD65CF04A}' must='1' spec='sid' bl='8' v='80'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93B2A0' oid='BD464A4FCC234d008AC4C2DF048702A4' temploid='{F58F0C59-D3C8-4d73-A662-70BE1872BFA8}' must='1' spec='sub' dtref='_000001B1ADB667A0'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>DiagSessionType</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD5AC80' oid='0C3183EB15124b0a8B52DEF7AB54F5F0' temploid='621C29062DDF424e8C69811BEFFB2286' must='1' dest='data' minbl='32' maxbl='32'>
+<NAME>
+<TUV xml:lang='en-US'>SessionParameterRecord</TUV>
+</NAME>
+<QUAL>SessionParameterRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='9647E9C0102449388FE8FF193715C624' temploid='{3F9D05D3-1DEF-4faf-81AC-C017A79A3B6F}'>
+<NAME>
+<TUV xml:lang='en-US'>STDS-NR</TUV>
+</NAME>
+<QUAL>STDS_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD59130' oid='89D5A470848248f0BB00D665D9EEDD64' temploid='{DBF3698E-7DEE-490d-A272-186A97C6ADF1}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD5B140' oid='8B68B8476DF3490d905A63EDA8F6D2E4' temploid='{5E80660D-DCB6-4b80-BD92-31A8A856EA62}' must='1' spec='sid' bl='8' v='16'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD59F70' oid='962C7F2B052449789A9A25B1BE59BC6A' temploid='{47BC107F-2D00-458d-97B0-2F8DE765AB85}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA4BB0' oid='85FAD8DB509543939982E86835C1384B' temploid='{8FC6AE38-830C-4f9d-8D85-26C88734B6A5}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($27) SecurityAccess - Request seed</TUV>
+</NAME>
+<QUAL>SA_RS</QUAL>
+<REQ oid='52A75AEBC5BD4f1e83C2DDEA5AAC219D' temploid='{F230C4B1-51C8-4414-A56E-196A56684D2F}'>
+<NAME>
+<TUV xml:lang='en-US'>SA_RSD-RQ</TUV>
+</NAME>
+<QUAL>SA_RSD_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD5A300' oid='DBD64B73BC9E442eB383AF1B705C7D33' temploid='{E3D2CABD-4E69-4b00-9A59-9FCE1CB7979B}' must='1' spec='sid' bl='8' v='39'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93AA20' oid='AB93107C16184f72BE65D9909273E3CA' temploid='{0178D2BB-04F9-458a-9E5F-DF940BA60BEB}' must='1' spec='accm' dtref='_000001B1ADB66C60' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>SecurityAccessType</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='4D1A23F628364d2aA90A20479FE748D1' temploid='{0E14B963-A799-488b-A412-FC517ABCAB6F}'>
+<NAME>
+<TUV xml:lang='en-US'>SA_RSD-PR</TUV>
+</NAME>
+<QUAL>SA_RSD_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD59720' oid='B1D4C8DC4DE840b38ABD0E14F79AE71A' temploid='{A2F8C0BE-1647-4611-9173-7BF248C37414}' must='1' spec='sid' bl='8' v='103'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93D280' oid='2D652D5FFDED428eA41E5C2631A25806' temploid='{80C72091-19A0-49c4-BC54-7B407E512ADF}' must='1' spec='accm' dtref='_000001B1ADB66C60'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>SecurityAccessType</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD5B860' oid='AD9C58F68BB440beAE5DE3D5F60CCC22' temploid='{B2024426-45C5-4a56-B1C5-EF8AC0593FD1}' must='1' dest='data' minbl='16'>
+<NAME>
+<TUV xml:lang='en-US'>SecuritySeed</TUV>
+</NAME>
+<QUAL>SecuritySeed</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='2522896EACF94af59FB77C5589293B8B' temploid='{75052912-F66B-427c-BEE7-BF18A361963D}'>
+<NAME>
+<TUV xml:lang='en-US'>SA_RSD-NR</TUV>
+</NAME>
+<QUAL>SA_RSD_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD594C0' oid='B342366250EA4746B1BEFA4D398E1376' temploid='{11505798-8C37-4148-9C9E-2A7933C21EF1}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD5ADB0' oid='ED476F2B671D47b883F77C639CC2806C' temploid='{9D624AA5-3297-4f7d-A833-47B7F15DC6FE}' must='1' spec='sid' bl='8' v='39'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD5B990' oid='C7C3616D9FF24e22BE07D36ED4850C9E' temploid='{A9F18340-0604-4c25-A844-6E30AB30A3D4}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB33570'/>
+<NEGRESCODEPROXY idref='_000001B1ADB333F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB324F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA3770' oid='968EC6C81BD645c99E9BC15830D0727B' temploid='{8C03504D-A0A3-410b-96C3-7BC4DECA8A30}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($27) SecurityAccess - Send key</TUV>
+</NAME>
+<QUAL>SA_SK</QUAL>
+<REQ oid='D76216A7753B4ff8BCF09D28D25A5604' temploid='{C1921A7F-AE08-4a91-ABE3-8FFD0664174F}'>
+<NAME>
+<TUV xml:lang='en-US'>SA_SK-RQ</TUV>
+</NAME>
+<QUAL>SA_SK_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD59850' oid='49BE8F690CF9444297218006465AACB8' temploid='{FFEE2150-B299-4f94-B251-0237E6E71EF2}' must='1' spec='sid' bl='8' v='39'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93D4A0' oid='95379590B09E40998A082DF342493990' temploid='{670E9D0E-8255-446d-812F-F96E61A8A4D3}' must='1' spec='sub' dtref='_000001B1ADB66C60' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>SecurityAccessType</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD5AEE0' oid='FC387A51B4504f9c929615AA9304B906' temploid='{162A7209-6C7F-4258-9606-30B866C25F77}' must='1' dest='data' minbl='16'>
+<NAME>
+<TUV xml:lang='en-US'>SecurityKey</TUV>
+</NAME>
+<QUAL>SecurityKey</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='80DC9D2C0358496d87C332825B6459A0' temploid='{305BCA2C-A17B-423e-AC55-49BB2681B906}'>
+<NAME>
+<TUV xml:lang='en-US'>SA_SK-PR</TUV>
+</NAME>
+<QUAL>SA_SK_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD59D10' oid='06E220CAE30B4e1294983F9B5B154321' temploid='{986CD1ED-1794-486b-8F59-0B5B3AAA297D}' must='1' spec='sid' bl='8' v='103'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93BA10' oid='7D77CB3D0A4944729870285F10869212' temploid='{336B63DD-0D0F-489f-ACFC-194BABB7ACC6}' must='1' spec='sub' dtref='_000001B1ADB66C60'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>SecurityAccessType</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='06172EA29C1E4008A9CFEA3A45ED6BE9' temploid='{4707EE93-B476-47df-AE87-407F165B89A7}'>
+<NAME>
+<TUV xml:lang='en-US'>SA_SK-NR</TUV>
+</NAME>
+<QUAL>SA_SK_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD5B600' oid='BC2C41252D784ff58C71164DC66BD73E' temploid='{5A870EBF-1A7D-4703-BD06-5EDE2269E64B}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD5BE50' oid='5B0A3234E9E141978104A5937FC27FD2' temploid='{EF8275A8-CBF2-4bea-8AA7-BC951D5EB014}' must='1' spec='sid' bl='8' v='39'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD5B4D0' oid='6D69E645765B48b5AB28B85E9A02030A' temploid='{6F61404B-A8F9-4b3a-BE79-F6FAACABA599}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB33570'/>
+<NEGRESCODEPROXY idref='_000001B1ADB333F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB324F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA39B0' oid='8D1EFCE7D5594331A9655DB01DEDCE66' temploid='{F9230D56-435C-46bb-9318-DAAA0B0EEC93}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($28) CommunicationControl</TUV>
+</NAME>
+<QUAL>CC</QUAL>
+<REQ oid='B7B8418FC2434e44917A894702E8946D' temploid='{3B535501-AF51-4db3-8B35-E5F3D408B872}'>
+<NAME>
+<TUV xml:lang='en-US'>CC-RQ</TUV>
+</NAME>
+<QUAL>CC_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD5B010' oid='A5D399784C69412dB534C58A504A1139' temploid='{35211487-B54E-4cb1-971E-C97706065EDA}' must='1' spec='sid' bl='8' v='40'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93B3B0' oid='E2780DCBD6C742d58037FE171DFF4C73' temploid='{40ACC51D-9BB2-4c70-B452-EFC5D293BD44}' must='1' spec='sub' dtref='_000001B1ADB65E20' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>ControlType</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD58DA0' oid='9C3B7D29E6234171A0F6054D86514F4A' temploid='{A1D6A0B0-75A1-4e59-9CEE-1F850207BD8C}' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>CommunicationType</TUV>
+</NAME>
+<QUAL>CommunicationType</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='2580272EC0F242859E20F5C53BB4C638' temploid='{D5869893-7AFF-4575-B2CE-61C3AC6B30CE}'>
+<NAME>
+<TUV xml:lang='en-US'>CC-PR</TUV>
+</NAME>
+<QUAL>CC_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD59E40' oid='D2B11CB5607744c2BD1DFB06B7EE92DB' temploid='{341ED511-10BA-4dbf-BF53-AE47F6A295B6}' must='1' spec='sid' bl='8' v='104'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93C4B0' oid='A1D413E97B6549caA9AF0BD7A0BD46F7' temploid='{D224AA87-20D6-43d5-B8AE-1490E470AD10}' must='1' spec='sub' dtref='_000001B1ADB65E20'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>ControlType</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='66FA8D10073843829063A35D9AE2D287' temploid='{BF4D531B-5BEA-418a-9E14-B1F094BF4953}'>
+<NAME>
+<TUV xml:lang='en-US'>CC-NR</TUV>
+</NAME>
+<QUAL>CC_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD5A430' oid='817548980BB0404cB97094E63942E09E' temploid='{20CE796A-1FA5-4fbf-92A5-AD03C2D0483A}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD58C70' oid='0AD7467D020B490798B579F827DE58FD' temploid='{82392C72-416C-41b0-955B-B6A75FD65C55}' must='1' spec='sid' bl='8' v='40'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD5BAC0' oid='D62874B498554d6b93B6565BA79FF4E3' temploid='{EBF82F6C-FD4E-48a2-B4AA-6F34E68C54A9}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA30B0' oid='1B098A7F7B4B4b1dBB0A02F5BD0C0963' temploid='{0E556C34-9569-41e5-BA65-D8EA0E99C3C8}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($3E) TesterPresent</TUV>
+</NAME>
+<QUAL>TP</QUAL>
+<REQ oid='D7F5F0581C494a2b85BCC2AACB5E8351' temploid='{CBC7D3A4-4A3E-4cd8-BB33-E00122E1B80A}'>
+<NAME>
+<TUV xml:lang='en-US'>TP-RQ</TUV>
+</NAME>
+<QUAL>TP_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD5BD20' oid='58C2D9C367AC4900957BEF9AFB0E16EA' temploid='{50A6BDC7-9FC9-4271-A671-6B6FF3688372}' must='1' spec='sid' bl='8' v='62'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD58ED0' oid='0B969B7145484fdf8E41932EEDA4B313' temploid='{277F1E50-C0C2-42df-9C8C-80500FB78B50}' must='1' spec='sub' bl='8' v='0' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ZeroSubfunction</TUV>
+</NAME>
+<QUAL>ZeroSubfunction</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='660563AB81074774BAC5E1E49C325B86' temploid='{BAFB8F97-121B-4ac9-8BB6-0950F00C755B}'>
+<NAME>
+<TUV xml:lang='en-US'>TP-PR</TUV>
+</NAME>
+<QUAL>TP_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD5A0A0' oid='A6EC4AEF86EE4461A80219DB98FBDCFB' temploid='{AC83156A-7331-46ec-A83F-EF5B70524470}' must='1' spec='sid' bl='8' v='126'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD5A690' oid='57316E6DA3154cbd8070C89939151E02' temploid='{4F48A6BE-8FAC-4a0e-AFCA-40ACDE6B1D1D}' must='1' spec='sub' bl='8' v='0'>
+<NAME>
+<TUV xml:lang='en-US'>ZeroSubfunction</TUV>
+</NAME>
+<QUAL>ZeroSubfunction</QUAL>
+</CONSTCOMP>
+</POS>
+<NEG oid='3C37B417FE2743e7BDD2BCA559234FFF' temploid='{E04CC93A-11C3-47e6-9C8C-47558B9115E8}'>
+<NAME>
+<TUV xml:lang='en-US'>TP-NR</TUV>
+</NAME>
+<QUAL>TP_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD5A7C0' oid='C4904B4ED7D849268C0D148A0FE50233' temploid='{597673B9-36CF-4295-9790-E1B5057EB66E}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD5A8F0' oid='64D06098DAC8427894DDD5B59D568261' temploid='{D48A3110-3718-4ad4-AFF2-FB83C0722086}' must='1' spec='sid' bl='8' v='62'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD5AA20' oid='5FFE518932C643e1B60101D9D1A83A12' temploid='{E4DDB08C-3C2E-49a6-B7E3-27390B30A3A5}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA4070' oid='E18D2B2C68914b47809F5EF06A26B8A3' temploid='{8AE31B71-849A-40bb-8688-A3219992C49B}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($22) ReadDataByIdentifier</TUV>
+</NAME>
+<QUAL>RDBI</QUAL>
+<REQ oid='79981EB418914ba69EE27D49E7C9FC64' temploid='{43DDF7D8-4F83-4b6e-BB3C-639960881D5D}'>
+<NAME>
+<TUV xml:lang='en-US'>RDBI-RQ</TUV>
+</NAME>
+<QUAL>RDBI_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD5AB50' oid='1E43201E45D0406aB691A8B5EDCA2021' temploid='{A15219A0-6A9F-43a4-BB70-E2E1FBD69CBA}' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD939920' oid='BA75A9EE5BAD4baaAA420E0EE310EBB0' temploid='{7A9F9295-C106-4db4-ACE7-EA83F61DC89B}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RecordDataIdentifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='7DDEB723CE51495f8F7317E1B36EC8F8' temploid='{1D7B0B97-456B-4869-B822-7DF6A53C603A}'>
+<NAME>
+<TUV xml:lang='en-US'>RDBI-PR</TUV>
+</NAME>
+<QUAL>RDBI_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD5B270' oid='3B63A9ED0BB04659AEDCF3347425A486' temploid='{7A327E28-1C07-448d-B0EE-5D6FBD46348C}' must='1' spec='sid' bl='8' v='98'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93CB10' oid='E0BC58384D3F4e4f962C1D384951C5D0' temploid='{07A3E62B-9848-4a7c-BBDF-DFA1214E33CC}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RecordDataIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD57710' oid='1316AC7CABE04c1aB7C898F241073910' temploid='{4C8B75DD-3BCB-4e4a-A9E0-1A4D5EB9EBFC}' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='E5EA44D537CB4867AF9251065D490379' temploid='{196E9DC1-1907-47f7-B382-75854FC57DDB}'>
+<NAME>
+<TUV xml:lang='en-US'>RDBI-NR</TUV>
+</NAME>
+<QUAL>RDBI_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD587B0' oid='304B1141BEC54a29839695AE0267EF87' temploid='{15DF7DBE-FD91-4b4a-9469-1AC3EA836CF1}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD55BC0' oid='7825A73D171B44c4A27D0F910E59CA60' temploid='{0F9F1AAC-8F4A-4826-A778-FB1757EB5CC1}' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD55960' oid='6E9E32C2711F45d0AF0F280C4FB52307' temploid='{A8FDF2D9-36A2-4907-A538-9DE90B4725DA}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA4DF0' oid='4D46A27A37CB44ae859D20DE3F04FDF0' temploid='{87D5177E-6748-4302-9928-B44BBE9814AD}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2E) WriteDataByIdentifier</TUV>
+</NAME>
+<QUAL>WDBI</QUAL>
+<REQ oid='57CA26D3AB114b3999B127721C5ABA15' temploid='{CEB035B3-A05A-4712-B74B-96EC23E7C159}'>
+<NAME>
+<TUV xml:lang='en-US'>WDBI-RQ</TUV>
+</NAME>
+<QUAL>WDBI_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD581C0' oid='2C979F05C0114d26B6923D08584A6E42' temploid='{7EAF6855-E82B-4e49-AF7C-14591844356F}' must='1' spec='sid' bl='8' v='46'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93C7E0' oid='8DCA45C65ADB495a8C607BF16BB1C3FE' temploid='{BF78EFF7-F073-4823-A5A9-DF371F07C11A}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RecordDataIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD554A0' oid='2731962232404dca9FCED899B92A6172' temploid='{89198DC2-3D4C-4034-AB75-0FDBD002636A}' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='9A08060192204e1d800C7638B410BEAF' temploid='{2941E465-13AB-4be6-B61A-C97B626522CF}'>
+<NAME>
+<TUV xml:lang='en-US'>WDBI-PR</TUV>
+</NAME>
+<QUAL>WDBI_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD57E30' oid='25059F2BDAE849a78788CE53C6DFF8C0' temploid='{A21163BC-E577-433e-95B1-E7BC062125CA}' must='1' spec='sid' bl='8' v='110'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93B4C0' oid='7DA27547C01D44c996A32363946328D1' temploid='{77D284B7-56F8-472b-B671-012241AAFF93}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RecordDataIdentifier</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='D2F3A00284AA449e9EBF15AAD61F8A53' temploid='{AA3FC864-D600-45ed-970D-0728268BECB9}'>
+<NAME>
+<TUV xml:lang='en-US'>WDBI-NR</TUV>
+</NAME>
+<QUAL>WDBI_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD574B0' oid='6087F2CF4B78458f90BBAAFCF214B456' temploid='{F62AE433-02BC-4de2-B0FD-88550BDD3BA5}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD56EC0' oid='8D6F20265A534c42A83C290A984C64F0' temploid='{142DE6F1-6BE4-4403-A2B9-42E6B1E89616}' must='1' spec='sid' bl='8' v='46'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD54530' oid='7558F1F2551641ccA819B97C73BCA84C' temploid='{4C438E74-4C0A-4c9f-8D0A-BAEB84569947}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB319F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA3BF0' oid='5352C60EBB53402cA83082320879A5F4' temploid='{0EF64197-9D79-447c-8FA3-D3D9B1B6C6A3}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($14) ClearDiagnosticInformation</TUV>
+</NAME>
+<QUAL>CDI</QUAL>
+<REQ oid='24115B492BC6448e9B8AA5B654655F93' temploid='{058212EF-935A-4711-B7D2-76ABF2C18796}'>
+<NAME>
+<TUV xml:lang='en-US'>CDI-RQ</TUV>
+</NAME>
+<QUAL>CDI_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD54660' oid='B5844E9FD1B24846B637E49348EB9C2F' temploid='{4D4459B8-3F87-4879-BD98-271866037509}' must='1' spec='sid' bl='8' v='20'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<GROUPOFDTCPROXYCOMP id='_000001B1ADC19D30' oid='67AC2646F2434f368430FE32A867F167' temploid='{66A47923-A01C-4dd4-A2FE-B92D0EE9A934}' must='1' dest='groupOfDtc' minbl='24' maxbl='24' dtref='_000001B1ABDEBB00'>
+<NAME>
+<TUV xml:lang='en-US'>GroupOfDtc</TUV>
+</NAME>
+<QUAL>GroupOfDtc</QUAL>
+</GROUPOFDTCPROXYCOMP>
+</REQ>
+<POS oid='F3E361B2DDE54011A9D5D618AD3E9E59' temploid='{0E7C08D2-045E-4c86-A59B-C0B42B3B9C7B}'>
+<NAME>
+<TUV xml:lang='en-US'>CDI-PR</TUV>
+</NAME>
+<QUAL>CDI_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD55370' oid='9B1B54E5D5244a32BB411BFBA5F55516' temploid='{9F95D06B-C778-487f-91C7-BEAC119F4D8D}' must='1' spec='sid' bl='8' v='84'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+</POS>
+<NEG oid='90F1F787EF074c9dABB3B148C1A990BE' temploid='{082213F3-1F46-4bc3-B930-6041598B98B7}'>
+<NAME>
+<TUV xml:lang='en-US'>CDI-NR</TUV>
+</NAME>
+<QUAL>CDI_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD57120' oid='085B3A40C2E44cba8CCC3ACDED0505B2' temploid='{1F94174E-9FF5-4534-9298-B7CA6D8BD631}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD56A00' oid='463DC01C5F664aaa98E2B2D7316D21A7' temploid='{9D3BB452-1F08-4c45-BC50-1A8D676736A1}' must='1' spec='sid' bl='8' v='20'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD588E0' oid='4AFE7B531DC1425fA78CE84271CC5379' temploid='{D6015629-3F84-4369-A524-F4547119503F}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA44F0' oid='B82F574F89CA4516AB1094E26E6677E4' temploid='{448AB011-169D-4d51-9C7A-58477FB62CD4}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report number of DTC by status mask</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSM</QUAL>
+<REQ oid='3F95D7DC49E64b3993DB2BB53DD8BDC6' temploid='{FC767626-510F-4846-A429-AED307323473}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSM-RQ</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSM_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD55A90' oid='6A4BB2A9F12D4243B03278F437D3F9BA' temploid='{5B6A9BC6-BF0B-4bce-AADE-D28BCAC831B3}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD58680' oid='07DA263B739B46deAD3B4518AC870A99' temploid='{101E590E-46B2-49df-9570-1897D1E738AC}' must='1' spec='sub' bl='8' v='1' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportNumberOfDtcByStatusMask</TUV>
+</NAME>
+<QUAL>ReportNumberOfDtcByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADD56B30' oid='CC8DB5BD45DC4e9dA0E32D0382BCAC59' temploid='{2ECFBB84-293B-42f1-8086-887D1CB90E42}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusMask</TUV>
+</NAME>
+<QUAL>DTCStatusMask</QUAL>
+</STATUSDTCPROXYCOMP>
+</REQ>
+<POS oid='0077373DCAEF444d98877D9A3AFD5D7A' temploid='{7A9123D2-C313-412b-B488-C310BD0D0E4C}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSM-PR</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSM_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD55240' oid='E5F7B1F5A5D14f3d96B6C8BB37FEB0F4' temploid='{D1788545-D15F-4264-8880-A206DC013313}' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD54FE0' oid='DBA4819DABCC49329C023E14D674CB3B' temploid='{61F17329-8328-4a04-9C81-DA1B38E249A5}' must='1' spec='sub' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportNumberOfDtcByStatusMask</TUV>
+</NAME>
+<QUAL>ReportNumberOfDtcByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADD58A10' oid='191AB9E21FAA4c6191C61C7F0148E50F' temploid='{A624BFA7-A3E3-4971-8F54-B626A3603B32}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCStatusAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD57AA0' oid='04F79A38D3254e54BE524B9BFF0E072E' temploid='{568E9CD1-32B9-405f-9374-F9B4DE7D8924}' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFormatIdentifier</TUV>
+</NAME>
+<QUAL>DtcFormatIdentifier</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92C5E0' oid='425DBDDA181F4821BDEB8F9E33ADD12C' temploid='CDC920DDD2C74c7192F654B31013F855' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCCount</TUV>
+</NAME>
+<QUAL>DTCCount</QUAL>
+<SIMPLECOMPCONT oid='33BBE951116D4a97A5A1FFA4BD9A1DA7' temploid='D1B79210569149a68C7B2683E889B00D'>
+<DATAOBJ oid='21B9E231EFDF4c62988CDD004571A2A6' temploid='EFE6E064D7214df5A5413DC101891AE6' spec='no' dtref='_000001B1ADB62B20'>
+<NAME>
+<TUV xml:lang='en-US'>DTCCount</TUV>
+</NAME>
+<QUAL>DTCCount</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</POS>
+<NEG oid='E37294D63CE843cc9502981DE9714522' temploid='{42A0CDB1-42E5-44dd-A946-7B24D0EFE3E0}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSM-NR</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSM_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD57970' oid='BE01C27AC113414fB6BC4BAE7A8DDD60' temploid='{07DA9783-2242-4852-8B92-A4EA803CAFAF}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD55CF0' oid='CD9208D9702144a189CEE20DB684CFDD' temploid='{A0D2D3E2-40EE-482a-B143-F503C6216E83}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD56C60' oid='8C9166BAB9D640cc9C41EB60CDDDB012' temploid='{35C6607A-C441-4494-9FE0-E091434B25EE}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA3E30' oid='A9D0E3B8FAED4135AB9083580D512381' temploid='{9160C686-30BD-4d09-BC16-FF3D79898CC2}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report DTC by status mask</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM</QUAL>
+<REQ oid='391ADF92206F417293BCE50CAE326CA7' temploid='{115D772F-19B6-443f-A169-2E2CF1986DA9}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-RQ</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD57840' oid='409B5CA4D44346d3911F71FC52D0737C' temploid='{EB68D45A-A720-4a0b-A029-3B2B8FAA7CAE}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD54EB0' oid='46815AD21819422dA1A6B4BA699D9495' temploid='{247F965C-18B8-454e-B2A3-C5205362CA79}' must='1' spec='sub' bl='8' v='2' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcByStatusMask</TUV>
+</NAME>
+<QUAL>ReportDtcByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADD555D0' oid='588A33F18DBB4e4584B812FCBFE3740F' temploid='{1CB3CA06-FE98-4b03-A46C-253669E41B4E}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusMask</TUV>
+</NAME>
+<QUAL>DTCStatusMask</QUAL>
+</STATUSDTCPROXYCOMP>
+</REQ>
+<POS oid='39F04D97C08A447cA36DA969E53E0856' temploid='{A0F8B142-D220-46d2-AE1A-974B3A85D81C}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-PR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD575E0' oid='CD76876816E448daAD97289B85E5456E' temploid='{66B73D27-8341-418b-B7D7-B9052D675E98}' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD58B40' oid='DDAC9279C96D4adbB5E269060A9E3A6A' temploid='{EE4AF460-5E12-4231-A908-092DE28EECB5}' must='1' spec='sub' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcByStatusMask</TUV>
+</NAME>
+<QUAL>ReportDtcByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADD54070' oid='41577B8D8CA4482b9421EC5E002E92C6' temploid='{4670AB19-641F-4107-8DBD-6F84C8A20631}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DtcAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAFC70' oid='24B61E958D2E4bb6859E112A1B4AC452' temploid='{9E6318F7-E927-43d2-90DE-53DDA4D1C150}' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfDTC</TUV>
+</NAME>
+<QUAL>ListOfDTC</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADD55E20' oid='930BDA1DABCF41fb86DE1F0F38A3F53E' temploid='{EC7B58C9-D8FF-4993-AE73-B06CD2DC32D8}' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADD55F50' oid='CEA88CD7FB964a5fBC1F4A5012EA6E1C' temploid='{80AE2014-BACA-4a8d-B1B5-AE2FC09CB650}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDTC</TUV>
+</NAME>
+<QUAL>StatusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='BD8A95E503D24e65B9849FF632F7F554' temploid='{E78421AF-6A5C-4917-A0C4-B102EB2D32F5}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-NR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD58090' oid='5A52D9E42C8B4318A38690B3C2FD4C6A' temploid='{52C0A0B0-7CC1-42bb-8B3C-473FDB2969A2}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD562E0' oid='7A267E1E77F148c2B6B4AC05C8C79719' temploid='{8306CB7D-9089-452a-BCD1-724FF5E093A1}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD56D90' oid='59E6A7226D844b4eA6FBD22F05FAAC3F' temploid='{BB133A47-D94A-4728-B4D7-DE1B826831D7}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA4730' oid='085241C8A50E46a98C3585D39973FBE7' temploid='{4E121323-E09F-4523-BA8A-E1BD2A755AE3}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report number of DTC by severity mask</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSMR</QUAL>
+<REQ oid='B69EDF8608CE4622B99A2C96762D9998' temploid='{A071489D-96F2-415a-91FA-E47FB9B66983}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSMR-RQ</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSMR_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD54C50' oid='B0CC47181A80475897306B5AF6569C5C' temploid='{A528C114-6A7B-42f5-9DC7-6FE37D1DF263}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD56410' oid='6BDBF649879D4b5b9409C353065D1793' temploid='{464745EB-E603-49cc-BB80-7860F69E91D5}' must='1' spec='sub' bl='8' v='7' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportNumberOfDtcBySeverityMask</TUV>
+</NAME>
+<QUAL>ReportNumberOfDtcBySeverityMask</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD541A0' oid='1380E51720D64b05894972C8AEE37843' temploid='{7B356F0A-D781-44ab-804C-7F2172DF35B0}' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverityMask</TUV>
+</NAME>
+<QUAL>DtcSeverityMask</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADD548C0' oid='B10FE597E2C44e63B401C0384D8D2208' temploid='{DF133D02-9343-42ea-AAE4-6E706C934D81}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusMask</TUV>
+</NAME>
+<QUAL>DTCStatusMask</QUAL>
+</STATUSDTCPROXYCOMP>
+</REQ>
+<POS oid='77DCD2D1B2D241f28214B40864230DB8' temploid='{EEEFF3E7-6890-4e81-A4B1-A5748AB82F80}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSMR-PR</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSMR_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD542D0' oid='3AAF81CA17DA4653B22FD27ECB9AD565' temploid='{83CA8907-D10B-4c1b-B9D1-2A6D1686AB4D}' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD567A0' oid='6CB496A380C14e06B68ACB1E5E4DE7FF' temploid='{BD7452CA-3299-4d95-ACD5-01C231D636ED}' must='1' spec='sub' bl='8' v='7'>
+<NAME>
+<TUV xml:lang='en-US'>ReportNumberOfDtcBySeverityMask</TUV>
+</NAME>
+<QUAL>ReportNumberOfDtcBySeverityMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADD56FF0' oid='BB293EB843664574B83BFB898738D49C' temploid='{B5A8FFA4-47BF-48fa-A1EB-5AE786D08907}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DtcAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD57BD0' oid='D418E592EA0F4e8dB33FBC0BCB3D3EF8' temploid='{0B4D9091-759C-495b-BD69-24F53B5FF036}' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Formatidentifier</TUV>
+</NAME>
+<QUAL>Formatidentifier</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92B540' oid='955ABD706DA84adf9A623703AF92C91C' temploid='FCA60056CE1D4085B710E3E16C34CC15' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCCount</TUV>
+</NAME>
+<QUAL>DTCCount</QUAL>
+<SIMPLECOMPCONT oid='3A98484E0273491aAEEEC6208B754D4C' temploid='9317AC5D5C704aacB386F88977178B9B'>
+<DATAOBJ oid='48741AF13C5B43b6B344AE2C4BC65027' temploid='84FED9EEE08A4f5eA768FC119DCBDEC1' spec='no' dtref='_000001B1ADB62B20'>
+<NAME>
+<TUV xml:lang='en-US'>DTCCount</TUV>
+</NAME>
+<QUAL>DTCCount</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</POS>
+<NEG oid='47CA6E285B934078BBA54742C967E24F' temploid='{242E1827-74AE-4581-9040-490AAB5C39BF}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSMR-NR</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSMR_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD57250' oid='415219462EAC464198E5EC6DD737448F' temploid='{E374010C-754E-4cb1-9FAF-380C3D901632}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD56540' oid='9ECE2211E84B4d678D576017EEA82DA0' temploid='{73EA79EE-7C9D-4337-8A6E-E638FB2271F2}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD57380' oid='2E8A69D95E654686AD62103C92BBAC81' temploid='{831ADB8B-C998-4de8-B73E-A123D4281E21}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA42B0' oid='5C9B2FDBF95E47deA31CEA6AC39096C3' temploid='{C299C50A-00A4-4878-9FE7-BF29B09F6434}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report DTC by severity mask record</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSMR</QUAL>
+<REQ oid='2C1098C67B974976AE042E32160DB26C' temploid='{88A5FA9E-8097-41fe-855A-CCFBCCE58735}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSMR-RQ</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSMR_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD56080' oid='429E1E9BD0B64b0bA1A443FAB60CBE68' temploid='{07C899B5-1B52-4144-92DF-BB5619EB7B94}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD54D80' oid='3636415B45D543709653C56AB3CF87CC' temploid='{7EC5F0B7-486A-450c-A041-CC7860BCDE78}' must='1' spec='sub' bl='8' v='8' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDTCBySeverityMaskRecord</TUV>
+</NAME>
+<QUAL>ReportDTCBySeverityMaskRecord</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD57D00' oid='77415547C93540e6B9EA2D2F5BFF4031' temploid='{C085206D-3D34-4eab-8160-B40B2D7B71E3}' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverityMask</TUV>
+</NAME>
+<QUAL>DtcSeverityMask</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADD57F60' oid='F35154BFE94F4bb788D96A9B795942FE' temploid='{4A955922-8C9C-4512-AB34-19A8B2D1B064}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusMask</TUV>
+</NAME>
+<QUAL>DTCStatusMask</QUAL>
+</STATUSDTCPROXYCOMP>
+</REQ>
+<POS oid='14EBB58D4B41490e9DF2D24E5D8AF05A' temploid='{7683F0BC-95DB-40a6-8B24-0A84E07196EB}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSMR-PR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSMR_PR</QUAL>
+<CONSTCOMP id='_000001B1ADD54790' oid='5E53B116B95F44208F0B6EB22DDC6098' temploid='{71D26C64-C0BD-4448-B7C0-A87E34A073A0}' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD54400' oid='93126F71C5DF47dd9D40EAFFBCEDFB83' temploid='{AB3F2231-3548-4a47-AA39-D0309F53B296}' must='1' spec='sub' bl='8' v='8'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDTCBySeverityMaskRecord</TUV>
+</NAME>
+<QUAL>ReportDTCBySeverityMaskRecord</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADD582F0' oid='A7E559D55A6F47689EF6050FA1EFD8EB' temploid='{89A9FBAE-907E-49ce-9B6F-FD34FD35F96A}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DtcStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DtcStatusAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAFF70' oid='E2B65C74DCCE4b1a930F766A9CC33393' temploid='{076C3A7D-57B3-4a97-93AC-75ECDD5B2117}' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfData</TUV>
+</NAME>
+<QUAL>ListOfData</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADD58420' oid='04E1E7E872CF43d4B71EE9151A46F496' temploid='A7CAAC48D2224ccd94D70836A469A72B' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity</TUV>
+</NAME>
+<QUAL>DTCSeverity</QUAL>
+</SIMPLEPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD54B20' oid='B380A247F6FB49ed980A44360932B6D6' temploid='7310167C33A540a68AF61A4B981A9D79' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFunctionalUnit</TUV>
+</NAME>
+<QUAL>DTCFunctionalUnit</QUAL>
+</SIMPLEPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD56670' oid='F5F834A2E6F04719A9FF8F63ADF4C8B6' temploid='{3B75728C-33AE-48c3-8C87-46BE37456203}' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADD58550' oid='E1CE7D511133481292AD67BF1F28C8C3' temploid='{10CA3DA7-1F9B-47a5-8849-EF0450414B30}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>statusOfDTC</TUV>
+</NAME>
+<QUAL>statusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='8CAE9017B1984d84B1CD6FE088DBB678' temploid='{B977BA82-2DCB-4c02-B9A1-4CE8F889F64B}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSMR-NR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSMR_NR</QUAL>
+<CONSTCOMP id='_000001B1ADD549F0' oid='118AD0D81F254bba92B29FF09E102966' temploid='{69A0C8D3-D076-47eb-AFFD-941A343D6E60}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADD55110' oid='87F1C68D633147ddBC14CECC7083A45E' temploid='{81B004C0-F886-4e6d-A179-7753850076AE}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADD55700' oid='C1AA8E8E5D624d5aA743A7D8B56FBC49' temploid='{010B8F57-7400-4399-90A1-CAC0E2C41338}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ABFA4970' oid='ED7AB712A90D4e09869F0B031A7342F5' temploid='{05662088-DA92-4087-BBD6-35C720570166}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report severity information of DTC</TUV>
+</NAME>
+<QUAL>RDI_RSIODTC</QUAL>
+<REQ oid='EB5CFA13E53C4b98B5E27C2B26592392' temploid='{3F8F0E59-7B19-481a-BA89-C68692A44A69}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RSIODTC-RQ</TUV>
+</NAME>
+<QUAL>RDI_RSIODTC_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADD55830' oid='C80397CFA8DE4717B29CA2912FB5BA76' temploid='{C971F9B0-B6A8-4437-AB97-356A502B9306}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC6EC0' oid='3FE96AF81E32441094E5B954F3602231' temploid='{DDC7C6CD-6A51-4fab-B404-2C3DDC891AFA}' must='1' spec='sub' bl='8' v='9' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportSeverityInformationOfDtc</TUV>
+</NAME>
+<QUAL>ReportSeverityInformationOfDtc</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC6670' oid='1D6F22C4027740adB89A0D7F766EC014' temploid='{303E6DE7-36EA-4161-A662-F48BA3763458}' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTCMaskRecord</TUV>
+</NAME>
+<QUAL>DtcMaskRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='3E62BD0EACC149b5A40FB7877B9C592C' temploid='{330DA280-89CC-4929-82E0-65078FF0D342}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RSIODTC-PR</TUV>
+</NAME>
+<QUAL>RDI_RSIODTC_PR</QUAL>
+<CONSTCOMP id='_000001B1ADDC6410' oid='DFD4D9B07A984521A182F3D208FFA789' temploid='{ADA41380-F11F-4955-8028-757978F1417D}' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC7F60' oid='6B6D5F694B394649BF5814886B570A94' temploid='{1FEE3497-9251-416c-BF1D-7F372AD8182E}' must='1' spec='sub' bl='8' v='9'>
+<NAME>
+<TUV xml:lang='en-US'>ReportSeverityInformationOfDtc</TUV>
+</NAME>
+<QUAL>ReportSeverityInformationOfDtc</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADDC6FF0' oid='67D4ED62F21940d9B9C82E596BCF32C8' temploid='{4B5EB935-FF09-4e50-83A8-C463DE53644C}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DtcStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DtcStatusAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAE970' oid='5DCBE8D8A75041c0AFB81958812F66A2' temploid='{D14A7C25-EF6E-44e9-80FE-B9174C0D25FE}' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfData</TUV>
+</NAME>
+<QUAL>ListOfData</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADDC8A10' oid='194E23F1F9AB4e22999B26D489E71CE5' temploid='EDCCE96A4AEC466eB8A769D3242A7DD8' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity</TUV>
+</NAME>
+<QUAL>DTCSeverity</QUAL>
+</SIMPLEPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC82F0' oid='57948C9005D74b94B0443D92180DA1BC' temploid='FCDDBA437D00472aA26ACAB94E96DE5B' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFunctionalUnit</TUV>
+</NAME>
+<QUAL>DTCFunctionalUnit</QUAL>
+</SIMPLEPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC7120' oid='3E3DE45A8F824865A8EED8002CD46435' temploid='{D5F53019-0216-470f-867D-BAC938D101F6}' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADDC8090' oid='73DC9CF61F944086A37B673707C48F4C' temploid='{05855393-EBF4-4b3a-A14A-0ABBC5073D38}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>statusOfDTC</TUV>
+</NAME>
+<QUAL>statusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='CB86704D710D4546B3D3F3469B85D971' temploid='{4358EB35-D592-4fe8-A587-596A1BFC2025}'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RSIODTC-NR</TUV>
+</NAME>
+<QUAL>RDI_RSIODTC_NR</QUAL>
+<CONSTCOMP id='_000001B1ADDC7250' oid='2443F66613B7496fA91D3439160E4A0B' temploid='{0358C764-957A-4e3e-A715-92BB4C86BC1C}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC6A00' oid='5F016BC6D54542618DB166261B550683' temploid='{850C01E0-D153-4063-A3F2-3EB057427D38}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC6B30' oid='0DE251B86E3E4a43B12ADC17B519BFCE' temploid='{640CF013-F598-4dd2-B485-29D0E226B656}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCE6B0' oid='B4727E420BC443889C56CD531F9A8424' temploid='{5B109BBA-A0F2-45e3-9A2E-50EE5A35BD29}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2F) InputOutputControlByIdentifier - Return control to ECU</TUV>
+</NAME>
+<QUAL>IOCBI_RCTECU</QUAL>
+<REQ oid='39A50105A79A44c59AE4F1D19D4D4254' temploid='{26E35707-43AA-4458-9CBB-D76AA957D64D}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_RCTECU-RQ</TUV>
+</NAME>
+<QUAL>IOCBI_RCTECU_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADDC8B40' oid='884CF9737B7241589E1C5C9D8140E0AD' temploid='{AA7DCD7F-2469-4d37-99D9-953EC43748DE}' must='1' spec='sid' bl='8' v='47'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93A1A0' oid='11D87E34599140b9B142E283E2E2EB29' temploid='{4BB9CED2-9B1B-487c-8394-E8E07560130B}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>DataIdentifier</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1ADDC5240' oid='02AA1576501D46bb8DD18839A8301D99' temploid='{E8DAEE57-8B1C-4d03-97D9-4BB0E13E11D5}' must='1' spec='sub' bl='8' v='0'>
+<NAME>
+<TUV xml:lang='en-US'>ControlOptionRecord_InputOutputControlParameter</TUV>
+</NAME>
+<QUAL>ControlOptionRecord_InputOutputControlParameter</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC8550' oid='EF2A63694E7D440b8FDF22C26BA61B45' temploid='F25F825E410042d68469F6D5CC1F4FEA' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ControlEnableMaskRecord</TUV>
+</NAME>
+<QUAL>ControlEnableMaskRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='CB47B64A44BE466dB3CA2212CA48B558' temploid='{7580B7AB-996D-41b9-AD76-AE15C2D61E72}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_RCTECU-PR</TUV>
+</NAME>
+<QUAL>IOCBI_RCTECU_PR</QUAL>
+<CONSTCOMP id='_000001B1ADDC7380' oid='BB56EAF0455248768E7F7796849DA0A2' temploid='{EC20BF9F-39CB-41f1-9266-E522EF9CB0CB}' must='1' spec='sid' bl='8' v='111'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93BB20' oid='71260B18F5D5445387C3A9F307A7EA9C' temploid='{350DF376-FB2B-4259-83C8-383FF6574AF8}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>DataIdentifier</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1ADDC6C60' oid='EDEB9BE45B12450a8E1A6BF7D9E570AE' temploid='{C0145628-BCFD-4017-90F5-2DB182D85C2E}' must='1' spec='sub' bl='8' v='0'>
+<NAME>
+<TUV xml:lang='en-US'>ControlStatusRecord_InputOutputControlParameter</TUV>
+</NAME>
+<QUAL>ControlStatusRecord_InputOutputControlParameter</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC4790' oid='1A9D914F823542388363DEAB24B4C5BA' temploid='B50CCE877A6749c280B7C6E2A772E610' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ControlStatusRecord</TUV>
+</NAME>
+<QUAL>ControlStatusRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='9958FC1FE50E4edaBCAE1FA0D28FF069' temploid='{797A09A4-86B7-423c-8590-23F051F83FE0}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_RCTECU-NR</TUV>
+</NAME>
+<QUAL>IOCBI_RCTECU_NR</QUAL>
+<CONSTCOMP id='_000001B1ADDC87B0' oid='2F58AD00ADE64241AD86440A09F173BB' temploid='{406929CD-4D10-4b09-B064-63C542744D63}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC5BC0' oid='7FA11746422448c1926D02C7F58A04EA' temploid='{D6158D88-258B-4a4b-9203-5417F7EF45E7}' must='1' spec='sid' bl='8' v='47'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC7710' oid='23E19683F4DC4e259A5D051F90214AFB' temploid='{263F0663-CA6B-472a-8F2C-A1AA1B8FAC07}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCDDB0' oid='CF5180D1B01F4b5b95D556639ABD9C3D' temploid='{FE3C0667-E694-45fa-BFC7-9052CA16AADF}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2F) InputOutputControlByIdentifier - Reset to default</TUV>
+</NAME>
+<QUAL>IOCBI_RTD</QUAL>
+<REQ oid='8CFFBFA9B8FC4d5a96B6CEDE1E0277F3' temploid='{124DFF6E-F3E4-49fb-A73F-8F6A73FD0EB5}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_RTD-RQ</TUV>
+</NAME>
+<QUAL>IOCBI_RTD_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADDC5370' oid='B352F68D245E4129983DA97FBF64EA92' temploid='{E05045A5-1F71-453b-BF81-4538BCA3E7C3}' must='1' spec='sid' bl='8' v='47'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD939E70' oid='99281C39BDE246949584C3DAB43F7667' temploid='{AA358848-7179-4cf4-A3A7-17EDA43F4D86}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>DataIdentifier</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1ADDC41A0' oid='3471949509E74fbe81294BB4F73C0B9F' temploid='{EC9AB2AB-937A-4026-8FA8-7D98F78094EF}' must='1' spec='sub' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>ControlOptionRecord_InputOutputControlParameter</TUV>
+</NAME>
+<QUAL>ControlOptionRecord_InputOutputControlParameter</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC74B0' oid='F153531B99F94f8c9F77642D7B69ECA7' temploid='8DBAD0F40A4F40e5B1198C791AA4DA00' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ControlEnableMaskRecord</TUV>
+</NAME>
+<QUAL>ControlEnableMaskRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='B1C1516B51DD4f05B9A97E881A421349' temploid='{9F928A8B-6281-4aa6-B091-16F5442C2C0B}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_RTD-PR</TUV>
+</NAME>
+<QUAL>IOCBI_RTD_PR</QUAL>
+<CONSTCOMP id='_000001B1ADDC5960' oid='140BDDEB3E34421eAF18DC20BF04964B' temploid='{9BE9715E-1FDC-4ff7-A1B8-C2EF93CC695F}' must='1' spec='sid' bl='8' v='111'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93BF60' oid='CD991E7A59644f4cB6D5ED04EFFE563E' temploid='{895A8244-B637-493b-98D7-3D3FC820CC02}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>DataIdentifier</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1ADDC67A0' oid='FF6B6A591B524772988644E3C3597FEF' temploid='{9CAC42E0-2F47-4da4-8B01-B05A704D3114}' must='1' spec='sub' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>ControlStatusRecord_InputOutputControlParameter</TUV>
+</NAME>
+<QUAL>ControlStatusRecord_InputOutputControlParameter</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC68D0' oid='A575BD8CB5094ae08AD3201A706CFDF0' temploid='B8808352AE1641f1B383D33205701367' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ControlStatusRecord</TUV>
+</NAME>
+<QUAL>ControlStatusRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='23DE67B5871B42efB52C726E61EE71B5' temploid='{98D807A8-C17F-4c27-9133-E0683D71B0AD}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_RTD-NR</TUV>
+</NAME>
+<QUAL>IOCBI_RTD_NR</QUAL>
+<CONSTCOMP id='_000001B1ADDC88E0' oid='189243DEF9E44cf38D9BB0042D49ED3B' temploid='{F33E65E3-0AC7-4209-BDB0-8C24ADF91EE0}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC48C0' oid='4B743D7408A841278FCDF111C9A48F0F' temploid='{B2C3EE55-B7CC-419d-99DC-0BBE4C6B97A8}' must='1' spec='sid' bl='8' v='47'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC75E0' oid='2920056727A346dbAF8D0676327B1EC1' temploid='{8E0477DA-001E-4a75-B28B-F1D3E8A96942}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCCBB0' oid='645AC771AD034870B86CB1960D601C37' temploid='{B753D4B4-F488-4cf8-B749-D205A4DFF9EF}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2F) InputOutputControlByIdentifier - Freeze current state</TUV>
+</NAME>
+<QUAL>IOCBI_FCS</QUAL>
+<REQ oid='E8D8D3C55186455c82217E1164C5AFB2' temploid='{AC04CC75-FE10-43c5-ADF6-F2929F2F45CF}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_FCS-RQ</TUV>
+</NAME>
+<QUAL>IOCBI_FCS_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADDC7840' oid='4CE15DA53D4942ac9F7DE2899AFD8F36' temploid='{8C69149C-1F70-4445-81AE-66962334C98B}' must='1' spec='sid' bl='8' v='47'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93AB30' oid='51C43B818F394470B8662933E2942454' temploid='{0788D437-26E9-4a77-9858-818436965F64}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>DataIdentifier</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1ADDC7970' oid='E73A195320B645cdA538E1862FCBEDD3' temploid='{BB48AB67-2FB5-42dd-B950-856B21BE6B81}' must='1' spec='sub' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>ControlOptionRecord_InputOutputControlParameter</TUV>
+</NAME>
+<QUAL>ControlOptionRecord_InputOutputControlParameter</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC49F0' oid='3D56D1DDAA604bf0BEAF51025D9C336F' temploid='3BD49CD7CF184eac848A5B77C56FEAAA' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ControlEnableMaskRecord</TUV>
+</NAME>
+<QUAL>ControlEnableMaskRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='53CEEC7E9E6E4904A084589556BD073C' temploid='{D5459DAE-5821-4c3c-80C9-6969B77F63FE}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_FCS-PR</TUV>
+</NAME>
+<QUAL>IOCBI_FCS_PR</QUAL>
+<CONSTCOMP id='_000001B1ADDC4C50' oid='D0867C9CB115492c80F2B1C07BB13E84' temploid='{813572D8-881C-4951-BA12-BEB67ADD602B}' must='1' spec='sid' bl='8' v='111'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD93C070' oid='BD9C0D56B0BF41a4B06B75EE8DE47122' temploid='{2218B75C-27BF-4653-A4D0-821F9A436DF1}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>DataIdentifier</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1ADDC5CF0' oid='03FEA05F2DFA4c4a90E95C7F82B41BDF' temploid='{0A035BC3-2976-4cf9-B6C1-F8C8368253F5}' must='1' spec='sub' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>ControlStatusRecord_InputOutputControlParameter</TUV>
+</NAME>
+<QUAL>ControlStatusRecord_InputOutputControlParameter</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC4B20' oid='62C8572F009247bc8D6710DFEA22ABFE' temploid='24CA4FFB051C4ff8856381EFAD354DCA' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ControlStatusRecord</TUV>
+</NAME>
+<QUAL>ControlStatusRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='3309934408A946519ED3A24A4F320EA3' temploid='{14E8243D-2090-47e2-958E-39DC97648332}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_FCS-NR</TUV>
+</NAME>
+<QUAL>IOCBI_FCS_NR</QUAL>
+<CONSTCOMP id='_000001B1ADDC4D80' oid='4ED868D5C1C246da8F3186D1C5539676' temploid='{20BD96E6-5A7F-43c8-A962-CB2B3942A316}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC6D90' oid='A7D76A3041F948f68F05A4981967CA7B' temploid='{8E04FBA5-9860-4eee-B010-BF8FF160D5F0}' must='1' spec='sid' bl='8' v='47'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC7AA0' oid='5D13E880592A4e0dA667ED4D54F79E21' temploid='{63D038DB-A53F-479c-972C-C7AF8FB335AD}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCC730' oid='8DE5FDEFAB744fd1986EABD99954A412' temploid='{1DA987DA-978A-45d9-9FAC-BF3750B60CE1}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2F) InputOutputControlByIdentifier - Short term adjustment</TUV>
+</NAME>
+<QUAL>IOCBI_STA</QUAL>
+<REQ oid='699319666054482795902B171D94E6B9' temploid='{44349174-CEAD-4bc9-95C2-64861A2C07D7}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_STA-RQ</TUV>
+</NAME>
+<QUAL>IOCBI_STA_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADDC7BD0' oid='D62F10A84F094857B6D0CE7584D419B7' temploid='{9D7BCC10-918A-4355-A36B-70040CBD9D91}' must='1' spec='sid' bl='8' v='47'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD916380' oid='B3812EF1D0B046c98CF3AA5E9C260A0D' temploid='{2CD7E739-2F96-4db1-BFC8-0DB22A03ECED}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>DataIdentifier</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1ADDC7D00' oid='4708A26B6EDB4cf3B8464581CD12524D' temploid='{CDFFB04A-63E0-4769-9111-425DC1DB53A5}' must='1' spec='sub' bl='8' v='3'>
+<NAME>
+<TUV xml:lang='en-US'>ControlOptionRecord_InputOutputControlParameter</TUV>
+</NAME>
+<QUAL>ControlOptionRecord_InputOutputControlParameter</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC7E30' oid='FDA9CF1D5E564e4f9B5EADD389EFD940' temploid='870A25F05EC34ffe8CF63F3ECFBF99C5' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ControlOptionRecord</TUV>
+</NAME>
+<QUAL>ControlOptionRecord</QUAL>
+</SIMPLEPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC81C0' oid='45013947B3C2410bAFDE0D487DA4F570' temploid='EDF9BC85578E4e068115749212011F80' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ControlEnableMaskRecord</TUV>
+</NAME>
+<QUAL>ControlEnableMaskRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='8D1043884FFA4aa68616D8BF83122E69' temploid='{C233A8F1-277B-4b95-B8A4-D2359567AB2F}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_STA-PR</TUV>
+</NAME>
+<QUAL>IOCBI_STA_PR</QUAL>
+<CONSTCOMP id='_000001B1ADDC8420' oid='CF36A1810A9E4a72B28244E39888E3CC' temploid='{6E67D7F5-0818-4c08-9A03-D17E4450C8D1}' must='1' spec='sid' bl='8' v='111'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD9143A0' oid='9163D4D34E994474AD1ED8126A0D2050' temploid='{598BDB4B-F86C-4577-9EE4-D53CD031C3C2}' must='1' spec='id' dtref='_000001B1ADB65370'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>DataIdentifier</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1ADDC8680' oid='5D6601196F4B4fc0A90BE719381BEBE5' temploid='{AA46C46D-BE4B-4827-8C9E-FA8D03478D03}' must='1' spec='sub' bl='8' v='3'>
+<NAME>
+<TUV xml:lang='en-US'>ControlStatusRecord_InputOutputControlParameter</TUV>
+</NAME>
+<QUAL>ControlStatusRecord_InputOutputControlParameter</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC4530' oid='D8DF385FF9DB444b9DED7A511BDCF73C' temploid='AE1D4450B8D84ecdAA519764BE58B9F4' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ControlStatusRecord</TUV>
+</NAME>
+<QUAL>ControlStatusRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='49B3095B16984826A9A0D4C6971E0799' temploid='{E6FD681A-7D7B-4f78-A8E6-BDD029C0B9D1}'>
+<NAME>
+<TUV xml:lang='en-US'>IOCBI_STA-NR</TUV>
+</NAME>
+<QUAL>IOCBI_STA_NR</QUAL>
+<CONSTCOMP id='_000001B1ADDC4070' oid='14A5C7D548E3450bAAEBCE8DFBD0F1DB' temploid='{98A4571E-330B-4513-9493-4F677B09FCA0}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC4EB0' oid='5CFE4C4A57784763A0709C1B397CA275' temploid='{FEA2A52A-FA79-4ff6-AD33-990C499A33CA}' must='1' spec='sid' bl='8' v='47'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC55D0' oid='5CDEEFA259EA4a8cA14AA77A3EAF832B' temploid='{9DF118E6-2DF1-4ff9-89EB-1CB1704A1E41}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCCDF0' oid='1F199CD47C89485985EEDA811C2046DC' temploid='{6F205035-E3D1-4353-A4D5-3E438874AB17}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($31) RoutineControl - Start routine</TUV>
+</NAME>
+<QUAL>RC_STR</QUAL>
+<REQ oid='18A8B585FC784221909749883B8FC7DA' temploid='{604685AB-47D3-4f3a-9627-F7D1D5417B63}'>
+<NAME>
+<TUV xml:lang='en-US'>RC_STR-RQ</TUV>
+</NAME>
+<QUAL>RC_STR_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADDC42D0' oid='FDA068EE6C49437183FA0447ECEC8F88' temploid='{DD59E62D-870E-44ab-A2D9-63D1EA2F5C32}' must='1' spec='sid' bl='8' v='49'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC4400' oid='D4AE789120564293BF3A70016EFAE7C8' temploid='{75CB9068-E04E-4b6f-9AE1-7C1C2D1A8B60}' must='1' spec='sub' bl='8' v='1' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineControlType</TUV>
+</NAME>
+<QUAL>RoutineControlType</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD9144B0' oid='FA29D516E298444aB5FF53E640B3BC3D' temploid='{305D594C-860E-4e87-A8A9-D91696EE0ABF}' must='1' spec='id' dtref='_000001B1ADB64790'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RoutineIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC54A0' oid='520B3A01C9C64aea8F2588144E8CD41E' temploid='{901E0FD4-46A8-4233-9AAD-9713AF5E6C95}' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineControlOptionRecord</TUV>
+</NAME>
+<QUAL>RoutineControlOptionRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='DEB8F8E1C8B04aaaA8D02EDA77AF6E0B' temploid='{73F9AF8F-F724-4a54-B58A-9963CBF97BD5}'>
+<NAME>
+<TUV xml:lang='en-US'>RC_STR-PR</TUV>
+</NAME>
+<QUAL>RC_STR_PR</QUAL>
+<CONSTCOMP id='_000001B1ADDC4660' oid='EF6CC5E8F971483782D92E771204A1CC' temploid='{1C3C8D12-6482-4738-A1BD-037FF128F3AF}' must='1' spec='sid' bl='8' v='113'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC4FE0' oid='CF300D191B664a43B4F0AE1B7388EED4' temploid='{BC43EF46-D678-43b5-9033-E3371DF62A3E}' must='1' spec='sub' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineControlType</TUV>
+</NAME>
+<QUAL>RoutineControlType</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD9146D0' oid='24CEFF9F57634c91A2EAE5BC9748048B' temploid='{B2D629BE-7215-4958-82CE-97106AC3A32D}' must='1' spec='id' dtref='_000001B1ADB64790'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RoutineIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC5A90' oid='225126AC99AE43cc93783A3FF1425B84' temploid='{48D133EA-98A6-4e66-AB71-E212C8A12E67}' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineStatusRecord</TUV>
+</NAME>
+<QUAL>RoutineStatusRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='06DCDCD38E5C4bd6AC9922F442AD6FBA' temploid='{9597820B-F95D-4026-92D5-41B451513E8D}'>
+<NAME>
+<TUV xml:lang='en-US'>RC_STR-NR</TUV>
+</NAME>
+<QUAL>RC_STR_NR</QUAL>
+<CONSTCOMP id='_000001B1ADDC5110' oid='29C11AAB7CC64ba3AF8F882957C021B7' temploid='{851A5365-6874-438b-9BF5-260DE91EB469}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC5700' oid='72869C295FB945f8A2E65CD2202BF7E1' temploid='{3988A1C4-3D8A-450b-BA11-86517E718F17}' must='1' spec='sid' bl='8' v='49'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC5830' oid='29784A95F33646a2B74320408BCC01C0' temploid='{BC908725-49AE-4330-A37F-1475EA5776D8}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB319F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCF1F0' oid='6F84C9E8D8AD489f989E778FB8F05600' temploid='{257E6FEF-06B3-458d-8F7B-BF6B5FADFC15}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($31) RoutineControl - Stop routine</TUV>
+</NAME>
+<QUAL>RC_STPR</QUAL>
+<REQ oid='7B56B092B64844a98723BC720D5BB644' temploid='{E7D2B9DB-69DA-48ff-AFA6-145FB9BADE65}'>
+<NAME>
+<TUV xml:lang='en-US'>RC_STPR-RQ</TUV>
+</NAME>
+<QUAL>RC_STPR_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADDC5E20' oid='1EBB6EBF9CF54bfd9BAB419256E13FED' temploid='{4EEB2A82-F2BF-4358-8B4A-830A4365EA52}' must='1' spec='sid' bl='8' v='49'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC5F50' oid='C90352B88FF04958824110A7EA7749EC' temploid='{55A1B434-5EF2-467f-BCF6-85EFD4806A6E}' must='1' spec='sub' bl='8' v='2' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineControlType</TUV>
+</NAME>
+<QUAL>RoutineControlType</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1AD914D30' oid='640215674CF24c19A869CD931C9BFE09' temploid='{76B69A77-FADC-4845-A6A4-AD45597198DA}' must='1' spec='id' dtref='_000001B1ADB64790'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RoutineIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC6080' oid='FC017E90A9B143fe91B62029F5F98DA7' temploid='{0CCDB5F0-46D7-4358-A6BB-DE1EB011881A}' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineControlOptionRecord</TUV>
+</NAME>
+<QUAL>RoutineControlOptionRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='52445A1BB97449908EFC1D1667B62C4B' temploid='{F11A2082-651C-45b4-B741-1360A515ADB0}'>
+<NAME>
+<TUV xml:lang='en-US'>RC_STPR-PR</TUV>
+</NAME>
+<QUAL>RC_STPR_PR</QUAL>
+<CONSTCOMP id='_000001B1ADDC61B0' oid='ABC519B10CF34c7fA94E4A2153F8D96E' temploid='{B3AB9906-7119-4aff-9E61-D8F253AC62EF}' must='1' spec='sid' bl='8' v='113'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC62E0' oid='D389644C5C0D48f58E1B8613E2A49B12' temploid='{0091038C-160A-40d6-8228-7BF5356F896A}' must='1' spec='sub' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineControlType</TUV>
+</NAME>
+<QUAL>RoutineControlType</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B18D0962F0' oid='E2D34BF856A344fb90D6BA03E7378D7D' temploid='{CB5F8440-8073-446f-A705-1F23B2BD0C87}' must='1' spec='id' dtref='_000001B1ADB64790'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RoutineIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC6540' oid='895D70DBC0194500869DB377B10C882E' temploid='{5B33E1D6-AF4E-4ea3-829F-66499344E5ED}' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineStatusRecord</TUV>
+</NAME>
+<QUAL>RoutineStatusRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='F62A77DC6EB145de87795E129B2B1C0C' temploid='{1E64F7B8-02F7-4537-A60B-94D316E4F82C}'>
+<NAME>
+<TUV xml:lang='en-US'>RC_STPR-NR</TUV>
+</NAME>
+<QUAL>RC_STPR_NR</QUAL>
+<CONSTCOMP id='_000001B1ADDCB3A0' oid='C695BFF4A66B40a6B29CF9106B751B7A' temploid='{2D35BEF2-216B-45a1-83A4-9A01990B9D29}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC8ED0' oid='289E2125B5C248d5B3297057A7E2AA0F' temploid='{D04FBA91-3ED8-42bc-ABBA-AB54877B7A2D}' must='1' spec='sid' bl='8' v='49'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC9260' oid='1DAEADC84DAF4ce9B1BCE29B9DD814C2' temploid='{E7CCDAAB-6C1B-4a13-B3E1-E1150E40E602}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB319F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCC2B0' oid='0619BC35FADD4a8f827FDD56AAA084ED' temploid='{BDC467A9-D858-4a98-9FB9-68132A2E458C}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($31) RoutineControl - Request routine results</TUV>
+</NAME>
+<QUAL>RC_RRR</QUAL>
+<REQ oid='44A84BA2A4F24f95988021F3E6702662' temploid='{3D0779EF-EC30-4be5-BA31-96927D3A3906}'>
+<NAME>
+<TUV xml:lang='en-US'>RC_RRR-RQ</TUV>
+</NAME>
+<QUAL>RC_RRR_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADDC9980' oid='6D8308F2A93546cdB321F1620FE8C046' temploid='{BDEAA3CE-9C9C-432f-8D0C-A676892F5D1B}' must='1' spec='sid' bl='8' v='49'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDCB730' oid='7D332C8C41F3439695D0FEAAE314F2A3' temploid='{B5B4E618-0B7B-4388-A81D-CE90CDB49E30}' must='1' spec='sub' bl='8' v='3' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineControlType</TUV>
+</NAME>
+<QUAL>RoutineControlType</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE307B0' oid='1E5A104814154d8d81F78EAE7E7CFAF6' temploid='{BFFA0B58-CF83-47cb-A2AF-2991CFD64680}' must='1' spec='id' dtref='_000001B1ADB64790'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RoutineIdentifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='80693E097D82457292E328C7238B7B7D' temploid='{CA3FE317-867E-4eff-A6A2-A63D304E0831}'>
+<NAME>
+<TUV xml:lang='en-US'>RC_RRR-PR</TUV>
+</NAME>
+<QUAL>RC_RRR_PR</QUAL>
+<CONSTCOMP id='_000001B1ADDCADB0' oid='4BDAA5B659794eae8DF074EF5C9315C0' temploid='{890A4193-C939-471a-9314-72CD10454CD1}' must='1' spec='sid' bl='8' v='113'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDCAB50' oid='FD112171C94F47e0B9DB8923D1444E52' temploid='{65AB3AC4-2A5D-4c50-A819-E47D466C0FDB}' must='1' spec='sub' bl='8' v='3'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineControlType</TUV>
+</NAME>
+<QUAL>RoutineControlType</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE31AD0' oid='FD335189178A4669BB332D1848E6116E' temploid='{FBD59D58-3E76-412c-B16F-8AEADBCD2E1C}' must='1' spec='id' dtref='_000001B1ADB64790'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RoutineIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC9F70' oid='63BCC469B19648b69A38E9833F3D7A61' temploid='{A69615F7-B47C-42aa-B33A-F350C78AC898}' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RoutineStatusRecord</TUV>
+</NAME>
+<QUAL>RoutineStatusRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='CCDE7699F46D41fbA49501998B287639' temploid='{D00FEFE4-DA98-4de7-A6BF-BB934B7AFF87}'>
+<NAME>
+<TUV xml:lang='en-US'>RC_RRR-NR</TUV>
+</NAME>
+<QUAL>RC_RRR_NR</QUAL>
+<CONSTCOMP id='_000001B1ADDCB860' oid='DA35470CAD84438e98EC000CCDC6DD1B' temploid='{E83311AD-0BB4-4fb3-9AED-E124C89CEA6F}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC8DA0' oid='1E00ADF25A114d85A9EBC3A611632E8E' temploid='{B2BC96CA-932D-4f42-BC1D-FD19F2EB3BB8}' must='1' spec='sid' bl='8' v='49'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDCA7C0' oid='8B3BB4CBDEFF4e2bB515E506A5E99CA7' temploid='{C30AA701-F925-4dc2-AF78-C293A985F514}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB319F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCE470' oid='212DF42CB97F45a0B7D87F7926F7AACD' temploid='{95F649FD-4295-4d05-8960-15572B230CE3}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($85) ControlDTCSetting (off)</TUV>
+</NAME>
+<QUAL>CDTCS_OFF</QUAL>
+<REQ oid='9AC3B0CFAB584b22B70635137D12342C' temploid='{47147EC6-704A-45ac-BB3C-BD2A8595D811}'>
+<NAME>
+<TUV xml:lang='en-US'>CDTCS-RQ</TUV>
+</NAME>
+<QUAL>CDTCS_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADDC9AB0' oid='51A921A9556B4d70BFEDE3688FDBB89E' temploid='{9EB81C6B-A92B-4528-8570-72AA804A9C93}' must='1' spec='sid' bl='8' v='133'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC9000' oid='3FFD839C117546629E76C1E7ED89BF72' temploid='35E761C085C14c1fB98E2905A52B79DD' must='1' spec='sub' bl='8' v='2' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSettingType</TUV>
+</NAME>
+<QUAL>DTCSettingType</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDCBD20' oid='3CE00DA4ADB2461b95B6A4246E80CB74' temploid='908BADB19A0C43b8BEB8E8CD7A1BAD7E' must='0' dest='data' minbl='8' mustAtRT='0'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSettingControlOptionRecord</TUV>
+</NAME>
+<QUAL>DTCSCOR_</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='DDE6B590CD384e9484D02F74B0D66AD1' temploid='{880AA16E-4987-4214-B19A-79EA38981F47}'>
+<NAME>
+<TUV xml:lang='en-US'>CDTCS-PR</TUV>
+</NAME>
+<QUAL>CDTCS_PR</QUAL>
+<CONSTCOMP id='_000001B1ADDC9720' oid='18DEE3F74D734c5fBBD06F53C5D53CAC' temploid='{2BC4F7EE-1C54-483b-BCBB-A8F1BF8638C1}' must='1' spec='sid' bl='8' v='197'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDCAC80' oid='3A50866D71EB41c4A387BBB0D58D6EA7' temploid='2C2E920AF9DF451eA0DE4C666D541B87' must='1' spec='sub' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSettingType</TUV>
+</NAME>
+<QUAL>DTCSTP</QUAL>
+</CONSTCOMP>
+</POS>
+<NEG oid='78F29D210618486492C76778EEF718BC' temploid='{8171C5E5-A360-421b-A725-FFB9E3377AEC}'>
+<NAME>
+<TUV xml:lang='en-US'>CDTCS-NR</TUV>
+</NAME>
+<QUAL>CDTCS_NR</QUAL>
+<CONSTCOMP id='_000001B1ADDCBE50' oid='EF2CCE16F9484780805B39F134F71761' temploid='{A324A333-AFF1-4556-B77F-38F4A6E943F8}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDCAEE0' oid='2D8E2DDF0E7A4ba58F97A7575F141527' temploid='{6B76FC57-9736-40f1-B3CC-AC37E1D592F0}' must='1' spec='sid' bl='8' v='133'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC9130' oid='B2CB283E25BE47ddA4C0B58E28E95E3B' temploid='{EEF361AF-FDEF-4b50-B265-76F197533AA6}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCF8B0' oid='63D3CD9401A64fefA80FF644260336AE' temploid='{E1585CEE-736D-46ec-BADE-40A04D1ABF88}' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report supported DTC</TUV>
+</NAME>
+<QUAL>RDI_RSUPDTC</QUAL>
+<REQ oid='6BD973F0E4F14055BE5511B35AB4A363' temploid='{FEC5DB82-3293-498d-9E64-CEA0DE06A1B6}'>
+<NAME>
+<TUV xml:lang='en-US'>RDTCI_RSUPDTC-RQ</TUV>
+</NAME>
+<QUAL>RDTCI_RSUPDTC_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADDCB010' oid='D56AB8BA89EE40e7BAB32A1D062F2DBC' temploid='{BF71EDED-E986-4981-8F1B-790B86FF91A0}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC8C70' oid='351CDDFAE7C043c1B3BBD37CF5F4CA89' temploid='{71A2E279-8002-4fe3-9080-0D65910D3565}' must='1' spec='sub' bl='8' v='10' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportSupportedDTC</TUV>
+</NAME>
+<QUAL>ReportSupportedDTC</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='C5E292B47A124eab8D9B355E4E30EAE5' temploid='{B9527DE7-D6F8-4ff0-9F0F-9B6A3CA30690}'>
+<NAME>
+<TUV xml:lang='en-US'>RDTCI_RSUPDTC-PR</TUV>
+</NAME>
+<QUAL>RDTCI_RSUPDTC_PR</QUAL>
+<CONSTCOMP id='_000001B1ADDC9390' oid='E6887DA6997F43f193E96591BCFEB1F4' temploid='{D57EA6DD-66F0-481a-AC58-F589B38F7989}' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC95F0' oid='95055F2F08B044af9756FEE3B6230703' temploid='{6A87CCEB-9E82-4e6a-8AFF-EEB27281B0A1}' must='1' spec='sub' bl='8' v='10'>
+<NAME>
+<TUV xml:lang='en-US'>ReportSupportedDTC</TUV>
+</NAME>
+<QUAL>ReportSupportedDTC</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADDCA690' oid='96C0FB31769B4c1e9AF01D383BF063B4' temploid='{8EC2430A-FB0E-4b2e-9F0C-C675565CC689}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCStatusAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAEA70' oid='C4B70CCB04814468B2594635DFBD7B8C' temploid='{97459D91-841E-4cd9-98EC-87CA8DC4454B}' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfDTCAndStatus</TUV>
+</NAME>
+<QUAL>ListOfDTCAndStatus</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADDCA560' oid='42CC1EF998FE49fe9DEEB9929ADC7A2E' temploid='{76D64A6A-A9AB-4177-9317-2BA6927E74BA}' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADDC9850' oid='FEC917ABD286425dB259926B3B37D88B' temploid='{FA4656A6-E388-4d55-A808-3578763D7EFA}' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>statusOfDTC</TUV>
+</NAME>
+<QUAL>statusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='2B33460AED734e22AD0FA544E544C9A2' temploid='{AEB1AB57-8991-46c7-B0F4-92120F023E41}'>
+<NAME>
+<TUV xml:lang='en-US'>RDTCI_RSUPDTC-NR</TUV>
+</NAME>
+<QUAL>RDTCI_RSUPDTC_NR</QUAL>
+<CONSTCOMP id='_000001B1ADDCA8F0' oid='D479E20831FB4c47AA6762555174FF5C' temploid='{F3AF41B2-2549-40db-9041-2356DCAEDA9A}' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC94C0' oid='A1A8289390BD4e169C5E93CF9CC41E03' temploid='{0237FA43-8A59-4db9-AEE4-52C4FFE8E57E}' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDCB140' oid='79F5AE30DCC041379A98E4E7DF1831E8' temploid='{A4C15B5D-77B0-4415-9D36-6956B23485D4}' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCE8F0' oid='7C638303EF38456fA1B6BF47406A51B7' temploid='FAB1499E2A604259B38566384B3A5C32' func='1' phys='1' mresp='0' periodicresp='1' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2A) ReadDataByPeriodicIdentifier - SendAtFastRate</TUV>
+</NAME>
+<QUAL>RDBPI_TM_SAFR</QUAL>
+<REQ oid='54C01568D4494d06A6C4A3597072BCA5' temploid='3CEC9AE748B44c33B3EBB68391291BF6'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADDCB270' oid='068F6179ECEB4f45A6B5265EC86ABBA8' temploid='5EC2796EED13452891DF6A87187C00A6' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDCB990' oid='813FC41038DE461a9A109C3201538F9F' temploid='8C0389BC73544e0dA24FBEC78FE30B00' must='1' spec='id' bl='8' v='3'>
+<NAME>
+<TUV xml:lang='en-US'>TransmissionMode</TUV>
+</NAME>
+<QUAL>TransmissionMode</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE31250' oid='B26477AA33AD49ce9BF08E138380B90C' temploid='BA4FF1448496431bB8101FF57D2B2698' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='AA04AA9FAB3246cdB6C94CC1C2B81BAF' temploid='2ED398855B09490489E7B9234B7A185E'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<STATICCOMP id='_000001B1ADE30590' oid='F82BA1105A03418a8D32CF036967DA1C' temploid='316C8A8EBCC545288C502535761E6AD8' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDC9BE0' oid='C385748CAF024801B61F7537687FCAAF' temploid='5A9684C84FB84cdd8FD1A4DA91B02AD9' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='058009B3521241b08B31081D07E2F715' temploid='765674EAC248478284B09D702EBA7E08'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADDC9D10' oid='259B32EFE2044be8B7971C21AD090126' temploid='E48DCD5984094a16BA1BD142D46FED6B' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDC9E40' oid='6DA8488A2E0F4fb28555ADEB6140C1A3' temploid='E509F83B0ECA4cf4BA28B54D9DEE0BE9' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDCA0A0' oid='3EEE223CE1D74e0cA1DF5F8D5BFFB26E' temploid='AC7372DB35644f298CE10B9EDFF153EE' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCEB30' oid='384E9637491F4ea3B3F42CFEE8DCD89E' temploid='362C9FF382FB4372AC14037343C41E0B' func='1' phys='1' mresp='0' periodicresp='1' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2A) ReadDataByPeriodicIdentifier - SendAtMediumRate</TUV>
+</NAME>
+<QUAL>RDBPI_TM_SAMR</QUAL>
+<REQ oid='D32F7BA5D00C4c4cAAE76A5B3A3079FE' temploid='6B06F1C57768440d85D5D78E9A5C4DCF'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADDCAA20' oid='AD4122CD3FF64e3eBDCFB61CE413F7AC' temploid='1A74C6CEE39E4f21BF4EF95A7121E595' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDCA300' oid='E6FB0652E3E14f84B4B23C077BDB467B' temploid='67E1647772AA464bAAB738A0E5131C40' must='1' spec='id' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>TransmissionMode</TUV>
+</NAME>
+<QUAL>TransmissionMode</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE329B0' oid='6ECABF76FBD14b5bA5F0BEB5E9DF01F0' temploid='7697C97DB1FD4fce90015F594B434513' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='FC84926FE3A34a2bBCC737A412D7C7A6' temploid='7C9D7CB1575845818F4B76055414E018'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<STATICCOMP id='_000001B1ADE33340' oid='6442E8A68C0149698A71C6C0505AF10C' temploid='98BA4C97960E44638E9F82BB69656A41' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDCA1D0' oid='688AD1E206F748e9BB6076F106858C2B' temploid='A86AF0E8E9174f24BEF2AC84044EF5E7' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='ED07A4225AF1481e82DA6CC85517560D' temploid='0B9EC11501E34a88A5DE15F9574ADAFB'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADDCBAC0' oid='6B3DBC62F525442e8C31E9CF1C97E9B4' temploid='2CB3C4306F46414bA6C1DE15B6546C9A' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDCA430' oid='2FD5BC2B55E54bf7BB0D4182C248CD58' temploid='DDC8FABD41A74ddaAECDB6B2878C732B' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADDCB4D0' oid='F3D64CFF6C1E431fA528758CF88733B9' temploid='8663BB7ABA9C4209BA44B783E385A0FD' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCED70' oid='8D14A75D1AA34fdc8D5FAB9452F54F5E' temploid='950168AC179641769230A75F73D20D4D' func='1' phys='1' mresp='0' periodicresp='1' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2A) ReadDataByPeriodicIdentifier - SendAtSlowRate</TUV>
+</NAME>
+<QUAL>RDBPI_TM_SASR</QUAL>
+<REQ oid='B14C17C138364a2684C7F039F6C87D83' temploid='150FAF1300DB4eb6B605D94796020C20'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADDCB600' oid='A45253E7E63E4c9a97FE4804EC2557F3' temploid='CCD755DBE114416e8DD112A411A289CA' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADDCBBF0' oid='1DC042921FAE49ccA3A20D4FA1E91E1E' temploid='566E30763DFD467eA0B50EE2195EA7D9' must='1' spec='id' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>TransmissionMode</TUV>
+</NAME>
+<QUAL>TransmissionMode</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33780' oid='9033DAE20DBF41f080A783BB66FBDE16' temploid='2AD9D10582AD4f5eA2206815322E78B3' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='611E6F75DB234db6B596DF503C6DD8F0' temploid='A5826DA66DD64c79AA226873BEECE757'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<STATICCOMP id='_000001B1ADE31580' oid='048E68ABF4BE4a778E31D10B0C71F393' temploid='A30787569BA44775B9CBC4814BF7CBFC' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE61D20' oid='296383C0388B45bbA80B0E37F6C79D43' temploid='78291FC0A24145c9ABCB3AB5C281A17D' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='0D9B9917CDBC4f858750C043E6D846FC' temploid='EB33F530693043ffB1A8696C45B44ADF'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE60A20' oid='C44ACD6F37EF4490AEFE52D5BF52F820' temploid='BA1647EB713B42ba87CC80CB3D84D8E1' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE62440' oid='F1F09B3FA99D42f3884BD55267D8CA7C' temploid='763A83EEAEFD400cA93540F6E5AAD02B' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE5FD10' oid='BEA150D52DFD4d9aAB0F58C5E7DB7090' temploid='F0B16F7F0F9248dc8B823EE2361EA8F6' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCEFB0' oid='60CF8A9F923845e68DE4DBBA086BC55B' temploid='4EC13B62DEB14bf29916F4190FC50C08' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2A) ReadDataByPeriodicIdentifier - StopAll</TUV>
+</NAME>
+<QUAL>RDBPI_TM_SA</QUAL>
+<REQ oid='E3BF9AC9A6F34c08A4FF1B54B4B8A54E' temploid='4E63DFACB07849e39E98CB81981E4331'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE61270' oid='2966689CE60D4967B3BB9C1B05A32A4A' temploid='ED838EB6827349eb9DFB4B790C24881D' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE61990' oid='9ACC09FB81DF4f5691C18C1E6CBC352D' temploid='8F197877C16242c5A2DCCCC22B1F598A' must='1' spec='id' bl='8' v='4'>
+<NAME>
+<TUV xml:lang='en-US'>TransmissionMode</TUV>
+</NAME>
+<QUAL>TransmissionMode</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='9294A241F3EB40b1B0AA3378F6F561A3' temploid='462D33986FBD427bAD9B7163F359B65F'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADE61E50' oid='A3041F7002C144518F7D5D212E036E3C' temploid='DE39997C45D049a88916D9179FC2EB36' must='1' spec='sid' bl='8' v='106'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+</POS>
+<NEG oid='45175722128F45efA937499889E14A87' temploid='DC3F8841B31D4030BF94F870EBF4B398'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE5EED0' oid='D1DAB83D401648c59D4517DA67AD59E0' temploid='6A9F8EF91D1144a883ED3D76BAD93DE7' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE60B50' oid='3452F1F050CA4aafB0C02650FEC8FF14' temploid='75D5AAA6C3334de28CB9D1B6BA13F571' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE61F80' oid='A74EBF6B95754167BD0DEA8D65915686' temploid='BBC8C5BF338C4cc08F7770E8B4EF82EA' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCF430' oid='0051DA13919B48968730C564E9BBC1B8' temploid='55CC02482E2B4da0B69FEBB32F369E16' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2A) ReadDataByPeriodicIdentifier - StopSending</TUV>
+</NAME>
+<QUAL>RDBPI_TM_SS</QUAL>
+<REQ oid='52B1B3A82E0D4bb8B895C6EBEEE80050' temploid='6396F5A4863247ceB33CF4CF18C48DBD'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE61AC0' oid='F85F2A46868647509262CB62FC81EFB8' temploid='A315AC02157846df9793C6888DFD23AE' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5FBE0' oid='3F67862C43D4483a9842370E13324BB9' temploid='38F2250D42994eacAE2F010CE94ACE7F' must='1' spec='id' bl='8' v='4'>
+<NAME>
+<TUV xml:lang='en-US'>TransmissionMode</TUV>
+</NAME>
+<QUAL>TransmissionMode</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE31360' oid='F6378B1F832C46888E24E621DF973562' temploid='BC9322C262504418B9BBA6F3B16204A6' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='0E39D3D2EAE84cfe886C58B38603E9B8' temploid='D143818ABD0940b1A8973A18CDAB7499'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADE5FE40' oid='91C57B237AC14280B1156F7E2436AC53' temploid='2D5B4C001C124655A45095C41590F050' must='1' spec='sid' bl='8' v='106'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+</POS>
+<NEG oid='701E28CF36914c2cA9F360B37B8F7774' temploid='1BE7AD7078EC4ce0ADD8FEAF4126FE92'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE60DB0' oid='536337B97C0F4d499FD52A5EF3FE3CCD' temploid='27631E0EF49A47b5B3E131EB6DD10494' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5F720' oid='FD7CE73389874ca0B77C1844CCB6CB74' temploid='E8899DA37ECA48c3A45A31A1654D4F5F' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE60690' oid='0DA0B071831B4459AD5E229DABEF01BB' temploid='DC614B97846E4c29B22125A315A8069B' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCF670' oid='38EED2938A384fd4B9E320E6813967CF' temploid='ABF486B24FCC44d98DA58A453BE68A05' func='0' phys='1' mresp='0' respOnPhys='1' respOnFunc='0'>
+<NAME>
+<TUV xml:lang='en-US'>($2C) DynamicallyDefineDataIdentifier - Define By Identifier (0xF2xx)</TUV>
+</NAME>
+<QUAL>DDDI_DBID_HB_F2</QUAL>
+<REQ oid='1972935766244aae9F4C9604122A1223' temploid='84DA42165EAB4ae2B16C4ED361726DC0'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE620B0' oid='2A304BA92F574759BA343159385F4ACE' temploid='63CDED69BE704002A692887A14C6A1A5' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5F390' oid='5F615603D34F483f93281BAE46D988E0' temploid='1AD3A1103A4E45679F10AA710024BBBD' must='1' spec='sub' bl='8' v='1' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>DefinitionType - Define</TUV>
+</NAME>
+<QUAL>DefinitionType_Define</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5FAB0' oid='48DDB67222F04a7aA32EAE98FFCA11B2' temploid='67584F0B8BBB45008D9DAD5F31A632D5' must='1' spec='id' bl='8' v='242'>
+<NAME>
+<TUV xml:lang='en-US'>F2</TUV>
+</NAME>
+<QUAL>F2</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE31470' oid='67A54B1D0EF04485B2E76E2263041381' temploid='B222367F2E35406d8C42BCA6CB5A544B' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>DynamicallyDefinedIdentifier</TUV>
+</NAME>
+<QUAL>DynamicallyDefinedIdentifier</QUAL>
+</STATICCOMP>
+<EOSITERCOMP id='_000001B1ADAAF870' oid='E20A7BFBB74247868BECC6EB57D49A28' temploid='BB1E5B868710448c878BF90B5547968E' must='1' minNumOfItems='1'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfParameter</TUV>
+</NAME>
+<QUAL>ListOfParameter</QUAL>
+<CONTENTCOMP id='_000001B1AD92A9E0' oid='6AAA9B4B123C4a9a93ACF5428D0FB155' temploid='50D413011DC14ba6865076AEF0E24AB4' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>Parameter</TUV>
+</NAME>
+<QUAL>Parameter</QUAL>
+<SIMPLECOMPCONT oid='73923929202C4c1dA51C1B5977A01A5E' temploid='13D87BE6E7DC4e3d8728AACCC701FF06'>
+<DATAOBJ oid='9E530D3481B64ba3B91EF99E93D39A88' temploid='6A9941C7FE8E438eA5D509AD34FF7E4E' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>SourceDID</TUV>
+</NAME>
+<QUAL>SourceDID</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='4659E2DB62594fc291EAA9A9F8834360' temploid='FBE1A8E41977420a82B92B920BD38EC2' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>PositionInSourceDID</TUV>
+</NAME>
+<QUAL>PositionInSourceDID</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='0C5EB2F97C664529B6D3C6D826B32931' temploid='459A9A86F2884477AFC80979A96739F8' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>MemorySize</TUV>
+</NAME>
+<QUAL>MemorySize</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</EOSITERCOMP>
+</REQ>
+<POS oid='D260CC12326147fcA787254B75CA0868' temploid='0091CD1E4292481b8523B55AFAF0E2B1'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADE61730' oid='583065BD9772479792B9EEDDD1935F42' temploid='AE7BD7CDBE5944919324DF5668C9E023' must='1' spec='sid' bl='8' v='108'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE61140' oid='9DD4B396E1644c0395A03FF4A2406010' temploid='E89EE05F612E47dd827074A3619B3FB1' must='1' spec='sub' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>DefinitionType - Define</TUV>
+</NAME>
+<QUAL>DefinitionType_Define</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5F260' oid='9F34A66DF6AC4f3082B120DE398AEBE4' temploid='F43D65D41CCC486f94FEF8509088A7FC' must='1' spec='id' bl='8' v='242'>
+<NAME>
+<TUV xml:lang='en-US'>F2</TUV>
+</NAME>
+<QUAL>F2</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32680' oid='FCDEF2721E18415dA255CAB35B226F9B' temploid='F8767BDB082942d388111C78FC9097B9' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>DynamicallyDefinedIdentifier</TUV>
+</NAME>
+<QUAL>DynamicallyDefinedIdentifier</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='372304CACDCD4d87AE9FA92D9D0EA11A' temploid='9C0C4B3971AC4b7c97040939C53D7B3A'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE613A0' oid='2F7858D607EC43259092B418E730FFE6' temploid='A41D718379F54a4e83B4A992E0ABF95B' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5EC70' oid='454CE60499E64c6690D1B70A9E2C38FB' temploid='900B13D7C89A4b9297F6B6953941F3A5' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE5F5F0' oid='C385535AE2C8475f99876145C9DDE11D' temploid='336F788FA28641e4A4C3A688E123BFCA' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCFAF0' oid='9F83FEBFA8714535982D0CF38499EFD6' temploid='1C5497C4F2E842b2A486AF5AE687E604' func='0' phys='1' mresp='0' respOnPhys='1' respOnFunc='0'>
+<NAME>
+<TUV xml:lang='en-US'>($2C) DynamicallyDefineDataIdentifier - Clear By Identifier (0xF2xx)</TUV>
+</NAME>
+<QUAL>DDDI_CDDDID_HB_F2</QUAL>
+<REQ oid='E2734DCCAB224c35A749DE2DE060ADFA' temploid='DBD9F575F8C746968D93E2794DA40B80'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE5F980' oid='15FC0620B5F840958C4BDAF8B71D58FF' temploid='3A347C36D71E4ba08910AE92055D726C' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE61600' oid='8E9A1A64D8604cb1B0A95BB7DE37D1E2' temploid='E4C4358C21024b9b89CED8F00AB677AF' must='1' spec='sub' bl='8' v='3' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>DefinitionType - Clear</TUV>
+</NAME>
+<QUAL>DefinitionType_Clear</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE608F0' oid='29B2CA8B9FE6430eBFBD11CB47BB8B13' temploid='85E2575584E3467580A7993B998D3EC3' must='1' spec='sub' bl='8' v='242'>
+<NAME>
+<TUV xml:lang='en-US'>F2</TUV>
+</NAME>
+<QUAL>F2</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE30D00' oid='CD08987E334D4690B646D469E398603C' temploid='CB149BBFD34F470f85A9EBDFB0C4D456' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>DynamicallyDefinedIdentifier</TUV>
+</NAME>
+<QUAL>DynamicallyDefinedIdentifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='B7BB8F278FA84290BA9CFA972D310F93' temploid='0F1BE0D341294b44891482AD8AA82648'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADE614D0' oid='088568C7A5E44c5789850A5FEDE4B2C1' temploid='4CCE91BD822847d88F0EA8DD8E5E5C5F' must='1' spec='sid' bl='8' v='108'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5F130' oid='1E65EB8D4E214c06989E0BD0D2B07A5D' temploid='DFAB8B99DE5A4bca8391C2FE3AC3C83C' must='1' spec='sub' bl='8' v='3'>
+<NAME>
+<TUV xml:lang='en-US'>DefinitionType - Clear</TUV>
+</NAME>
+<QUAL>DefinitionType_Clear</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE62900' oid='BD5FB0862F9949278DCAFB6AC5FE6F37' temploid='9631C4A7F5E64365B7DA84A4167D2E78' must='1' spec='sub' bl='8' v='242'>
+<NAME>
+<TUV xml:lang='en-US'>F2</TUV>
+</NAME>
+<QUAL>F2</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32BD0' oid='3532FB7141B248e79444B3CD5C04EE12' temploid='30579E94474A45cd9CE235CBC627BF22' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>DynamicallyDefinedIdentifier</TUV>
+</NAME>
+<QUAL>DynamicallyDefinedIdentifier</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='60F4E2372E5C478dA6D12BE588A1E1B3' temploid='15E61ED13106423aA4B56A831B43D4B5'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE5E8E0' oid='62989F4B05E742b382B04CF561829396' temploid='46F79B969B334300936BB10DA4269DB4' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE61860' oid='5C939FC1846446e7951C6EC0D82CCDE5' temploid='36EC780817004e86918E78CF5E41BC70' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE62310' oid='9FA9FAFF0CF5414eA4B43E46A45F8E75' temploid='A91A1910759444e0A2938E4F35BD665D' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCC970' oid='AD178B784D7E4dbbBFF3F9545B199AFB' temploid='3645B4444C6946d0A146BD409B87F1E3' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($22) ReadDataByIdentifier - SendOnce (0xF2xx)</TUV>
+</NAME>
+<QUAL>RDBI_F2_SendOnce</QUAL>
+<REQ oid='A29F4862D29642b083FE6D3CA9FD02E2' temploid='90432564447B45d19622DF2FB788BC1B'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE62570' oid='1239CDCABC924f6f9652A037A5C4B57A' temploid='A0CD588DF17E44dcB589FBF6749C56EA' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE626A0' oid='9B2129679D934a618094F69D6B15A723' temploid='5C9560DF34CA48579B96CFD1FCA12049' must='1' spec='id' bl='8' v='242'>
+<NAME>
+<TUV xml:lang='en-US'>F2</TUV>
+</NAME>
+<QUAL>F2</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33010' oid='A5E266783F204faaA51924E140F9BFD7' temploid='292404D13E7F488b964896884CEDE3ED' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='8056D9CB83FC42d791538D07A114AB8B' temploid='91DB6314B1AA4acbB2481B947B42E99C'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADE5E090' oid='5BF3921595834b08B3DF2E6168973FB6' temploid='21F63591DD9A452cB41EB14A831237CC' must='1' spec='sid' bl='8' v='98'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE60430' oid='DB3428D2EC94472aA1571FA56AC63178' temploid='F7DF0FF60C2A483a90E5BCCFE04AFD3D' must='1' spec='sub' bl='8' v='242'>
+<NAME>
+<TUV xml:lang='en-US'>F2</TUV>
+</NAME>
+<QUAL>F2</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE319C0' oid='39C21EA45485420f99BF2A84CBFA7DFE' temploid='946D5CAEFE5A4ce093233107E50A5AE2' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE5F000' oid='688108E939A64134A9A81E838E275F3D' temploid='D9C0AF8DD075437aBF115E6099F1B706' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='55D677102EFB497a80089856D2F1CBDC' temploid='4B1BE3C3729547eeB96ECFDA021176BF'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE61BF0' oid='6CF592BA9EDE4c4fBC429497EFBFB91F' temploid='3CCD2584886443a9BC269A620AB3E81C' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5F4C0' oid='F6F173FB6CEA4379BE163A815016D166' temploid='BB878F74A6474e3aB2164523276FAD95' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE60560' oid='7B8AD05D52374327887237B27010683B' temploid='6D4E14B1927C44adACC57A5315B9D86D' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCDB70' oid='BC323532674749ca8B485B6E200F21AC' temploid='826166856EBC456b90352E97CFE4073B' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($22) ReadDataByIdentifier - Dynamically Defined (0xF2xx)</TUV>
+</NAME>
+<QUAL>RDBI_F2</QUAL>
+<REQ oid='4A671722DF054c4f8C23E9B2CF2E0B61' temploid='A2E4EB58D15843d6A837E49DADBD64C8'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE62A30' oid='76A4652A1C5C41fdADEF84B5ED41876A' temploid='894A1D957B7940d2BA64BE1A3ECC4818' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE60EE0' oid='5AF2B2FF268E40109BEE9E2F70A8B23E' temploid='457A5448D6D04f5e8DA703916091D21E' must='1' spec='id' bl='8' v='242'>
+<NAME>
+<TUV xml:lang='en-US'>F2</TUV>
+</NAME>
+<QUAL>F2</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE31140' oid='2E369CEEBB5141fe9F754D770157A05C' temploid='58611446E7524fd0AE94F6A8023356E0' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='D35EB35D377C4558809B54E605F6C84A' temploid='C78C9C30D5ED409aADD86E89ACB1ED1C'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADE627D0' oid='FE2BF90E6B394bddBF3FBFAFF01F2678' temploid='21B4EEDF77E8497cA1B6F96BF77E4F02' must='1' spec='sid' bl='8' v='98'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5F850' oid='06BF7907D28B4d7a9D29CDBF846443CD' temploid='78E18424BB994f118391FFD636ACAD67' must='1' spec='id' bl='8' v='242'>
+<NAME>
+<TUV xml:lang='en-US'>F2</TUV>
+</NAME>
+<QUAL>F2</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32DF0' oid='360467534C4B47da8C6DC078F2009039' temploid='D848152546814017B3B2BD791081849F' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE62B60' oid='D18DF85FAB1B425bA8827A7BB17F5C5A' temploid='EF197BEFD5D549cfBDCD5B6DA6B11E51' must='1' dest='any' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='4BEA94A8FD8345679E6A9BA60EBFD04D' temploid='DE3D90CCEFB14429943A4772178920CF'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE5E1C0' oid='1E307E7509604c098ED2CF70B2CD98D6' temploid='5F996D81C2644adaA981CC2948119BD1' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5E2F0' oid='222562D2A41B49cfAA4B83E25461ADC3' temploid='6A42B887DEB24c5782491500FDD5546C' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE5FF70' oid='3230ECEDEFDB4833882AF9B8980B809B' temploid='EE238BA0EA8B4b6eAD00817F9AD9ACD8' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCDFF0' oid='E1E08AECA10C47b594577AE9A67107C4' temploid='E9FF69161CF44c09A0CFC65D04237A76' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - ReportDtcSnapshotIdentification</TUV>
+</NAME>
+<QUAL>RDTCI_RDTCSSI</QUAL>
+<REQ oid='A6BDA6AE46694368A05185B4C5CB8684' temploid='7BA40A058E2C4a1e9CDAAB21BA837908'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE5E420' oid='966EF4FE40924a72B6B4821AE8850F48' temploid='C512F72922D54a97AC2ACC7CDD21A7E4' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE600A0' oid='6B3FC5565579442787D3FD7C3B84CA1C' temploid='B3A4C4B0124E40a2B7AE136263097421' must='1' spec='sub' bl='8' v='3' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcSnapshotIdentification</TUV>
+</NAME>
+<QUAL>ReportDtcSnapshotIdentification</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='EDDCFCF877FF4fafB30B984AC7D38A77' temploid='F289501569B44ab3BA3016F027454D7E'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADE5EDA0' oid='4DD8B2DC778C4eefBCBFF9F641A4E0EB' temploid='7CEBDF7370C84586AFF9AC27C1AE4F41' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE60C80' oid='08F6B90310954afaA6D85919E081B8BF' temploid='7704698D64C540c0810955D29C2F630B' must='1' spec='sub' bl='8' v='3'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcSnapshotIdentification</TUV>
+</NAME>
+<QUAL>ReportDtcSnapshotIdentification</QUAL>
+</CONSTCOMP>
+<EOSITERCOMP id='_000001B1ADAAE470' oid='7971ABB505714177A90E3EFC5063FDAF' temploid='3FF806A9A6FF4cfe9466A4C1C8E347FF' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>DTCAndDTCSnapshotRecordNumber</TUV>
+</NAME>
+<QUAL>DTCAndDTCSnapshotRecordNumber</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADE601D0' oid='70FF9ED4C07F474580C4EBA9EDAAC90F' temploid='92DEC307E6F34195BC052A139C34FDD4' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92CC00' oid='AE523DDC043D4ece82059B0DE9203B03' temploid='FBB4A0220ABB433194DE2F8F8765949A' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordNumber</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordNumber</QUAL>
+<SIMPLECOMPCONT oid='0AAB05B16AE54c66A1C4B8F1CF8995DA' temploid='D8403AB653134955AF48B81FA2265CA3'>
+<DATAOBJ oid='9CD2CDD7ACBB44f38A25AB2965F854DC' temploid='FB39BA7D8E7D4b3291F170F0C32E040F' spec='no' dtref='_000001B1ADB65F50'>
+<NAME>
+<TUV xml:lang='en-US'>SnapshotRecordNumber</TUV>
+</NAME>
+<QUAL>SnapshotRecordNumber</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='0017F4B97EF445058C08E7D1024E945E' temploid='C136C2CC09CD4425BDD381F4A1F1E2A6'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE60300' oid='3447585145344dda84995A5A8808F1E2' temploid='9151D7506BF9466e8F62114F246F8E34' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5E680' oid='94327CC3FCA343908591D0C573950FB1' temploid='8585ECC4A77C4d2c8869644F1A647F77' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE5E7B0' oid='28AA8E163B26441882910FD13D07F4EE' temploid='B2F797E7FA8242edBB45243BD9F02C8A' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCFD30' oid='7D652E23822942a1947D917F7056BA0C' temploid='B72A111817414dc685565A03ACFFD5E6' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - ReportDtcSnapshotRecordByRecordNumber</TUV>
+</NAME>
+<QUAL>RDTCI_RDTCSSBRN</QUAL>
+<REQ oid='09E7ADBBADBE43609EAFE61A2E9EAA87' temploid='19852C800571468dBD5253FD171C5564'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE5EA10' oid='089577B9E47640fc89CF631A414FF58F' temploid='A04FE071D8B34a48A9383FE4A68AFD92' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE5EB40' oid='B80BB2A94F9A4c3d8F36ACE6241C34CF' temploid='2BA849CED812437dB29C9E82F8DBE42D' must='1' spec='sub' bl='8' v='5' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcInformationRequestServiceID</TUV>
+</NAME>
+<QUAL>ReportDtcInformationRequestServiceID</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE65030' oid='0E01DC007EB84c6cB6F09630019563C8' temploid='25897428C0BD44bdBFECD4CE7C7D4901' must='1' spec='id' bl='8' v='0'>
+<NAME>
+<TUV xml:lang='en-US'>FreezeFrameNumber</TUV>
+</NAME>
+<QUAL>FreezeFrameNumber</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='6F81E7E5FC50451b97CF9AAD0A02A287' temploid='9CFA135F788D44b69515330082968808'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADE62DC0' oid='CCE7C27E86FA40289F6398259C4A8D80' temploid='1A0EF5CCF0EC4b2cAB486530978187BE' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE64A40' oid='763D29FF3CA04659993B726E188D8620' temploid='C161476CE84D4c3a89BDF4172FE7B39D' must='1' spec='sub' bl='8' v='5'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcInformationRequestServiceID</TUV>
+</NAME>
+<QUAL>ReportDtcInformationRequestServiceID</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE64B70' oid='DCFD522EA5EA47f69ACB2B15DE4C5117' temploid='46BE36AF2E8346ed80E9AC9A8EB6BDEE' must='1' spec='id' bl='8' v='0'>
+<NAME>
+<TUV xml:lang='en-US'>FreezeFrameNumber</TUV>
+</NAME>
+<QUAL>FreezeFrameNumber</QUAL>
+</CONSTCOMP>
+<EOSITERCOMP id='_000001B1ADAB1270' oid='68CDA9B6CACB42db8EFF28251AF5EF4F' temploid='D22F35DB0E834ce7B062696FA4F959C9' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfExtendedDataRecords</TUV>
+</NAME>
+<QUAL>ListOfExtendedDataRecords</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADE65C10' oid='5F8EAF832D92498eB34E0C9629206C37' temploid='BCC4DCFFDBBC40a686EED7E7521543E2' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADE64CA0' oid='295573295B1047d4B2F5AA3B67B7DBD1' temploid='BBF0EE67B2C04aa2B067EB03E7D2990D' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDTC</TUV>
+</NAME>
+<QUAL>StatusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE63740' oid='205BB3DD5DE54bf9B7901A03CC8CFBF0' temploid='045BCF1C1F1249079D886FE6F76D7A40' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordNumberOfIDs</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordNumberOfIDs</QUAL>
+</SIMPLEPROXYCOMP>
+<MUXCOMP id='_000001B1ADE63150' oid='AFD92D34FC9246908BBDFF3610A21DDD' temploid='31A17D44765F44ea8AF28051421DB467' must='1' selref='_000001B1ADE65C10' selbm='4294967295' dest='envData' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>SnapshotRecordData</TUV>
+</NAME>
+<QUAL>SnapshotRecordData</QUAL>
+</MUXCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='4F6E79EC6B7445d7A8CC89C064A89571' temploid='716DFE0FE0D74c0a94447ED34F10EE01'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE63870' oid='F765BCC62DA047ceA6AC2A3A2C86774D' temploid='402B8B2FDF1B4b5993B86786B525A5D8' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE65290' oid='2041C792CF364f4eB2F6A2156215AD8F' temploid='5F79614150DC46b886EAF0BF326CF8A9' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE63D30' oid='6256EFBA94944e3097D5931A755C5300' temploid='2B086573A2BE4ebfB297E859AF2BCCC1' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCC070' oid='9E81F2AAD0B145ea8AE45CE22C5702A9' temploid='1999B126B5FE41b6BF4BF000BD74789F' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - ReportMostRecentConfirmedDTC</TUV>
+</NAME>
+<QUAL>RDTCI_RMRCDTC</QUAL>
+<REQ oid='FD6EFF2260944111B7C0AA3160A1B682' temploid='F05F25817AE74b51BBDFB56870D48A17'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE65E70' oid='10F49A35D4B246bfA05A53F0B98F11D5' temploid='16BB9CB48B0F49c8A6594D76AB7A4FD7' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE62EF0' oid='4D9FAF7BD8BE4a1080BC5AABBA833991' temploid='0107BDA6A52648c3BCC549BDDBDC6DC1' must='1' spec='sub' bl='8' v='14' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportMostRecentConfirmedDTC</TUV>
+</NAME>
+<QUAL>ReportMostRecentConfirmedDTC</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='89D093E47F334e9cAE4F9130881BBFCE' temploid='A2CDD6536ACF450f97C170EC3B76310E'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADE65880' oid='2CA572DF9E9C4a51A4E73381F1964C7A' temploid='A2C4255C4FA54a17BB5578BEFC9C38C8' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE65620' oid='14549B61DE6C4ec89362DA864B3F8AF5' temploid='F2973B40EE5B4531840F26AC45B3160C' must='1' spec='sub' bl='8' v='14'>
+<NAME>
+<TUV xml:lang='en-US'>ReportMostRecentConfirmedDTC</TUV>
+</NAME>
+<QUAL>ReportMostRecentConfirmedDTC</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADE639A0' oid='17A1A2DEC0EA47f89D03B70C6B94A4A3' temploid='6F80CA989E154867B6F83CEF4FB9A14B' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCStatusAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAF270' oid='A9BA8B0C66B94145AC78F35A87E0F1B9' temploid='685D68DCC78B4079807F4D49BDA061F9' must='1' minNumOfItems='0' maxNumOfItems='1'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfDTC</TUV>
+</NAME>
+<QUAL>ListOfDTC</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADE65D40' oid='8588502925C7433388E7574C5BEA0610' temploid='570A27BCD8724eed8514334601557653' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADE646B0' oid='4883FED063AC48ea8D91AF85B3454BDF' temploid='43C60982D26A4e719626DDFD02436936' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>statusOfDTC</TUV>
+</NAME>
+<QUAL>statusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='516B4A4889C042e89D7735AEA30ABE7C' temploid='3F7C328E23CB4e9eAEBC18C6DD30D7A0'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE634E0' oid='09C2972DCC8D46d9897B5EBF568F6E8D' temploid='4B96BAB837D245c8942DD91E2BD31126' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE63280' oid='C4272BA3B7EA446aAC294134C512A7A0' temploid='F11FFFD2AAF046ba82A5A5305E49EA47' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE63AD0' oid='2FA31C67BF004a9fA0F69653F74CF202' temploid='75D957A37D9D46378DF1110A1689C4A2' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCC4F0' oid='C423B902809846e98326434B66962FF8' temploid='CC2D432447BE451a9A0EE5D68E15C23B' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - ReportFirstConfirmedDTC</TUV>
+</NAME>
+<QUAL>RDTCI_RFCDTC</QUAL>
+<REQ oid='C3D85A0AF3FC4e75AFF4957C22B09BDF' temploid='59EBDC0F9CE04bb28E290E36BAD13AF6'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE63020' oid='325F96C41BF242d1978A1D68CF9A9A5C' temploid='65A92E0AAA23454dBB68CAC137001FC9' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE641F0' oid='97A4FCBE3738485aA1C9D0C9AD59A411' temploid='98F2CBB9DBF54e9d84AF25D637FAE46E' must='1' spec='sub' bl='8' v='12' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportFirstConfirmedDTC</TUV>
+</NAME>
+<QUAL>ReportFirstConfirmedDTC</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='9993954D53844b308C1A2CA73CF4476D' temploid='29C2D20B03AC478e9D3BB8BBE341462D'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADE64DD0' oid='C8AEE32173D54b45AEDF134DFD7BBF6F' temploid='A40627DB7CD64471BE79C1FEB9CF5AF9' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE64580' oid='6DAEF001779E4ee68E944D57AD8DBBBC' temploid='72EE35016EA346499C6FD2F817C713E0' must='1' spec='sub' bl='8' v='12'>
+<NAME>
+<TUV xml:lang='en-US'>ReportFirstConfirmedDTC</TUV>
+</NAME>
+<QUAL>ReportFirstConfirmedDTC</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADE62C90' oid='B86D817A4CE14cc98BF3E5C7CBB3919E' temploid='86C6340E0D6E4e739423D81FF74F50A0' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCStatusAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAEB70' oid='F1341E84540B4543A689C664532BD62A' temploid='00E5EA981B474b7a814EC4DBE0CCF2D9' must='1' minNumOfItems='0' maxNumOfItems='1'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfDTC</TUV>
+</NAME>
+<QUAL>ListOfDTC</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADE65160' oid='03CE6338A3684bdcBCB1551EEEDD54AE' temploid='F13679FE4B2D4b23BE614809E696B83A' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADE633B0' oid='E208C6B19EAE4133A16634C63119231E' temploid='B8484D5A840143e09B72F9D269F675C1' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>statusOfDTC</TUV>
+</NAME>
+<QUAL>statusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='69BD8E39E0964712970D5D33C3D1E2E1' temploid='C165D719C8CE46798C2302583315CCE7'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE63610' oid='AC198EA667624e9182B0C486094AE69F' temploid='A108EA99233941c3A8F35EF8F2A3A92C' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE63C00' oid='58DA557B83684726965D69BAD9FA8E05' temploid='987926F06E8B4be28BD21CE92740E3D1' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE63E60' oid='6F740920C3924a8bB3D3D2E8671567CF' temploid='0C7BE826EFE245fd90B7EA21BE728632' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCD030' oid='939DCBAD3773441dB0087766C2619DD9' temploid='F7BAF36D1D0047c7A46B47AC492C3EE1' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($85) ControlDTCSetting (on)</TUV>
+</NAME>
+<QUAL>CDTCS_ON</QUAL>
+<REQ oid='AFAB49FA6E6C4f0a874C7FE7C9BDB4C5' temploid='E303F540EAD6474c87AA4CE51C334D08'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE63F90' oid='28156A834DA34231BFE0B0AFDA80445E' temploid='7935FD20E57C452bBCFC9541557C14BC' must='1' spec='sid' bl='8' v='133'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE640C0' oid='1F45B32121274fbe8B5A850E9FB1E81E' temploid='2F10804CFA2A470aB29108987E96F5B8' must='1' spec='sub' bl='8' v='1' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSettingType</TUV>
+</NAME>
+<QUAL>DTCSettingType</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE659B0' oid='502733BE9E4C443396608014DD215724' temploid='29AB244DC54343fcB572385F9BB30785' must='0' dest='data' minbl='8' mustAtRT='0'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSettingControlOptionRecord</TUV>
+</NAME>
+<QUAL>DTCSCOR_</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='8DC0983A3EE3460c9BF2009ECB8FC9AD' temploid='51C68FCA86C0411f80C075B43C56B3B2'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADE64F00' oid='058299304ED4486eAD3476B85456DCD0' temploid='FF594FC8FF914662804FEA8D6B1E98FA' must='1' spec='sid' bl='8' v='197'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE64320' oid='B0857E88CDA94bb980CC018F58A47741' temploid='8B9DBBFD3D0940b1AFFFBE7FBA1C4AC3' must='1' spec='sub' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSettingType</TUV>
+</NAME>
+<QUAL>DTCSTP</QUAL>
+</CONSTCOMP>
+</POS>
+<NEG oid='6486DDA4179D4ffbABA089E0F3E6504B' temploid='8EAF0735CDE94c0eA1A1E66A68CC6B2F'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADE64450' oid='C15E474F9D9D46749A0DF65D28AB28BD' temploid='93A5DB7A48E448109B41B737540AD5B2' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE653C0' oid='2BE8DEF92E2F4036BDF7D006E0C2E8F0' temploid='BF736D9340DE43448921D1ECFEA27684' must='1' spec='sid' bl='8' v='133'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADE647E0' oid='4E5122ACC0784984BF9834DEE8F106CC' temploid='09F959C84ABF4902BA0C2F9B30401A09' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCE230' oid='E50F0CBDF6084b399A9D7A29FF9F7E81' temploid='8C1FB6601A0A4ba6A163B750CCD9ACEA' func='0' phys='1' mresp='0' respOnPhys='1' respOnFunc='0'>
+<NAME>
+<TUV xml:lang='en-US'>($2C) DynamicallyDefineDataIdentifier - Define By Address (0xF2xx)</TUV>
+</NAME>
+<QUAL>DDDI_DBMA_HB_F2</QUAL>
+<REQ oid='446A0E4C97B240efA1AE251A02E73375' temploid='A708D12F3ADB4755B1E887839A94380D'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADE654F0' oid='759D32F4A94742f181D6E892B518810E' temploid='152D8E139483454eA16F82AD82ED0BDB' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE65750' oid='1AD339BF7856451f835164A8E5B33FA4' temploid='D557A736D42143ac8F69FF6A0F695F44' must='1' spec='sub' bl='8' v='2' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>Definition Type - By Address</TUV>
+</NAME>
+<QUAL>Definition_Type_By_Address</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADE65AE0' oid='FCC8F62F8D454380AB98BDCF98F61A4F' temploid='2D701629625049cc866E477473C4ACCA' must='1' spec='id' bl='8' v='242'>
+<NAME>
+<TUV xml:lang='en-US'>F2</TUV>
+</NAME>
+<QUAL>F2</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE31690' oid='971F3E39C1AD45a781C59818AC99B9AA' temploid='EAD2097DEEBA4e7aA4C6B5C7885AAC55' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>DynamicallyDefinedIdentifier</TUV>
+</NAME>
+<QUAL>DynamicallyDefinedIdentifier</QUAL>
+</STATICCOMP>
+<CONTENTCOMP id='_000001B1AD92AAC0' oid='C2830855B36B40f39361F7BEFF399CAB' temploid='08D1987B6AD146cd9DB0647B081B23E4' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>ALFID</TUV>
+</NAME>
+<QUAL>ALFID</QUAL>
+<SIMPLECOMPCONT oid='DC2AD0F35602435a9C13DD831B6FA0E1' temploid='29FC7145E85A4b06AA0EC52EB031C6AD'>
+<DATAOBJ oid='A056C1555570434494E8B49063B947B7' temploid='5265A638C383470b8B983393CF164C6B' spec='no' def='36' dtref='_000001B1ADB64B20'>
+<NAME>
+<TUV xml:lang='en-US'>ALFID</TUV>
+</NAME>
+<QUAL>ALFID</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<EOSITERCOMP id='_000001B1ADAB0C70' oid='93CEDEDC82C44cec84C38EB0A4B2CD3F' temploid='19E59413679B4909B1A80E3D21D0F289' must='1' minNumOfItems='1'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfParameters</TUV>
+</NAME>
+<QUAL>ListOfParameters</QUAL>
+<MUXCOMP id='_000001B1ADEAADB0' oid='1CB00DCBF24E455bB9478572067FC59F' temploid='BE45969FAAF5467b98BE4BD038BBDBAC' must='1' selref='_000001B1AD92AAC0' selbm='4294967295' dest='envData' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>MemoryAddressAndSize</TUV>
+</NAME>
+<QUAL>MemoryAddressAndSize</QUAL>
+</MUXCOMP>
+</EOSITERCOMP>
+</REQ>
+<POS oid='8FE438FB578545b3BCE5397E47EFC977' temploid='8A7EA2F085AF412091DE76E9DAF49A33'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEAF290' oid='A1473FEEEFDF43c08FCDE05AEB480577' temploid='0D93FD6A2ABC4db684EFDECC55440902' must='1' spec='sid' bl='8' v='108'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAE580' oid='1ECDDEDF226B47ea82E99844389D339B' temploid='68D787C18ED84ebfA7CC8AB38F498206' must='1' spec='sub' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>Definition Type- DefineByAddress</TUV>
+</NAME>
+<QUAL>Definition_Type_DefineByAddress</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAF4F0' oid='7BBBD8DF51CD42b1A8EB9834DC78C634' temploid='704BCC0249934fabA85E47EF6F797A31' must='1' spec='id' bl='8' v='242'>
+<NAME>
+<TUV xml:lang='en-US'>F2</TUV>
+</NAME>
+<QUAL>F2</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33BC0' oid='D8AC7561925643e6B1606E2FAFD95DEE' temploid='3673E9D28C9F4ce39EC5B075EC3B400D' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>DynamicallyDefinedIdentifier</TUV>
+</NAME>
+<QUAL>DynamicallyDefinedIdentifier</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='48B2E893E9B2442cA201BB8F292071B3' temploid='CB4584417B474168A0BF138BAD0CEB84'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEAC0B0' oid='1CAF9BB215614ca99DA1B96F257DE53C' temploid='17C7700459D94e3f97C377C822439E51' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAF620' oid='EC30C2AB909D47aa884715F69E721B28' temploid='BEE95D65E33946a78AD142B64FD4203D' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEAE1F0' oid='C8E42E81257347cf91B3F73569E1ECCC' temploid='53B2EF6C65F841fb980065AC7A25060A' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCD270' oid='B395D9C649824c3395831C514B1C6355' temploid='D148D6944933498c952B3E04A00ED589' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($22) ReadDataByIdentifier - Dynamically Defined (0xF3xx)</TUV>
+</NAME>
+<QUAL>RDBI_F3</QUAL>
+<REQ oid='B774202EB0D54ef187E6C3FDA4FC44F1' temploid='53C27E1C8C0D4c99BE395136872D761B'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEAC570' oid='948764CD8F86484f94011C273FBC8D2F' temploid='6D6DBB886FCC46ab8D62CC14BF3DED50' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAF160' oid='92D02886FE4F472b9230A45CD31BAFC0' temploid='D1AE0BD58FA348579E6C1F0EFE0CD792' must='1' spec='id' bl='8' v='243'>
+<NAME>
+<TUV xml:lang='en-US'>F3</TUV>
+</NAME>
+<QUAL>F3</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE317A0' oid='9577152EEE1A453eA42FEA274F252049' temploid='C9E1C0BDBC77460289C3FDBCDBE49908' must='1' spec='lid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='E54602D6276E4e1c83C0F6C4833E9C97' temploid='3E0446DEA4224c4aAC8C6328FC580F8D'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEAD870' oid='D665AF6C9C9B4c32828150ED3D4F5139' temploid='49FE3D54D64549929AF708B4E013DCB2' must='1' spec='sid' bl='8' v='98'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEABBF0' oid='6FF79D74ACED4da6A6ABB7750A6B1957' temploid='C9FA34249A27477a97C16F4F24ED0970' must='1' spec='id' bl='8' v='243'>
+<NAME>
+<TUV xml:lang='en-US'>F3</TUV>
+</NAME>
+<QUAL>F3</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE31030' oid='5133022DD48B4dbcB568926BBF82B4F9' temploid='3C219D21E0514853899D808DCFF7ACF6' must='1' spec='lid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEAD9A0' oid='F87D81CB1E524ce48E23482E5C6871A7' temploid='24098B44C8DF42d5B4055BF52355462F' must='1' dest='any' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='A1D433FEF2684e9d8C728B94E5F15FF8' temploid='BD754ED7189C4905ACF6E9B1FFE551C7'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEAAEE0' oid='6DCDBC37C582472aB96E9E8929093B88' temploid='E0AD67A5BC8546c0A61E4DAB807345AA' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEADF90' oid='65B07D07E45A4692BD1EB181F1D0DC5E' temploid='F4C9811F6ABE46feA0B0F0FE394FC563' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEAB3A0' oid='E5AA19FE12FB4d0d9541917A40CF31EE' temploid='A3C399A0AFF34d449755BE97AE028A75' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCD4B0' oid='40F49050B80740e792F2B7C439843320' temploid='17422AC8AD8448c28824C69D502604BA' func='0' phys='1' mresp='0' respOnPhys='1' respOnFunc='0'>
+<NAME>
+<TUV xml:lang='en-US'>($2C) DynamicallyDefineDataIdentifier - Clear By Identifier (0xF3xx)</TUV>
+</NAME>
+<QUAL>DDDI_CDDDID_HB_F3</QUAL>
+<REQ oid='76800988DE8849fbBAC317FC15B18A5E' temploid='C01C284BBD4A4fb4BA77592F4080F66E'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEAE6B0' oid='EC43EA5F85E941a6B415F99C61AAFEEE' temploid='EFAD4DEF90C4418a97E64BA9EA35D45C' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAB010' oid='0568D5D79CBB4e92AD2826C261BEE4A6' temploid='0965E25292CB4140B2B05436C82C4F97' must='1' spec='sub' bl='8' v='3' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>DefinitionType - Clear</TUV>
+</NAME>
+<QUAL>DefinitionType_Clear</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAC440' oid='1021102D3B494288831A2EEA93E15653' temploid='E4158C61486B450b88A931A86906FDE4' must='1' spec='id' bl='8' v='243'>
+<NAME>
+<TUV xml:lang='en-US'>F3</TUV>
+</NAME>
+<QUAL>F3</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32AC0' oid='0FB2F3136D994b08A5C7A332D0D58217' temploid='AA8ACA81146046bdAA8CC8618F04FEB5' must='1' spec='lid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='3CE37069790842f9A31EF4A0E1E26C00' temploid='4FC31D0BC8C54652BCCC60C06C878300'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEAD020' oid='9901C7D5CCBC4be1829B726332E79F97' temploid='721EFFF2095B451e9A251347035B82AE' must='1' spec='sid' bl='8' v='108'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAB860' oid='F40AEF0D803F40caAC61C798264672B1' temploid='3B10A680A18C4bcd93AC97153B8ADCF2' must='1' spec='sub' bl='8' v='3'>
+<NAME>
+<TUV xml:lang='en-US'>DefinitionType - Clear</TUV>
+</NAME>
+<QUAL>DefinitionType_Clear</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEADAD0' oid='560CB91367A74faa9EB14265D17C181A' temploid='6D8CF0CF8C714b0e8CC66EFD9633B115' must='1' spec='id' bl='8' v='243'>
+<NAME>
+<TUV xml:lang='en-US'>F3</TUV>
+</NAME>
+<QUAL>F3</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE31BE0' oid='663D65EA866E48ee8FD20CA1BDBA90D4' temploid='0B510CD5EF47457485817F33AB64E7E0' must='1' spec='lid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='60F9E5DAAD224435BF5289EE4B2F0925' temploid='C6DA4C6630924f76B571EAFAD07CE635'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEAC6A0' oid='1E9E75B9F8B149fcA0CB3E1FDD1C49E0' temploid='7CC95D40AAA342aaB3015321D798CED4' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAECA0' oid='49A82D1091EA412d8C2C839C7FA250BE' temploid='70C3CAD8B7DC4c82A1FAB6ACBC453CEE' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEADC00' oid='A89EE2B2CFF7463bAEF1332CD5178D38' temploid='C90A47210D39498fBD30080F87A7773D' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCD6F0' oid='B227CFB0383340c38949EA53C276E504' temploid='2F83C22E665D4c1dA5FC7A726D5B5652' func='0' phys='1' mresp='0' respOnPhys='1' respOnFunc='0'>
+<NAME>
+<TUV xml:lang='en-US'>($2C) DynamicallyDefineDataIdentifier - Define By Address (0xF3xx)</TUV>
+</NAME>
+<QUAL>DDDI_DBMA_HB_F3</QUAL>
+<REQ oid='8F31BB7A493F407b9EFA29EF6E9EAA38' temploid='C1F4735700304616BFFCECCBB6DB4D06'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEAB730' oid='7689B0864D2743ffA9340C26BF89A831' temploid='697A26BE85AE4c72882A6E8159469CFE' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAAC80' oid='0446AC004D6140499579AD28EBA55E66' temploid='7FC18C81E9874ce98E145823DB26A966' must='1' spec='sub' bl='8' v='2' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>Definition Type - By Address</TUV>
+</NAME>
+<QUAL>Definition_Type_By_Address</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEABF80' oid='4066BD13DF8147a4B6E6884CC755CEF0' temploid='A98153E84EAE42ebA4612F7800656B65' must='1' spec='id' bl='8' v='243'>
+<NAME>
+<TUV xml:lang='en-US'>F3</TUV>
+</NAME>
+<QUAL>F3</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE31F10' oid='2DDA70537CB04669A0AD6C6DA178123F' temploid='9162DFB9183B43e2A587DF9E4EDEAFF6' must='1' spec='lid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+<CONTENTCOMP id='_000001B1AD92CCE0' oid='E188CE00C0614dccBA2DEB4897680896' temploid='480F9B18CA5143c7B9EFAF0E04454371' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>ALFID</TUV>
+</NAME>
+<QUAL>ALFID</QUAL>
+<SIMPLECOMPCONT oid='F8A0AD4FFC724d128E55498F739A8C16' temploid='A55FB8B9C90A4fac82CCF18253B63FCF'>
+<DATAOBJ oid='6E2B34668B58462582957F364934044C' temploid='2D10110D022840fa832A56B94960AC46' spec='no' def='36' dtref='_000001B1ADB64B20'>
+<NAME>
+<TUV xml:lang='en-US'>ALFID</TUV>
+</NAME>
+<QUAL>ALFID</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<EOSITERCOMP id='_000001B1ADAAD570' oid='91CF2320994E4f3eB4A81D55A57A224B' temploid='6747EA9DA8AF4490B18DD871D4D2712E' must='1' minNumOfItems='1'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfParameters</TUV>
+</NAME>
+<QUAL>ListOfParameters</QUAL>
+<MUXCOMP id='_000001B1ADEAB4D0' oid='A5EFED8A43714d68AF46166F512881DE' temploid='634EC10CFE0C4c85BFC09CDBFB74D603' must='1' selref='_000001B1AD92CCE0' selbm='4294967295' dest='envData' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>MemoryAddressAndSize</TUV>
+</NAME>
+<QUAL>MemoryAddressAndSize</QUAL>
+</MUXCOMP>
+</EOSITERCOMP>
+</REQ>
+<POS oid='7B9F928FB5144519AD8A046B9B9C97D2' temploid='7BDD527CE57E4aac9E490C00E3BC5802'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEAD740' oid='E2388E9891A642e8A6EFBCB787E4FC58' temploid='CD1CF17F91AB45799917FAD0045DB6B3' must='1' spec='sid' bl='8' v='108'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEABD20' oid='5C0365B799A64964878D4D30947D43E9' temploid='4188B0CE8F0E4f2eB893068ABB77EC0B' must='1' spec='sub' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>Definition Type - By Address</TUV>
+</NAME>
+<QUAL>_2C_DynamicallyDefineDataIdentifier_Define_By_Address_0xF2xx</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAC1E0' oid='655173CF48EE4eb9A6E62EF6508CE747' temploid='8DBD78C5041D4dac8A59A8CF379F79B1' must='1' spec='id' bl='8' v='243'>
+<NAME>
+<TUV xml:lang='en-US'>F3</TUV>
+</NAME>
+<QUAL>F3</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE309D0' oid='7226361D418D478f9E45C5CF1A56A9C1' temploid='20C91A3ABBFF40179AE7F02B2813D213' must='1' spec='lid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='DC58C5F45D434991BAAFF86EE806EAF6' temploid='7FDE3C4C182347f1A3D814D1E2392DC4'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEAEB70' oid='C6E00E6025324224BDE699C8C5486850' temploid='1DACE903AF1043f0BCBCD27E4CDDB52C' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAB270' oid='22E9ECF190A945afB82502B3665C4227' temploid='5A0664C1A24E4eb38C3DB6401FD8A57B' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEACDC0' oid='4F4C46352A424ae585A97699BF64197A' temploid='8A419FA04E574dd7AD21816D2D38EB6E' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADDCD930' oid='C8DD72F922AB48f3A2A56C854A899A61' temploid='26D4FFF3D8244b81AA0515AC67456BCA' func='0' phys='1' mresp='0' respOnPhys='1' respOnFunc='0'>
+<NAME>
+<TUV xml:lang='en-US'>($2C) DynamicallyDefineDataIdentifier - Define By Identifier (0xF3xx)</TUV>
+</NAME>
+<QUAL>DDDI_DBID_HB_F3</QUAL>
+<REQ oid='CF19C6A7FC834da7A75BFF87920B09DD' temploid='741CB24982E74e34946CD4C1AE25845E'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEAB990' oid='3AF596FE6597492fB98572BF796E4B8B' temploid='A3F3EE9FA69F478d8D844DE37CE3C878' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEADD30' oid='28CF34DAF9F045749F057E9FDAB605E8' temploid='B83D9028E8814bc1B7BA21092B0BF460' must='1' spec='sub' bl='8' v='1' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>DefinitionType - Define</TUV>
+</NAME>
+<QUAL>DefinitionType_Define</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAF750' oid='60D9589155AE417b9FE0475A572C6C63' temploid='11AC0491AA664ae9872997B02B4F57F7' must='1' spec='id' bl='8' v='243'>
+<NAME>
+<TUV xml:lang='en-US'>F3</TUV>
+</NAME>
+<QUAL>F3</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE30480' oid='3FB7E10BAB88425493DBC8A5F8CB5855' temploid='CF13CA14367A410280A12EFC20A4FCAD' must='1' spec='lid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+<EOSITERCOMP id='_000001B1ADAB0570' oid='957B2C085F174628A2E7E66F42809430' temploid='93CEBAD8E5694389A0FF97CC863AB054' must='1' minNumOfItems='1'>
+<NAME>
+<TUV xml:lang='en-US'>listOfParameters</TUV>
+</NAME>
+<QUAL>listOfParameters</QUAL>
+<CONTENTCOMP id='_000001B1AD92AC80' oid='5668C6DD74FC4bbeB2F7AB4536ABFC27' temploid='ABF8B2F3E97845b2A6532586EF3437DE' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>Parameter</TUV>
+</NAME>
+<QUAL>Parameter</QUAL>
+<SIMPLECOMPCONT oid='6D5A4F42E7BA4c9b8F21EDF7E0C64540' temploid='DD34CA7FE8E247a0ABA77E3DBF061F71'>
+<DATAOBJ oid='954274F2DE924db28F01F1C68EC5D1AD' temploid='C0A262F54C16451a8B226D762ABB1C6F' spec='no' dtref='_000001B1AD958EA0'>
+<NAME>
+<TUV xml:lang='en-US'>SourceDID</TUV>
+</NAME>
+<QUAL>SourceDID</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='F4A74A4E9F7940d28B5CDED3FEB84457' temploid='58AC789DDDDC48cf97229508C9C8028A' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>PositionInSourceDID</TUV>
+</NAME>
+<QUAL>PositionInSourceDID</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='9345030A2D194ca591DB1F95EB2C9D22' temploid='67D0B126F23C4b178F57E903ED0F5E66' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>MemorySize</TUV>
+</NAME>
+<QUAL>MemorySize</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</EOSITERCOMP>
+</REQ>
+<POS oid='F414030146D24ad59CCCF0F910BC3983' temploid='5765524C88874de2B1C242428A6EAF35'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEABAC0' oid='4EA9F3399CA34e7b97C66D34A5C3B9C3' temploid='A6CAF45626E74b3c8CB3E8E5C6A106F3' must='1' spec='sid' bl='8' v='108'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEABE50' oid='A9E216E5C9BF4cb790DB4F9C55DEE2F8' temploid='BE8EEEC271374761BB2739117353C907' must='1' spec='sub' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>DefinitionType - Define</TUV>
+</NAME>
+<QUAL>DefinitionType_Define</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAEDD0' oid='1DC6C9510F584388A9D4164CBC8FC68A' temploid='F363948AFBB7486aA17C61D63CED65C5' must='1' spec='id' bl='8' v='243'>
+<NAME>
+<TUV xml:lang='en-US'>F3</TUV>
+</NAME>
+<QUAL>F3</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE31CF0' oid='6D4FB87F483046d6B7DD9B60E8F28096' temploid='7D75A61979924a94948E6EA406E22BE4' must='1' spec='lid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='A623DB9DD6514f4aB7DB7DBCB48ED43D' temploid='3DF6BC342AEF4ff5BBC579533FFD575F'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEAE7E0' oid='CC12140332A948cf957B24778BB87D89' temploid='FB00425D7B1841a69BDF867E46B15D7A' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAC900' oid='63EFA6AE373A4be8892D18D8E9526320' temploid='1D380D7761C644029C76AACE20DE3CBE' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEAC7D0' oid='BE8433CB58E64c90AC597F8C1B902B72' temploid='D10ED3C6C3A5424886CD857E7664D99B' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF16260' oid='13195DEEEAEB4a849F347A4D517DEDC9' temploid='A24479DD498940f58E19D6890B3CA4E0' func='0' phys='1' mresp='0' respOnPhys='1' respOnFunc='0'>
+<NAME>
+<TUV xml:lang='en-US'>($2C) DynamicallyDefineDataIdentifier - ClearAll</TUV>
+</NAME>
+<QUAL>DDDI_CDDDID</QUAL>
+<REQ oid='2EA3E23990C04c5897610164B1844341' temploid='B3C171FAD6BB43199AFF8FDA338BB44D'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEAEF00' oid='167DA588A111492d8E5FBB9DF2D05D89' temploid='CE5D8CAF487346a88043C1EB239587C8' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEACA30' oid='5051C091DB0042058F7BE35AAA9C6961' temploid='CACE7166050C4d8fA87A8DB163B2FCC5' must='1' spec='sub' bl='8' v='3' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>DefinitionType - ClearAll</TUV>
+</NAME>
+<QUAL>DefinitionType_ClearAll</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='E76CE82EC27B45e28BD86EF220C71E2B' temploid='4AA374594B8349fe8D9CB66F1E28973A'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEACB60' oid='98ECF5124EBD413bA501C6579BF56F00' temploid='E47715D22766468cA984FED7C47E03BB' must='1' spec='sid' bl='8' v='108'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAE0C0' oid='EAA5E14E9A8146d986864C3FA9A0E07E' temploid='59A4FC5CEB5C4cb5B82A69F89C6A867E' must='1' spec='sub' bl='8' v='3'>
+<NAME>
+<TUV xml:lang='en-US'>DefinitionType - ClearAll</TUV>
+</NAME>
+<QUAL>DefinitionType_ClearAll</QUAL>
+</CONSTCOMP>
+</POS>
+<NEG oid='1D9428B897984e18AB1AE12745F6D2BF' temploid='D4C7FB340B1C4155B200F9449E373ABB'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEACC90' oid='AC53A8B6C1EF47b2A886A2DA63A16386' temploid='AD3C3C6E04B94de887CBEDBAB89183DC' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEACEF0' oid='D861E08ABBC54eea9DD4A400893BD081' temploid='CEAF6E79B02D4b608C7C3C36491A2757' must='1' spec='sid' bl='8' v='44'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEAD4E0' oid='C6A695B43D2B4b4f8345CD65C24CEAC6' temploid='0070CC54188D45ab98082EB00E626046' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF17D60' oid='CB1D54BA64564805892C0D6C2FED9248' temploid='E9BA8818DB7D439dBF32D36A1E7A0B58' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - ReportDTCFaultDetectionCounter</TUV>
+</NAME>
+<QUAL>RDTCI_RDTCFDC</QUAL>
+<REQ oid='21E189EC821A408eBB9798F95ECED71C' temploid='750CA15772A8447f99BAC044A5A84F3B'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEAD610' oid='7956B3DA360C4ffcAD6DD5571AF9B811' temploid='2F6F719E03744ddaBF192B37C22F30F9' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAEA40' oid='BBEADB5A5F204042A217B64201479987' temploid='62CDA15B906D4b45BE8AFA3F0A02D47F' must='1' spec='sub' bl='8' v='20' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>reportDTCFaultDetectionCounter</TUV>
+</NAME>
+<QUAL>reportDTCFaultDetectionCounter</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='28E7BE67727941d0961625D149AFAB41' temploid='55AC12C5A3A24321B9B01B3F1DDB3A64'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEAE320' oid='9C4D2747B5A844a0A74292B9041E3ADA' temploid='8B6E786FF8EF486f969665B55BA7E75D' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAD3B0' oid='82CEE055D0DA40be9FB896E1B3BD83AF' temploid='8F4A077478A9497cB5E385F97D402A29' must='1' spec='sub' bl='8' v='20'>
+<NAME>
+<TUV xml:lang='en-US'>reportDTCFaultDetectionCounter</TUV>
+</NAME>
+<QUAL>reportDTCFaultDetectionCounter</QUAL>
+</CONSTCOMP>
+<EOSITERCOMP id='_000001B1ADAAEC70' oid='185364F8D62E4150B188D25F772FAC21' temploid='56EC0604C1E645578E5DED28E2D9E70F' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFaultDetectionCounterRecord</TUV>
+</NAME>
+<QUAL>DTCFaultDetectionCounterRecord</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADEAD150' oid='5956F6BC04CE4ebf8A2C98DC509246F3' temploid='FC16C3E6EE7545c29335EEBD8EDD75CA' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92AD60' oid='E46B33A94CCC4bedB6EFB0E2D5A89B93' temploid='72D518188A2C447cB302E335616783DB' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFaultDetectionCounter</TUV>
+</NAME>
+<QUAL>DTCFaultDetectionCounter</QUAL>
+<SIMPLECOMPCONT oid='962C9B7D0B9145ef85FC7395E9D2F480' temploid='73EF869DCF7D4812ACA940BC614D0869'>
+<DATAOBJ oid='F046BE59E519420d99C43E6B3BCA46E1' temploid='2404751F5D6E4d9e8C200859E862BCBA' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFaultDetectionCounter</TUV>
+</NAME>
+<QUAL>DTCFaultDetectionCounter</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='AAF10CD8DF3C4ca8B3EDB30872D8D607' temploid='B60E28B3502A4b8a9D6685043011B7CB'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEAD280' oid='5D910789B9FD4502A2FBA8524F7A4489' temploid='DC5B86217B134ebfAB8D34B5200D30EA' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAF030' oid='AF1AF6CB25964d04A5697557DC95BAE4' temploid='D7111182F6FC4a6f8167A73486BCCF04' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEAE450' oid='69A639562A914ee4B0C4FA917ED17F97' temploid='4192CD22F8F5422f9A5E7A57975DA598' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF166E0' oid='BE32858663D64b1dBC23B5FCE68578DA' temploid='63EBD29F04764c54BB092B2B03F9F6C2' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - ReportMostRecentTestFailedDTC</TUV>
+</NAME>
+<QUAL>RDTCI_RMRTFDTC</QUAL>
+<REQ oid='0944263FD0264475996167ACBC594922' temploid='3B125F697F454d3aAC2AB6D70085A315'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEAF3C0' oid='4458C3BCC7B346d09738D1F49CCA37FD' temploid='91BFBE07968A413a8FD8057CA309A0FB' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB2DF0' oid='D274538A95984150B89F6565C8D516FE' temploid='9CC5A8E394A94876B7252CFE90F5BF55' must='1' spec='sub' bl='8' v='13' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction</TUV>
+</NAME>
+<QUAL>Subfunction</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='0322D4E33A6F4d03BE5CD034F5B0DDD9' temploid='A905E15ACD6C41d0B567BA3FB062FD2F'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEAFC10' oid='5F58EB36F6BE455590791ED7A05ACCF5' temploid='580E515340334e16A3ECBF839399D90D' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB3D60' oid='1685A953ED3D4db69C3D7555EC9861F1' temploid='93D7B1F0B74947b49E48082E7CFF17A3' must='1' spec='sub' bl='8' v='13'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction</TUV>
+</NAME>
+<QUAL>Subfunction</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADEB0330' oid='C2E7A818AE374abaB1F0D75A97B4A8E0' temploid='13352AD557F149e8BF6F0701BA7F876D' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAED70' oid='5611A619077846aeBC808005F5C44D96' temploid='B2EE0B6DF3C347f692A4CADF53593544' must='1' minNumOfItems='0' maxNumOfItems='1'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfDTCAndStatusRecord</TUV>
+</NAME>
+<QUAL>ListOfDTCAndStatusRecord</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADEB2F20' oid='1F22280BCEFE4ea99895B6F4720B5714' temploid='30C5C7B356904f8f8BCD01BE7A6879B9' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADEB3510' oid='E9784D5F084B4ca3A504075D85866FF0' temploid='E7514786D94242b694CE6DDC2F4EBF2E' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDTC</TUV>
+</NAME>
+<QUAL>StatusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='6BBAC555C155423bB1127F95DD3EE533' temploid='96ED9C017AB748ac8420A3B5A53226AC'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEB12A0' oid='E867DF9D312046da905EAF6A05ACD885' temploid='36945E6B5E8C4867B1EE31CEB789A131' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB0DE0' oid='4D658D1CAE864accB5248BF58276CE81' temploid='905DE80DD63C4f2dAA1353725509E2FD' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB32B0' oid='409E55176EA9468dB868B1DDAD32DFED' temploid='C4767F2B6C9048eeB330849383DCEEB4' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF149A0' oid='CA9D1072EDF047b4BA530538DDF80799' temploid='2F1FC847B02749ab85829D4361969134' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - ReportFirstTestFailedDTC</TUV>
+</NAME>
+<QUAL>RDTCI_RFTFDTC</QUAL>
+<REQ oid='2E9F0D0D31024b16BF5FA691980B7F7A' temploid='21D1EDCA3C93412eB2A300DE410C6D4C'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEB2470' oid='896CD4FE52434716AEFD6A9D93B390BD' temploid='5A0B81D6B21948758858CBD5977D9457' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB0CB0' oid='84BD702FB43C4852AE9465F6ED2440ED' temploid='1750F143CA2A4556B677039D534EF182' must='1' spec='sub' bl='8' v='11' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction</TUV>
+</NAME>
+<QUAL>Subfunction</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='5F8F14342D864b68943961FF5ABF2C22' temploid='9DE52BDE030947d284684B74195F8E69'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEB0590' oid='FD4E013EAF8B41aeA5F36135B6EBBE54' temploid='2882FF1CEF484ecfB096806E2A603B36' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB2A60' oid='D25F0493E36A4d518F45C0DE83D28950' temploid='A078CF822108424a874300B40A5CF5ED' must='1' spec='sub' bl='8' v='11'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction</TUV>
+</NAME>
+<QUAL>Subfunction</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADEB0F10' oid='0C6C6C1D77AE45d2B430C998C72519C3' temploid='D61D157D65FA43959FE0DD474FA6901F' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>StatusAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAB0D70' oid='5BEE263EFCF7454386004AD6A2FC71BB' temploid='686049823FD54cbdA5B65F23429A515E' must='1' minNumOfItems='0' maxNumOfItems='1'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfDTC</TUV>
+</NAME>
+<QUAL>ListOfDTC</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADEB0200' oid='E81DAF8A8B4643ceB51F60D767B53293' temploid='278135F00CB242f08CCFB07B9883FB49' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADEAFE70' oid='01B60EBA820C4a0381BB0DD168AFEDA9' temploid='CFFE011E25FE461a865BCBC6003DFECD' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDTC</TUV>
+</NAME>
+<QUAL>StatusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='192248CF3E1646a89848FF2AD73E086A' temploid='83B5CD0CAC9D49a0817EA90A4257EEF4'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEB25A0' oid='1F2019ECBC78428699ABD12F5183C25A' temploid='F5A644CEF7BF4ad5BA531FA8B4867615' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB0460' oid='3F399C609DDB43f8A1AD6FC204D6FBE1' temploid='A10DE732512346a2A5DA89FE4397A13F' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB2B90' oid='292E9F716D8645309540A7D3CF228EF6' temploid='DAC03939742A4344B3DD90AD844313A0' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF15060' oid='997C48088DC74af098177B25509DCBA1' temploid='699CC2B9E7E14dd393B30723C1DD7C80' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($11) EcuReset</TUV>
+</NAME>
+<QUAL>ER</QUAL>
+<REQ oid='8F897BEB62584c47B656DF5E771FC5F0' temploid='34309C4B74FB406aBBF3617E32CD6FA6'>
+<NAME>
+<TUV xml:lang='en-US'>ER-RQ</TUV>
+</NAME>
+<QUAL>ER_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADEB1040' oid='676F417BA35F49fdBAC8B8E4B642C390' temploid='571B23963701403a87CE5920BAF7713B' must='1' spec='sid' bl='8' v='17'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE318B0' oid='2B34F4D4209F437e8F7A645FEA72E8D7' temploid='F3750F4D955D471d98BD117DB247CEF6' must='1' spec='sub' dtref='_000001B1ADB67120' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>ResetType</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='2A451F68DDC14975BC593BB1DA8188C8' temploid='CB03849FC52742d88E860E7EEE544955'>
+<NAME>
+<TUV xml:lang='en-US'>ER-PR</TUV>
+</NAME>
+<QUAL>ER_PR</QUAL>
+<CONSTCOMP id='_000001B1ADEB0B80' oid='92F13C24D28F46d3B721925BA0BCFD74' temploid='260C9DCE4C3540edAD05C2BBFF223F81' must='1' spec='sid' bl='8' v='81'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE328A0' oid='9377960EB88E4de092E5124C755D5A4C' temploid='B2D0BE74F210490cBBAB4556942D6E0B' must='1' spec='sub' dtref='_000001B1ADB67120'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>ResetType</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEAFFA0' oid='D1C168F1F7C84e84BA843251CC592316' temploid='02E88338DA15439f9F92735E4F68A1E9' must='0' dest='data' minbl='8' maxbl='8' mustAtRT='0'>
+<NAME>
+<TUV xml:lang='en-US'>PowerDownTime</TUV>
+</NAME>
+<QUAL>PowerDownTime</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='D89A1D7B9FCF4ab7A5423CEDBA03ADAF' temploid='1060B6DB61584388AFACBF554FD6E427'>
+<NAME>
+<TUV xml:lang='en-US'>ER-NR</TUV>
+</NAME>
+<QUAL>ER_NR</QUAL>
+<CONSTCOMP id='_000001B1ADEB06C0' oid='257C1CF71EDF4455AD145BBA853B80C4' temploid='91403874EFDC4325B3CF2E1C182ABCC1' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB2CC0' oid='9DE5912AF241451189F39806AC3E225F' temploid='6E166BE907EB4c158D2AB4C09D52B1A3' must='1' spec='sid' bl='8' v='17'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB1170' oid='232512FC46F549a59251C8CAFB1B023E' temploid='299666255DC54735819472DB8CDE1913' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF14760' oid='8E7F91DE0AEF4eb2AD5F3DCED906B584' temploid='F135FD2000554ae5A7341DDD94B18D20' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($23) ReadMemoryByAddress</TUV>
+</NAME>
+<QUAL>RMBA</QUAL>
+<REQ oid='8EFAD15D72244d12BCEED9085E089CB5' temploid='81F802C5C1DB4ccaA6CDCC32E9D27EF8'>
+<NAME>
+<TUV xml:lang='en-US'>RMBA-RQ</TUV>
+</NAME>
+<QUAL>RMBA_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADEB38A0' oid='B088DDBE71D348108DDF14ABF0490464' temploid='95CC429F049F4904B4757804E339F99A' must='1' spec='sid' bl='8' v='35'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONTENTCOMP id='_000001B1AD92B700' oid='07AB5A8DF6DB487dBA009C270CF7961E' temploid='38D8DF49B1544b0fBE958FFAA514806B' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+<SIMPLECOMPCONT oid='A219422D0F354cd59A3295D522CF22EE' temploid='67928D0AD28743608451C6D09B0E3B81'>
+<DATAOBJ id='_000001B1ADEB2800' oid='04996EEFAA924207BE3D5A9957A6CD93' temploid='F879D84712E743b888C3012BB9B249E1' spec='no' def='36' dtref='_000001B1ADB64B20'>
+<NAME>
+<TUV xml:lang='en-US'>Address and Length Format Identifier</TUV>
+</NAME>
+<QUAL>addressAndLengthFormatIdentifier</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='956DD96CD98D4dcf871D4E645478BA63' temploid='092A9300EB8C40cd8570587D64ADDBF2' spec='no' dtref='_000001B1ADC1A860' dataObjectRef='_000001B1ADEB2800'>
+<NAME>
+<TUV xml:lang='en-US'>Address and Size</TUV>
+</NAME>
+<QUAL>addressAndSize</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</REQ>
+<POS oid='FE2A123FD55A49919A7BA20DE1684E9B' temploid='7DC7B0C5B28F4ebaAE2632CEF1B0580F'>
+<NAME>
+<TUV xml:lang='en-US'>RMBA-PR</TUV>
+</NAME>
+<QUAL>RMBA_PR</QUAL>
+<CONSTCOMP id='_000001B1ADEB2210' oid='BDE8D129837744dfB30DF4ED7EB6A2C7' temploid='CD6C08C1DAAF4cc1BC13E7A395671EB4' must='1' spec='sid' bl='8' v='99'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB3640' oid='9F380175872E40c799BA8A2ACA251395' temploid='0D0A4527F8954ba18FF0B298C3341671' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='9A7BC5BDE08B41e1B30EDBCEA59F4B1C' temploid='B360BE7699424d5aBE8A4DD4306453AF'>
+<NAME>
+<TUV xml:lang='en-US'>RMBA-NR</TUV>
+</NAME>
+<QUAL>RMBA_NR</QUAL>
+<CONSTCOMP id='_000001B1ADEB00D0' oid='B79113620F694c31B59E92AC1683B171' temploid='42351FFE58CF41fbB51406E936491565' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB1C20' oid='E3897EA11FB540daA37B4536BC14E9BF' temploid='C8538D3078D647b589387BAB1B9DE67C' must='1' spec='sid' bl='8' v='35'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB0920' oid='8BBFEBEB902448f99B16B46EB22C6DE3' temploid='B5B6483BCA4A4f89A6F97B7E486C2C0E' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF16FE0' oid='97929596B59444d8A854388E807E007A' temploid='4E0375E72BDE4ce88DF17FDE5BF710C0' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($3D) WriteMemoryByAddress</TUV>
+</NAME>
+<QUAL>WMBA</QUAL>
+<REQ oid='FD369A3BE37A4f91999240555090D411' temploid='713FF8D934FB44989AA659338E30CFE4'>
+<NAME>
+<TUV xml:lang='en-US'>WMBA-RQ</TUV>
+</NAME>
+<QUAL>WMBA_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADEB3FC0' oid='B49797CF169741d9AD4038336E04A56B' temploid='566FB812272C48a18B0723632B08E855' must='1' spec='sid' bl='8' v='61'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONTENTCOMP id='_000001B1AD92B9A0' oid='540B9F1FDA53407c97F9ACE3F250D11C' temploid='DFB395D3A9864463AC615EC0F06091EF' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+<SIMPLECOMPCONT oid='C958678399BC4979B73717A5DFA56EEB' temploid='24C6C34DCCD94c33947E0E75DC910BAB'>
+<DATAOBJ id='_000001B1ADEB2930' oid='622EB5ABE92D446b968EAA0595868BF8' temploid='1377DEDB1E764083AFA78C209AAC4A54' spec='no' def='36' dtref='_000001B1ADB64B20'>
+<NAME>
+<TUV xml:lang='en-US'>Address and Length Format Identifier</TUV>
+</NAME>
+<QUAL>addressAndLengthFormatIdentifier</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='078FC5BA162B48bd8FC3100479B87F94' temploid='DA491E01A4914cd2B3A6333AFC31173B' spec='no' dtref='_000001B1ADC1B6D0' dataObjectRef='_000001B1ADEB2930'>
+<NAME>
+<TUV xml:lang='en-US'>Address, Size and Data</TUV>
+</NAME>
+<QUAL>addressAndSizeAndData</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</REQ>
+<POS oid='349E54943F754039B1354906DBB8D216' temploid='C40242D0F647474cA7C0A85499DFD73D'>
+<NAME>
+<TUV xml:lang='en-US'>WMBA-PR</TUV>
+</NAME>
+<QUAL>WMBA_PR</QUAL>
+<CONSTCOMP id='_000001B1ADEB26D0' oid='18E78FBA72DE4ce8916324DBE7976779' temploid='D418D5FFEA29435b8CAACDC95D171ADF' must='1' spec='sid' bl='8' v='125'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONTENTCOMP id='_000001B1AD92EC60' oid='BC267F42FDC34200AAB69F3E3A6807D5' temploid='8514A26963C44db1A2DBCFCFD34542F0' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+<SIMPLECOMPCONT oid='139340C08E9F4f0999F9B684050479DD' temploid='972DC2D5D23642959DFBCEEE8D2AD313'>
+<DATAOBJ id='_000001B1ADEB1630' oid='679A5BCCAB4A4b0e86CB4E24E4B3950C' temploid='8C136102080B4497B62F1E9A61B00C5E' spec='no' dtref='_000001B1ADB64B20'>
+<NAME>
+<TUV xml:lang='en-US'>Address and Length Format Identifier</TUV>
+</NAME>
+<QUAL>addressAndLengthFormatIdentifier</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='79AB20071A8E4421B887F62504CEB001' temploid='FF94B1F5D841437dA55466228EAC1E9C' spec='no' dtref='_000001B1ADC1A860' dataObjectRef='_000001B1ADEB1630'>
+<NAME>
+<TUV xml:lang='en-US'>Address and Size</TUV>
+</NAME>
+<QUAL>addressAndSize</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</POS>
+<NEG oid='B28A83DAEA6E4045857B65D729586F6E' temploid='86D448A7E67C4b7dB38554136454E9DC'>
+<NAME>
+<TUV xml:lang='en-US'>WMBA-NR</TUV>
+</NAME>
+<QUAL>WMBA_NR</QUAL>
+<CONSTCOMP id='_000001B1ADEB3E90' oid='4F9DA0C8936B454a9B0929F34362DB6B' temploid='FD59310C95974c838805E4AF00B751A7' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB3770' oid='0BE8B0F1268C4b4a9722F7A352A3D7BC' temploid='0333A44EFC5B47159EC207F495035DB7' must='1' spec='sid' bl='8' v='61'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB3180' oid='DEFBEFCBF2EF47199B1B9C49DD9143E8' temploid='EE0E08EE3C954dcf98FAC2B0C9CA2752' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB319F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF14BE0' oid='92575F007A074c7d8C0A0FB09F9516B1' temploid='E2CC39935BA6452fBA8C7641F292350B' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($34) RequestDownload</TUV>
+</NAME>
+<QUAL>RD</QUAL>
+<REQ oid='3ED62B0BE3AE48ebB7632B568E4E4E1B' temploid='412ED7C5AF274538B4117DEAF1FF10DB'>
+<NAME>
+<TUV xml:lang='en-US'>RD-RQ</TUV>
+</NAME>
+<QUAL>RD_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADEB33E0' oid='68EE8570B2CD413d8989D89A86F5BFA5' temploid='B28ABEC38E7C4fadAD55C9B01C9C2E14' must='1' spec='sid' bl='8' v='52'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB39D0' oid='BA7471AD28614b13AF7858FEAC838D5E' temploid='33541718F3C2400889C573459D39F942' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DataFormatIdentifier</TUV>
+</NAME>
+<QUAL>DFI_</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92E800' oid='FDB87B7ACC124b198E3A5599366DC792' temploid='426823DC2BBE4e6698BC9AEEC9C0095F' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+<SIMPLECOMPCONT oid='A22F96012CB242f8B0BF72510499549B' temploid='B2EF6082FF084c948C8AE9E7FFA7BEBF'>
+<DATAOBJ id='_000001B1ADEB40F0' oid='95DE93A69D634761A29258F419EAEEF3' temploid='24BD9712E05B4db881E3FA905D1F04C4' spec='no' def='36' dtref='_000001B1ADB64B20'>
+<NAME>
+<TUV xml:lang='en-US'>Address and Length Format Identifier</TUV>
+</NAME>
+<QUAL>ALFID</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='6EA5FA7F0A6D439fA1C004B423DEDA0E' temploid='68B0741341F5432cBCE9F5A5FBB9586D' spec='no' dtref='_000001B1ADC1A860' dataObjectRef='_000001B1ADEB40F0'>
+<NAME>
+<TUV xml:lang='en-US'>Address and Size</TUV>
+</NAME>
+<QUAL>MA_MS_</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</REQ>
+<POS oid='74B9C28126014d8a898351E19318C894' temploid='6D72A71294784355B63097C58CE69A32'>
+<NAME>
+<TUV xml:lang='en-US'>RD-PR</TUV>
+</NAME>
+<QUAL>RD_PR</QUAL>
+<CONSTCOMP id='_000001B1ADEB1500' oid='A60060D21E9941b1ACEF6AF6781BA47B' temploid='52EDD4C506F44c2c9240989FD7D20B84' must='1' spec='sid' bl='8' v='116'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB4220' oid='A3FB24E9DF0A4ac5A20D26956ACD7D34' temploid='1AF035058D8740f7B27B0CDE4F5DA524' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>LengthFormatIdentifier</TUV>
+</NAME>
+<QUAL>LFID</QUAL>
+</SIMPLEPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB3B00' oid='7B41F0FA5637405c9CB932F69FCD1E08' temploid='644C3139E5834ff7A4DF4A61DDFF8258' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>MaxNumberOfBlockLength</TUV>
+</NAME>
+<QUAL>MNROB_</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='6AA27BA87541489c960E59B8896A9FAB' temploid='AF3B0671FCB643ed950C9114E1F82501'>
+<NAME>
+<TUV xml:lang='en-US'>RD-NR</TUV>
+</NAME>
+<QUAL>RD_NR</QUAL>
+<CONSTCOMP id='_000001B1ADEB3C30' oid='DF4B06756CC54c08B9B4FD295AC2EF2B' temploid='57D37F20EB0F48a5AC75FAEF20789B93' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB13D0' oid='2374677B5A1945c79D749E07EE7EBFC8' temploid='BC2E4ACD83FE401c80178E74C971713F' must='1' spec='sid' bl='8' v='52'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB1D50' oid='299FA7ED56D74eeeA26E7FC802C1D686' temploid='C30878BC7259467e92CFD3C83AB47B0A' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB31EF0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF14E20' oid='C9A55715D5374085AE599AAE17D7B00F' temploid='9FAE93D2205B4fee96E9ED9740934866' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($35) RequestUpload</TUV>
+</NAME>
+<QUAL>RU</QUAL>
+<REQ oid='33CBCEED9CE44ae1BB713ECB6A825922' temploid='0B3C14511F634ca883172139B859438D'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEB20E0' oid='4510BE29AB6F4cf89A35AF539AB31187' temploid='EF5B5F527B0B437389B167F05A04701F' must='1' spec='sid' bl='8' v='53'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB4350' oid='0C912E116EAC45e3B0B47CD4C25390C3' temploid='28BED285C98B40d1A0FB6C20C8CE63D5' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DataFormatIdentifier</TUV>
+</NAME>
+<QUAL>DFI_</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92E2C0' oid='D000C10A0F974605A4E05E319E2800BA' temploid='576B728A9F9B4a73971FF6537CE401FF' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+<SIMPLECOMPCONT oid='A8E94BFC13224b809AEC9E905AE8AA09' temploid='AFA05AABA4E74382B8571CCB13F4A2B6'>
+<DATAOBJ id='_000001B1ADEB2340' oid='C173D5CA7AC5462aA6074B05EAB82441' temploid='050E53B1B30E4c1eB312DA7BE7E8D168' spec='no' def='36' dtref='_000001B1ADB64B20'>
+<NAME>
+<TUV xml:lang='en-US'>Address and Length Format Identifier</TUV>
+</NAME>
+<QUAL>ALFID</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='E490E201911B4de78DC7179633A8F53C' temploid='B6660CD9FA1B4c0cB8DD40770301C608' spec='no' dtref='_000001B1ADC1A860' dataObjectRef='_000001B1ADEB2340'>
+<NAME>
+<TUV xml:lang='en-US'>Memory Address and Size</TUV>
+</NAME>
+<QUAL>Memory_Address_and_Size</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</REQ>
+<POS oid='01CC5B8DD4C449539C82D40B7A9CE7AE' temploid='86681E8B1BC240f2921DF54756A1D226'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEB0A50' oid='5D28664637104acd8DB4203521A501FB' temploid='1C0D17AD5BF14f0fA0F05265FE9A30BC' must='1' spec='sid' bl='8' v='117'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEAF9B0' oid='0102372F79BF4bc29B3CB5217ED5A996' temploid='25918AF75C4646b2AFB250A23177C713' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>FormatIdentifier</TUV>
+</NAME>
+<QUAL>FormatIdentifier</QUAL>
+</SIMPLEPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEAFAE0' oid='CF39E00197D44ba680EDA66033B09487' temploid='9475A8248B8C484eADF863B0584B2043' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>MaxNumberOfBlockLength</TUV>
+</NAME>
+<QUAL>MaxAnzahlBlockLaengen</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='02EED6006BCE4562A9FBCB579ADCCE76' temploid='44302D0E4F014c74947B6DBFDBA8D72E'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEAFD40' oid='BBAE1BDC0AD64526A0C4AF24B6419880' temploid='3A87C85ECC2D402fABEBFDA4B937F229' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB1890' oid='3378303C598A48ee84D51494C7C17E7C' temploid='3FB0709CF32840c0B747363A10429C72' must='1' spec='sid' bl='8' v='53'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB1E80' oid='349AEE583D4943d0888DA3FF8AB28DDA' temploid='793A490B63DF45deA936AC72DA77CB27' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB31EF0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF164A0' oid='295424D680234428BD00556B4D89A8D7' temploid='B9DDE99671CC459090110597F7E30490' func='0' phys='1' mresp='0' respOnPhys='1' respOnFunc='0'>
+<NAME>
+<TUV xml:lang='en-US'>($36) TransferData</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>A) Download (transfer from the client to the ECU)
+1. $34 download request
+2. $36 request:
+  a) sequence counter
+  b) download data
+3. $36 response:
+  a) echo of the sequence counter
+  b) optionally: checksum
+    (data-correctness double-check beside the sequence counter)
+    (depends on the manufacturer specs)
+
+B) Upload (transfer from the ECU to the client)
+1. $35 upload request
+2. $36 request:
+  a) sequence number
+  b) optionally: memory range for the uploaded data
+    (depends on the manufacturer specs)
+3. $36 response:
+  a) echo of the sequence counter
+  b) the uploaded data.
+</TUV>
+</DESC>
+<QUAL>_36_TransferData</QUAL>
+<REQ oid='98CF20E39FBA4d46A637087AD458D28A' temploid='B719EF5F5EF24155B4EA0C961260B443'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEB1AF0' oid='C1E8AE17A2B7475a877B7365F178D9E9' temploid='347CD47FDBCE4f4f844C3B37705B6A6A' must='1' spec='sid' bl='8' v='54'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB1FB0' oid='D3D76AF2E5AA484bA679E915C63A66A0' temploid='96DCD27AD6A74523B6A9AB562663718C' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Block Sequence Counter</TUV>
+</NAME>
+<QUAL>Block_Sequence_Counter</QUAL>
+</SIMPLEPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB5650' oid='42B2E0A7934948b68898F66889E14A29' temploid='F016D1F4112E4da9B14A81B48E2FAEC0' must='1' dest='any' minbl='8' mustAtRT='0'>
+<NAME>
+<TUV xml:lang='en-US'>Transfer Request Parameter Record</TUV>
+</NAME>
+<QUAL>Transfer_Request_Parameter_Record</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='71369320F4B944d7991F26A5C5484651' temploid='DBFA240096E249fb9747F020D9E40E6E'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEB5520' oid='FBC5BA87C3D643a3B8F9589CAF4B671C' temploid='AB98DF1E2423464c9B1AF5D82A68B2C4' must='1' spec='sid' bl='8' v='118'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB46E0' oid='F2E15780FFD84613A8768C87F88B942E' temploid='CDE7F83A572745478E81202E89800C11' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Block Sequence Counter</TUV>
+</NAME>
+<QUAL>Block_Sequence_Counter</QUAL>
+</SIMPLEPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB4A70' oid='37143C12E731461bAFC051278F4F6B3A' temploid='EF8E27F547314e5c85E570941276211E' must='1' dest='any' minbl='8' mustAtRT='0'>
+<NAME>
+<TUV xml:lang='en-US'>Transfer Response Parameter Record</TUV>
+</NAME>
+<QUAL>Transfer_Response_Parameter_Record</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='45ECC3E3E2DD498eA3262E91D909EF48' temploid='7428A15CEE8047dbBE5C4506F6B8A4DD'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEB59E0' oid='25BA2258DAC240b0A088ECB761BFE114' temploid='6EDC2C7E8F4C477a829F647F31EEBF26' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB4E00' oid='80351F16D3734794B9F4C7999F3B133D' temploid='8A120BFBA4D54aeeAFB210ACC77CDA6D' must='1' spec='sid' bl='8' v='54'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB4F30' oid='5F2EE9D536A54fe692EB85F554A0873C' temploid='6F060EA0CA654338984F8FE423FBC1A9' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB31970'/>
+<NEGRESCODEPROXY idref='_000001B1ADB319F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32A70'/>
+<NEGRESCODEPROXY idref='_000001B1ADB33370'/>
+<NEGRESCODEPROXY idref='_000001B1ADB30470'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF152A0' oid='DDB4561C77D441b68D5362620828826C' temploid='991D8DC6322F492e9E2FAD520E903AB4' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($37) RequestTransferExit</TUV>
+</NAME>
+<QUAL>RTE</QUAL>
+<REQ oid='7DF0BB7BD5324a398CC9507FF8B92487' temploid='9C0B736FA0164f509CC9B17CC5585A50'>
+<NAME>
+<TUV xml:lang='en-US'>RTE-RQ</TUV>
+</NAME>
+<QUAL>RTE_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADEB58B0' oid='2A5B1B81F8F64b56AC898FDEC815F11C' temploid='3BB65931F39541d88913302A196024AB' must='1' spec='sid' bl='8' v='55'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB4BA0' oid='466DED7CE69C4d8eB4C87270E637AE6C' temploid='1C9C9A13FD1E4f33B88BE00558114364' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RequestParameter</TUV>
+</NAME>
+<QUAL>TRPR_</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='C0BD18865A0C4df4967CEA1665052B04' temploid='DFF448A3FBD44d0e968FD9C55091DB31'>
+<NAME>
+<TUV xml:lang='en-US'>RTE-PR</TUV>
+</NAME>
+<QUAL>RTE_PR</QUAL>
+<CONSTCOMP id='_000001B1ADEB5060' oid='6887C870F0554f239ABCBD28E52BB2CC' temploid='3C9E9CDA9A6947beB9D53166E66A67B5' must='1' spec='sid' bl='8' v='119'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB5B10' oid='847CF607C85143419964AEBEA845B771' temploid='5C2C1FEB5E13478d936D517AEAE03BD3' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ResponseParameter</TUV>
+</NAME>
+<QUAL>TREPR_</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='A4E75643A8BF416e804D29C0A85C1284' temploid='79C1409489B043c7878B846C13351DCC'>
+<NAME>
+<TUV xml:lang='en-US'>RTE-NR</TUV>
+</NAME>
+<QUAL>RTE_NR</QUAL>
+<CONSTCOMP id='_000001B1ADEB5C40' oid='38089F9963634564AD2E3DFDE480A6E5' temploid='99609D846EC443b782FD809DF117896C' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB5190' oid='D402DED55F534d76A49ABC0576EC6275' temploid='8F05791AE2BC46d59692ECB9784508C7' must='1' spec='sid' bl='8' v='55'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB45B0' oid='07FB5E0217D84089AA442EC6C6C69318' temploid='1C1B0B58B4D847cf857BD72392D631A7' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF16920' oid='C3D4D168D9024c4cA987F7399D9A89A8' temploid='A9DB70E999ED4faa8836320F4603D418' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report WWH-OBD DTC by mask record</TUV>
+</NAME>
+<QUAL>_19_ReadDtcInformation_Report_WWH_OBD_DTC_by_mask_record</QUAL>
+<REQ oid='6EF4F04A42904792A96CA904A3477C2E' temploid='E5DF120B660647f0A80128D0C20F4624'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSMR-RQ</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSMR_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADEB4810' oid='5099A275635D49339BB503D207AB92AD' temploid='E6C57717FE0D41b88F92D6C62C2AF8FD' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB52C0' oid='E3DD718A755944c2BE99DC632D867EBB' temploid='F936484AC634466dBB299F9DA9BC2ACA' must='1' spec='sub' bl='8' v='66'>
+<NAME>
+<TUV xml:lang='en-US'>ReportWWHOBDDTCbyMaskRecord</TUV>
+</NAME>
+<QUAL>ReportWWHOBDDTCbyMaskRecord</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB5D70' oid='4BD0F8F39E824fd881AB995628A67DF9' temploid='132FD6834798443cB5695642DA607968' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>FunctionalGroupID</TUV>
+</NAME>
+<QUAL>FunctionalGroupID</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADEB5EA0' oid='6E1EE1DA3AF64edaAD0CE40595D576D2' temploid='D65CED5CC4644a3dB1D3AC888714AF6B' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusMask</TUV>
+</NAME>
+<QUAL>DTCStatusMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB4940' oid='2ED52E25E7704a4e9B3DBF0220EBD05D' temploid='D77EE84783904d0e9422DF2471F2CF7D' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverityMask</TUV>
+</NAME>
+<QUAL>DtcSeverityMask</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='E41D081B0EFE43b09EC7AF32197B17B9' temploid='9B998D0C6FF14fa28868ECE3DFB1E087'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSMR-PR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSMR_PR</QUAL>
+<CONSTCOMP id='_000001B1ADEB5780' oid='6EEF524117394dffB2EBCAA5E8555337' temploid='904FF91432854a7bAC538B6F74F2594A' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEB4CD0' oid='9D47267D8F974544A07229754EE78D60' temploid='447E858D36C74b49BE5C0C9157BCDD06' must='1' spec='sub' bl='8' v='66'>
+<NAME>
+<TUV xml:lang='en-US'>ReportWWHOBDDTCbyMaskRecord</TUV>
+</NAME>
+<QUAL>ReportWWHOBDDTCbyMaskRecord</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEB4480' oid='85826FDFE0F1445bBBA08FD1263E36A1' temploid='587ADD51E3FE4562ABFF1C812CF77875' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>FunctionalGroupID</TUV>
+</NAME>
+<QUAL>FunctionalGroupID</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADEB53F0' oid='1E03FCDA0E6249178F156BDC351D597A' temploid='60AB2ACCE5724e2498451E4616FB8638' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCStatusAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA7380' oid='CA84554BF2EC44ac8E65F5CB0E0BA846' temploid='D6C610FB7B6A41cdB0A215E7F382C557' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverityAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCSeverityAvailabilityMask</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92DF40' oid='66AB89D95FB94d538AA2A84AF9780B88' temploid='1F677202044F4243AEEF1713D933A43B' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFormatIdentifier</TUV>
+</NAME>
+<QUAL>DTCFormatIdentifier</QUAL>
+<SIMPLECOMPCONT oid='8252B626622D45ddA4A9131D3761862B' temploid='741C229FC29D426f916C536C28CFAFF5'>
+<DATAOBJ oid='91D7F027FD7C48dfBAA278845A9327F5' temploid='321F2AFA7777466a8902621DCB793840' spec='no' v='4' dtref='_000001B1ADB64400'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFormatIdentifier</TUV>
+</NAME>
+<QUAL>DTCFormatIdentifier</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<EOSITERCOMP id='_000001B1ADAB0F70' oid='3BFED869A61D4b7c9ACD109C389EF8FB' temploid='430715CBEBF7427cAFA6FD17B00405E9' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfData</TUV>
+</NAME>
+<QUAL>ListOfData</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADEA9E40' oid='0E588144728A4503B1925FBE64CCA73F' temploid='F8B26A3A583349e28FEE3338CBBFBB90' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity</TUV>
+</NAME>
+<QUAL>DTCSeverity</QUAL>
+</SIMPLEPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA6670' oid='EACFE7FF67B9471a8F5B9B77E5260066' temploid='4D1B775F72B14304A3645F1F250DBE65' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADEA88E0' oid='CEF6B75661834c68A525D5A773B799BD' temploid='84DF3C245F414a19A2B85657A425992B' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDtc</TUV>
+</NAME>
+<QUAL>StatusOfDtc</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='41F300DBAD2C40f7A75DC9D91979F5DF' temploid='322769C9ED0F4502A866B5807ECD853F'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSMR-NR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSMR_NR</QUAL>
+<CONSTCOMP id='_000001B1ADEA9260' oid='684257818E2E4faf97B3C7823C6D11F8' temploid='60A4C61BB3774f45A76F0B8D25ADD964' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA7120' oid='F4C19FE2CA6C46adAB77F002D521917A' temploid='977352402AFF49d49CAF7942E809DC49' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA67A0' oid='D60BB1ADB71E486dB988DF3CFA8F1239' temploid='26C7F3C573F54b55901F198FB8FBB487' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF17B20' oid='398AA7E89E6246e4B4D13E2664C1E801' temploid='0223597E048D4ffd85B0ACB1201C7984' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report WWH-OBD DTC with permanent status</TUV>
+</NAME>
+<QUAL>_19_ReadDtcInformation_Report_WWH_OBD_DTC_with_permanent_status</QUAL>
+<REQ oid='0E5DA26309754802ADFBA6C38D4B9AD3' temploid='88CEE288EC8C45998DC838E443AD9A1C'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSMR-RQ</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSMR_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADEA7250' oid='4149FFF9E1D24a3d8C89557AC346802A' temploid='AF3100B2F72A470893D93B465A929EA9' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAA1D0' oid='AB2D85C93BC94369AFFE423448A0B5FD' temploid='1693887034FF4c4686E16764F6F1C958' must='1' spec='sub' bl='8' v='85'>
+<NAME>
+<TUV xml:lang='en-US'>ReportWWHOBDTCWithPermanentStatus</TUV>
+</NAME>
+<QUAL>ReportWWHOBDTCWithPermanentStatus</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA68D0' oid='4B2F7909D36D44459EF33E191AC04E04' temploid='76BB31DE4CBA4c4f94C9FE2451B877E2' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>FunctionalGroupID</TUV>
+</NAME>
+<QUAL>FunctionalGroupID</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='6AAE8E3D1216494f965D0BE5C0808DDB' temploid='A5A04B44E3F643c0B1FA901120319999'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSMR-PR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSMR_PR</QUAL>
+<CONSTCOMP id='_000001B1ADEA9130' oid='7050D44261C14a7b8D16ED2C174D7A4C' temploid='D0EA5EB778D74905871E9A36EC1B7591' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA9D10' oid='6F237000C72B4f65A648A11FD14DFE0A' temploid='C156D8592A6741feA1D990294D05C867' must='1' spec='sub' bl='8' v='85'>
+<NAME>
+<TUV xml:lang='en-US'>ReportWWHOBDTCWithPermanentStatus</TUV>
+</NAME>
+<QUAL>ReportWWHOBDTCWithPermanentStatus</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA6B30' oid='BC8967F8CB814ebbBFD4CF87F97AD87F' temploid='4D3280D955C64aad9AD5249C9D976556' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>FunctionalGroupID</TUV>
+</NAME>
+<QUAL>FunctionalGroupID</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADEAA8F0' oid='B96E939B5B5F463b8A6D69214C75ECDD' temploid='20B9EA0F4A3C48d1BFC6167147EC17CB' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCStatusAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92D680' oid='746F3DADAF1447788920661AAD7727BA' temploid='4F757123C598490f93873015711C3EA2' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFormatIdentifier</TUV>
+</NAME>
+<QUAL>DTCFormatIdentifier</QUAL>
+<SIMPLECOMPCONT oid='35792F5F296E47faA3DBBE5208529E31' temploid='91D635DA66CD4f8dBCB8C3287693174F'>
+<DATAOBJ oid='FF3C42A683BA41049AABCE835D90D6F2' temploid='535470D5B80046e5B91DB539FCD8F70D' spec='no' dtref='_000001B1ADB64400'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFormatIdentifier</TUV>
+</NAME>
+<QUAL>DTCFormatIdentifier</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<EOSITERCOMP id='_000001B1ADAB1070' oid='D42BC9A50FFB45b3ACAAC40DFC44029E' temploid='CA2EE32B4C6942be87D9A3076AB44B01' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfData</TUV>
+</NAME>
+<QUAL>ListOfData</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1ADEA6EC0' oid='39553FF18EE8459d9BFCF0396455EA67' temploid='4DA346B99E694be78DA769E72C763D02' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADEAA300' oid='38692365F32C4723A9316818CB72C191' temploid='95A6A971F6174d1f8524998CD373F9BB' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDtc</TUV>
+</NAME>
+<QUAL>StatusOfDtc</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='CDAC67820733449b82288110E42C034F' temploid='5099BA8035F64019B4B1A49513869353'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSMR-NR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSMR_NR</QUAL>
+<CONSTCOMP id='_000001B1ADEA7D00' oid='26E2620CCC244a6c9EE6B91526A2ADBE' temploid='60B539112C9E433fBDEA53A24C5987B0' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA8C70' oid='3FD5C02E32844757847836FCF92947CC' temploid='A90622FABF49423c80946F7EA7656B4F' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA6D90' oid='EB9227CB45144ccf8038B8EC4DB5E4C5' temploid='684888C90C6746679C0C10E98BC37883' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF15720' oid='468A20F1B41647caBBBB5D74E7879673' temploid='D8FFAE5CA4AB436aB985073B657C145B' func='1' phys='1' mresp='0' periodicresp='1' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2A) ReadDataByPeriodicIdentifier - SendAtFastRate (Dynamically Defined)</TUV>
+</NAME>
+<QUAL>_2A_RDBPI_Dynamically_Defined_SendAtFastRate</QUAL>
+<REQ oid='01FCDA2434754214B3474929A362FC41' temploid='227A4328DBFD4801B34041673E8D925B'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEAA430' oid='138C480C742D4b86844B83E79630B23B' temploid='49A4C5AAE351401c9901FC93FDFC5126' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA75E0' oid='4FA1BAC84277423eBBA54A1865A0978F' temploid='3ACDC752BC8A474182FA13E728691513' must='1' spec='id' bl='8' v='3'>
+<NAME>
+<TUV xml:lang='en-US'>TransmissionMode</TUV>
+</NAME>
+<QUAL>TransmissionMode</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32570' oid='1ACD05A85AE34cb5A6557182662E7F68' temploid='4E4F845EF09149a3B456900089982533' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='A3EDD1DDA65F45f5A89ABCC8EDB6ED5F' temploid='C1FD98BEB921402c9F98381CC1299345'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<STATICCOMP id='_000001B1ADE31E00' oid='B1F5E769D34846058984190D0A24F988' temploid='367F5731F1C64e97996558F1C547E6B8' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEAA7C0' oid='752DFCE2B7F7469494F1B45B8CAD38E9' temploid='17DAB321A4EE4da9AC2024EBCE5E535E' must='1' dest='any' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='2910CFF4A195464cB160A08C8766F6C5' temploid='657D8C28219446caBDD1610D6C417A2D'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEA9F70' oid='698D9197C8DD4927883CA5F7BDFA5B87' temploid='0725E78AEAB54f538419257161AD00C0' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA8B40' oid='66D7FE191D0748a18B90FF9006335FDD' temploid='F262A948EB7B4007856EF1C06CC697EB' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA74B0' oid='28B24DD527FE45e1B09F582A9FB1C84A' temploid='F3FC6D1EF75F49cc88D6A85344322BFD' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF16020' oid='0D0BFBE4B3814ebeA62AD6622C5957CF' temploid='6C217E9F2CAB47228B5723B953FF0455' func='1' phys='1' mresp='0' periodicresp='1' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2A) ReadDataByPeriodicIdentifier - SendAtMediumRate (Dynamically Defined)</TUV>
+</NAME>
+<QUAL>_2A_RDBPI_Dynamically_Defined_SendAtMediu</QUAL>
+<REQ oid='0A79D0A7D40A4d09ABEE22730D0DFEC3' temploid='9200D0817CD64a228D4D8B227883443A'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEAA690' oid='48E034B4BD654d04B5889F39E010EA0E' temploid='746FF7600CCC4e218DD3EC3549C7F059' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA7840' oid='AF6CA1160E6748a3A5BF0FD1F5D4DBAB' temploid='136E5501FEA440ab875E7A6AFC7B4283' must='1' spec='id' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>TransmissionMode</TUV>
+</NAME>
+<QUAL>TransmissionMode</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32460' oid='998DE950D2C241429FA14C05FA350403' temploid='3C18508ECD0C4e139BB28D2719258FD9' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='B3305A50B1BC40c2B407132081A5EAD2' temploid='7E39E295C8234e719C19197B599372EE'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<STATICCOMP id='_000001B1ADE32020' oid='D06025CF6E094addB40CEE541378D77B' temploid='AE887F5C19664ffb95251BBD2D5A9967' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA6A00' oid='63583133CB2F425a875A5B7C90CEEC73' temploid='B6E1BFEC2C734cb4A8E7A329B7D2E088' must='1' dest='any' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='0DAFE652FCF044cd83F9EC603D1E106C' temploid='74324AD921AB4edbAD515F9BFDB77BBC'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEA7BD0' oid='F29909620A4346c98E6F74AC2815353F' temploid='DB1192CE288B4b7d94DFB3209439E5FF' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA6FF0' oid='56422A5338744722BE1D772A5EAE83BD' temploid='5595A2E79BD34aee8ACBF0F964B0D3F9' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEAA0A0' oid='642B85C94F824830AACFB8E9BD7EDE68' temploid='F28BAEC5BEFF4c3b98AD1799242A8E72' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF154E0' oid='5C1FDD7A8E7D4e16A6FCFC9B2FE4FF91' temploid='583D6EC5140E415c9CD2E05C05DB6AB5' func='1' phys='1' mresp='0' periodicresp='1' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($2A) ReadDataByPeriodicIdentifier - SendAtSlowRate (Dynamically Defined)</TUV>
+</NAME>
+<QUAL>_2A_RDBPI_Dynamically_Defined_SendAtSlowRate</QUAL>
+<REQ oid='3DD3C121833846928B4D83D2F4E735C9' temploid='C7F1E11D090248b7B7800DF8EE9B395B'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEA8DA0' oid='7A3504E7EAC44d5cBC594DD1033B8FA3' temploid='B551D03863CB44a781F31E846DBB5B29' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAA560' oid='C583EC43554A462cA55E131156DD7CBE' temploid='9BE73F54AE034860800A4E222567E59E' must='1' spec='id' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>TransmissionMode</TUV>
+</NAME>
+<QUAL>TransmissionMode</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32130' oid='15A107ABC8BF4e25931A1508B458DAF6' temploid='BE36BA40D7AB40efAF1873D8250CC8C2' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='D10B47DD81CD41018F96726A13D3FA1D' temploid='6D2757B329E5441f8088F9C8D85A3F69'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<STATICCOMP id='_000001B1ADE30AE0' oid='0E39F997D07F49559BE6A1B6A1DDF9E0' temploid='F81A55B0F9804aed9948C108AA562610' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PeriodicDataIdentifier</TUV>
+</NAME>
+<QUAL>PeriodicDataIdentifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA9390' oid='717DD8B76D2244d693EBF4EAF20EAE38' temploid='13B17E3C75154716B61332D86F0EE2CF' must='1' dest='any' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='395A76B095914b36AE93BA87452ACE71' temploid='8957172531A940f5AD19F6C83F60DC93'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEAAA20' oid='0C6A5033DB584da5B1BA8FCDA910E82F' temploid='48E49FDFDD1A4b68B32DABEA99B45CDC' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEAAB50' oid='75088738000840a8BC869A174EF282EC' temploid='0E46859602EA43419DB26D65CF30CD23' must='1' spec='sid' bl='8' v='42'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA61B0' oid='BBC94F369035495e9C0803DB3BCD03C4' temploid='A3D3A2FFB74240798E6E504EEB57AC96' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF16B60' oid='F3EC7ADE589E47188E086995A0CF15FF' temploid='8430AC2C52354466BF3A2520F978078F' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($24) ReadScalingDataByIdentifier</TUV>
+</NAME>
+<QUAL>Rsdbi</QUAL>
+<REQ oid='156ECE1810B84ae983D9A163B0A9E6C9' temploid='5C11C480BB8B429987C9F29FE109D9CF'>
+<NAME>
+<TUV xml:lang='en-US'>Rsdbi-RQ</TUV>
+</NAME>
+<QUAL>Rsdbi_RQ</QUAL>
+<CONSTCOMP id='_000001B1ADEA62E0' oid='7AA068AAC3C2423f9C51F79B321BD3ED' temploid='67ECCBC738A2467e9D5016BD7EDCF741' must='1' spec='sid' bl='8' v='36'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32CE0' oid='3680AFE19A764e0d810650394A490231' temploid='A7C0560014374d82A7BA23A145689C91' must='1' spec='did' dtref='_000001B1ADB64D80'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='78159B16A1F74b1a8319C7E6E1D51990' temploid='E08AB09F9EE54c208B217D19C29B4C40'>
+<NAME>
+<TUV xml:lang='en-US'>Rsdbi-PR</TUV>
+</NAME>
+<QUAL>Rsdbi_PR</QUAL>
+<CONSTCOMP id='_000001B1ADEA7970' oid='1F06EBFD963E487f8C721982D6EFD7E6' temploid='A004B43A1685467597F1682D26BD2A2D' must='1' spec='sid' bl='8' v='100'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE306A0' oid='8069650BEF7243cdB79A77177F3FA70E' temploid='428E9CFCFD89412d9336E63F14F9D2F3' must='1' spec='did' dtref='_000001B1ADB64D80'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA7AA0' oid='BB86CDEFD30A4c06B144E034E3B481B1' temploid='4633A89B494D43fcA792C98A3793CF97' must='0' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Scaling data</TUV>
+</NAME>
+<QUAL>Scaling_data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='0D071A1169A94706807FFDCEF10FDC10' temploid='200F959B186D49669546392D768B6E16'>
+<NAME>
+<TUV xml:lang='en-US'>Rsdbi-NR</TUV>
+</NAME>
+<QUAL>Rsdbi_NR</QUAL>
+<CONSTCOMP id='_000001B1ADEA6410' oid='ED96CFCC51FE4321AC11EFE1D0B4A6AE' temploid='8206CE7FB5D04ed79DF956BB56AA7984' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA6C60' oid='704555EA283F439aBE9008BEF0CBCD49' temploid='1E8FFB420BFD45c1BE657F3600FFC1DA' must='1' spec='sid' bl='8' v='36'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA6540' oid='11F40AFBB4AF461d83D139FA4B714F81' temploid='0F4A092847F54d3aADFD6F942B6AC1BF' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Response Code</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF17220' oid='7B1387131125481692F13929467E2BE4' temploid='9C97428048584af78A46F0010B87B6DB' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($86) ResponseOnEvent - stopResponseOnEvent</TUV>
+</NAME>
+<QUAL>_86_ResponseOnEvent_stopResponseOnEvent</QUAL>
+<REQ oid='B53F8305C9024115BD2CA543E30C758A' temploid='D199B4026DE943f691F48AB4A2996D86'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEA8A10' oid='8E9E3DA4160041edB9D192F8BA624B50' temploid='8D58B7255A534e4b95A1D162A1043773' must='1' spec='sid' bl='8' v='134'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA7E30' oid='AF00E2ECFCA34708BCDE6F0C9A3A2CB0' temploid='FFFEF4B6C1A84eda86768F6C42155F28' must='1' spec='sub' bl='8' v='0' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventType</TUV>
+</NAME>
+<QUAL>EventType</QUAL>
+</CONSTCOMP>
+<CONTENTCOMP id='_000001B1AD92D760' oid='65349DDBE62D47ae954A2AA5DEC070CE' temploid='717B5B4B8EBD4e5dB327D386C7ECA534' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+<SIMPLECOMPCONT oid='729F2A4A169943458C91502401EF41D8' temploid='A92DAC5AE7644f8e9785924ACA15A02D'>
+<DATAOBJ oid='6EB6854DB7324a498F02BC203AC810AB' temploid='A92F889986614d2893C662BCDF6B9043' spec='no' dtref='_000001B1ADB64FE0'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</REQ>
+<POS oid='9934649341204d8e95CBF4416C1E9ED4' temploid='10AA4DD7C98E4f61900C4936D6A98398'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEA7F60' oid='ADCB402D2F9C498f81818E8B256F14C7' temploid='D597325A710B4d4a838AF0AB4D5DECFE' must='1' spec='sid' bl='8' v='198'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA94C0' oid='3B719BB1316A4a91BC777D118E7D899C' temploid='8811FFDF3E7948f5A4C5925E16F1168B' must='1' spec='sub' bl='8' v='0'>
+<NAME>
+<TUV xml:lang='en-US'>EventType</TUV>
+</NAME>
+<QUAL>EventType</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA8090' oid='8EAFFA01A82E40438286023BF199896F' temploid='FFFC0AF61A144eb092244615D0BEFA97' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>numberOfIdentifiedEvents</TUV>
+</NAME>
+<QUAL>numberOfIdentifiedEvents</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92D840' oid='36A232E402544d37B78D53AC60D5C4E0' temploid='060A6D8DBF1A42d0B2793387114C3654' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+<SIMPLECOMPCONT oid='CA737C3E37684b0eA496A016918E0661' temploid='53E6672982454d27AC2B8DE7CD4783A4'>
+<DATAOBJ oid='53B9DD4413234981A6B6E43A6BC4FE33' temploid='DE3F8AB613C34513BEBD43AF94C978FB' spec='no' dtref='_000001B1ADB64FE0'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</POS>
+<NEG oid='0CC1BCE027B643d8B8C18F9C4541D36C' temploid='286E522F52B24405A647AFA09EC866FF'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1ADEA81C0' oid='2DD48238F0BC4a88A04AA23931AC0902' temploid='D94B938341A945879680FC0846616D12' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA8420' oid='2E1656B88DEE4e4d867B701AB04EC3B7' temploid='C5C9AC3FF2B546fb90BD7C3A1E48503C' must='1' spec='sid' bl='8' v='134'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA82F0' oid='2C7DD597ECA242049C5305F1BBBE0A6F' temploid='7F375D36327C4f25972D0E3275E5D2F3' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF17460' oid='1C9D7A74B04747a7BF82B1900593E8DA' temploid='5C099ACA7F5345dfB7608A8371A74D19' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($86) ResponseOnEvent - onDTCStatusChange</TUV>
+</NAME>
+<QUAL>_86_ResponseOnEvent_onDTCStatusChange</QUAL>
+<REQ oid='6B5060300B644fe78F2A15FED25096AB' temploid='E91C30ED7D7D49ce92431A4AF54810A9'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1ADEA8550' oid='9D43C4035A744f898D75F5FB7BDCB7B4' temploid='9BA4C9629A114118BF0CCB38E48CD87B' must='1' spec='sid' bl='8' v='134'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA8680' oid='E9D551517EDF4699928A146AE0B111D9' temploid='615B7CA0DDC04ccb81B5A6A329E315DC' must='1' spec='sub' bl='8' v='1' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventType</TUV>
+</NAME>
+<QUAL>EventType</QUAL>
+</CONSTCOMP>
+<CONTENTCOMP id='_000001B1AD92E640' oid='6F419A9772B4451398B8934BDA88A3AF' temploid='E2EB87A7788F4dc89F5EC1E9E850F045' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+<SIMPLECOMPCONT oid='87620A50CCFE49efBBD7787A5CF9F565' temploid='1CC3CEB435154908932E1F9A321D8A26'>
+<DATAOBJ oid='3877EEE770084079884EF400C0FF950C' temploid='993890281CA042ad93B53A04A2B99BCA' spec='no' dtref='_000001B1ADB64FE0'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1ADEA8ED0' oid='2087412A73144da4A7793D0FA714193D' temploid='E262208DA81341cdA215C96CB09FED60' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>EventTypeRecord</TUV>
+</NAME>
+<QUAL>EventTypeRecord</QUAL>
+</STATUSDTCPROXYCOMP>
+<CONSTCOMP id='_000001B1ADEA95F0' oid='7775FCD9806440d3AAF101A35FDEFD26' temploid='C58601B814374734B8FD4BCA9F57015F' must='1' spec='sta' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>ServiceToRespondTo (ServiceId)</TUV>
+</NAME>
+<QUAL>ServiceToRespondTo_ServiceId</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA9720' oid='E3B02BD0F2CE4bffBAD96C881CDEC961' temploid='A784A4158ABC4cabA42DA6892D25E720' must='1' spec='sta' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>ServiceToRespondTo (ReportDTCByStatusMask)</TUV>
+</NAME>
+<QUAL>ServiceToRespondTo_ReportDTCByStatusMask</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1ADEA9850' oid='B10FDFA77BB04df29E5CCF8B8677F8BF' temploid='D936DD9289B9434fB06A538FD096A5B9' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ServiceToRespondTo(DTCStatusMask)</TUV>
+</NAME>
+<QUAL>ServiceToRespondTo_DTCStatusMask</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='9EBB978542FB44bfB7F21EC528CC199A' temploid='A20864A7C1C446579C3B78871ECC9855'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1ADEA9AB0' oid='B9B8AE6BF80A4588A99A8FC43AB9AB2B' temploid='139EE992EEFC4602A69DC5C16BA73B7E' must='1' spec='sid' bl='8' v='198'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1ADEA9BE0' oid='04998781949D4616A98E4B45C8BFEA6A' temploid='867B84EBED9C4e99A0C2F2FECD399933' must='1' spec='sub' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventType</TUV>
+</NAME>
+<QUAL>EventType</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2A6B0' oid='5153B2D94CBE434882C4D1B1C31093CE' temploid='5A248CA4C99B45ce8505E623157AF0DD' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>numberOfIdentifiedEvents</TUV>
+</NAME>
+<QUAL>numberOfIdentifiedEvents</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92E560' oid='282FD4E4B90C47678F696C6CD9166356' temploid='2A785879043445ff8D6FC76157CA0661' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+<SIMPLECOMPCONT oid='8C61F1F54ED44748B047D0B0CE19434E' temploid='2C41BA787C9244d0B0F92CAE7022722A'>
+<DATAOBJ oid='7F9FF5A2EEB04c178C878EBFA85692A4' temploid='AFF561984A144dba8EDCF51896223B7F' spec='no' dtref='_000001B1ADB64FE0'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFE2AA40' oid='FEBFEF6A20684e539D4DB4C1EFA4EE00' temploid='CD92A360F11D4e3d8AEA2CF739195879' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>EventTypeRecord</TUV>
+</NAME>
+<QUAL>EventTypeRecord</QUAL>
+</STATUSDTCPROXYCOMP>
+<CONSTCOMP id='_000001B1AFE2A450' oid='D9DB0D63D24847558C5C529C5C790D2A' temploid='B3976A3CE7154462832F19AE358A30EF' must='1' spec='sta' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>ServiceToRespondTo (ServiceId)</TUV>
+</NAME>
+<QUAL>ServiceToRespondTo_ServiceId</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE293B0' oid='F6F9BA5212704993B1EA1D7BEBAA5DE4' temploid='7C464BC21A2D4819A12B0FEEF1493C74' must='1' spec='sta' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>ServiceToRespondTo (ReportDTCByStatusMask)</TUV>
+</NAME>
+<QUAL>ServiceToRespondTo_ReportDTCByStatusMask</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2A580' oid='7762FEEFA1184048AE6878960873B666' temploid='273E911F22874bd4AA7D9EC687B7D5C1' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ServiceToRespondTo(DTCStatusMask)</TUV>
+</NAME>
+<QUAL>ServiceToRespondTo_DTCStatusMask</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='DE8735459D744903A1DD8CA20FCDC793' temploid='723CE8BD15554fd8916635FA989B15DF'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE294E0' oid='635DE63A531C40ac82D6AE027177E5D6' temploid='E658830517B547498B441F1CEDBD8987' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE29280' oid='205FCEAD04D0401295A4163F6483FF04' temploid='99E1692A4F9E4a45AF51FE237E6F14A0' must='1' spec='sid' bl='8' v='134'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE29E60' oid='9269B9E0FC88431089662C1750FD17D6' temploid='B99F58A460104c59BDD74674DA902CA6' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF176A0' oid='0B2400AB3A4C4bd4BF5B28D509B0FBCE' temploid='46A9B5B5D96945feA9FD96115624016B' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($86) ResponseOnEvent - reportActivatedEvents</TUV>
+</NAME>
+<QUAL>_86_ResponseOnEvent_reportActivatedEvents</QUAL>
+<REQ oid='10DED604A96242c2AFE6907E8E4F86BD' temploid='57C831581A6E47d8A5195833360FD9D7'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE29610' oid='13F47B44D06244608D85398279214F1B' temploid='121196AAAB1F4cedA32429899B3CA692' must='1' spec='sid' bl='8' v='134'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2C6C0' oid='DD8E3904314146cbAD51542A567DABCC' temploid='E0C6499177784a238FA4114628D04898' must='1' spec='sub' bl='8' v='4' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventType</TUV>
+</NAME>
+<QUAL>EventType</QUAL>
+</CONSTCOMP>
+<CONTENTCOMP id='_000001B1AD92D3E0' oid='C48BCEFD2B81441bAF0E3345C3600470' temploid='4B02D561DC344387A66436A499969FE0' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+<SIMPLECOMPCONT oid='25C005254008429387CE142CAAE282E3' temploid='CF62CF83BAC147e9BF8B27093E0ED625'>
+<DATAOBJ oid='B72D868592B840a9B66801FC535440A2' temploid='D360F4C590A340ef8E557B9450710AB5' spec='no' dtref='_000001B1ADB64FE0'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</REQ>
+<POS oid='F47A646671BD45688111F29E24EEFA7B' temploid='681AAA5ED0D24952A8AD097011D0C666'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2A7E0' oid='3F90D0475C39476384AE3794C58FBDFB' temploid='9C069CF13B3A4d8a932F53F2AAEE0C02' must='1' spec='sid' bl='8' v='198'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2C200' oid='ACA2116DD4CF4339AE8451E5A51E80B4' temploid='4F49088E0B98427aB2324B144F2D6FAF' must='1' spec='sub' bl='8' v='4'>
+<NAME>
+<TUV xml:lang='en-US'>EventType</TUV>
+</NAME>
+<QUAL>EventType</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2B4F0' oid='5E289025950B46ca8D5B0E00C19D08B9' temploid='2639EDBB01AD426dAC4721DEE92A961E' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>numberOfIdentifiedEvents</TUV>
+</NAME>
+<QUAL>numberOfIdentifiedEvents</QUAL>
+</SIMPLEPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAD670' oid='39C460C693A040edB10B67714ED2E699' temploid='AF9331C89EF94e3494EBB3CE112F0F45' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>ActiveEvents</TUV>
+</NAME>
+<QUAL>ActiveEvents</QUAL>
+<CONSTCOMP id='_000001B1AFE2C920' oid='9C9EB24B4E154740B315B5AD4DBD466F' temploid='887A74C031E54da4A0FA900BAA526A68' must='1' spec='sta' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventType</TUV>
+</NAME>
+<QUAL>EventType</QUAL>
+</CONSTCOMP>
+<CONTENTCOMP id='_000001B1AD92E9C0' oid='6668CB5A92FB4f238848BC7866AF3C08' temploid='3EE803FDBEB241269E21F6EC223C8DD2' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+<SIMPLECOMPCONT oid='567E0849188242cdABDBED1B7A936D3C' temploid='A7150DC7BA0C4a3d8FCDE6FF2F27A519'>
+<DATAOBJ oid='D6BD5214352A480b982CC4B5F9AA9909' temploid='FDD823D811424abd87DAB666F9D6F9BF' spec='no' dtref='_000001B1ADB64FE0'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFE2A0C0' oid='CE9949739F894ac8BEC408A2D3A8761D' temploid='DB5AD8104E3845138827CACCF0315D3C' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>EventTypeRecord</TUV>
+</NAME>
+<QUAL>EventTypeRecord</QUAL>
+</STATUSDTCPROXYCOMP>
+<CONSTCOMP id='_000001B1AFE2B620' oid='D2D770641F05479a85658DB3E1F93D35' temploid='D9740981A9A948b2B5819933F8E7CE00' must='1' spec='sta' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-ReadDTCInformation</TUV>
+</NAME>
+<QUAL>SID_RQ_ReadDTCInformation</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE299A0' oid='C13C19D1969F4d2480FB96929847495C' temploid='C3A58A3D243C4c7f8052DB56E2B4D824' must='1' spec='sta' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>ReadDTCByStatusMask</TUV>
+</NAME>
+<QUAL>ReadDTCByStatusMask</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2CA50' oid='1E8C1673184342c79BCFD51E0A194DDA' temploid='DFC94CE9C66D441b8AA81207259B69DD' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusMask</TUV>
+</NAME>
+<QUAL>DTCStatusMask</QUAL>
+</SIMPLEPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='7F45CB6AD9734533BF9F3A2EBD32E082' temploid='A4FE1A053AAC4bc2BA7CFD2AA66D4782'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE2C330' oid='900B5956532B489aB8C748D5E86F692A' temploid='F3422FBAB17C4ca9AB36B635B2668F9A' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE28EF0' oid='7721387CFB9D4785BDC77FC24216DB0E' temploid='36E134767AEA427c853B46542A0AEAE1' must='1' spec='sid' bl='8' v='134'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2CB80' oid='DDBED4A7951D49b18990924EABCA5145' temploid='15FB7056C0064325BE1A9DE4C02691FD' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF16DA0' oid='398DBEC931714a86BE2B720743E65AD6' temploid='A642412ACD9A41e88EF5878359E0AC95' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($86) ResponseOnEvent - startResponseOnEvent</TUV>
+</NAME>
+<QUAL>_86_ResponseOnEvent_startResponseOnEvent</QUAL>
+<REQ oid='8ED15CDE7ABE4ce588259524D97E726D' temploid='BA2034383E674a3d9AD685A3DB02720F'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE29870' oid='C51F11361D0246d89A52C96B2194DC43' temploid='3BA152E9F9554ff195C5314A8DFAF41B' must='1' spec='sid' bl='8' v='134'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE29AD0' oid='0789F2CC1253402a90849DD8410B8ABC' temploid='3A0C8FC537FC49668459D3921B775DFD' must='1' spec='sub' bl='8' v='5' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventType</TUV>
+</NAME>
+<QUAL>EventType</QUAL>
+</CONSTCOMP>
+<CONTENTCOMP id='_000001B1AD92EAA0' oid='F9877A0C020E4aa49FEB91507096987F' temploid='42B600E442564d6bB81D10307B2FF637' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+<SIMPLECOMPCONT oid='DA8A5DE5BEB04edbB88C3734214302D1' temploid='305D42F415194fe0BD863240412B84DA'>
+<DATAOBJ oid='C33D68ECADC64e5593B0DBF3AF290178' temploid='8712D469814D4c38ABE910348CBC3084' spec='no' dtref='_000001B1ADB64FE0'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</REQ>
+<POS oid='89E2EE8135504b3689C2976B37C632FA' temploid='B781014A11994601906A6B5B9FD9D343'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2BC10' oid='4E50EF81638F49a6A3FE40BD96BCB120' temploid='2BB2CA57F61749a0A88CA19D36C9E74A' must='1' spec='sid' bl='8' v='198'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2B750' oid='D8FDDA09116249ea960517160553D1B0' temploid='759A77D693EB45b19D2A7720C077C299' must='1' spec='sub' bl='8' v='5'>
+<NAME>
+<TUV xml:lang='en-US'>EventType</TUV>
+</NAME>
+<QUAL>EventType</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2D630' oid='667BBA7B20D04aaf98D26FDE20D32BA9' temploid='86F4391945D14b21AD56DA39C4996ED5' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>numberOfIdentifiedEvents</TUV>
+</NAME>
+<QUAL>numberOfIdentifiedEvents</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92EB80' oid='8402EFBA46E64d75B2504ABE27DF2D47' temploid='6CB1B5D4BAAE4cb5A010CA7AC2F458DE' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+<SIMPLECOMPCONT oid='5866A160B2A14a918BADF6376C27604C' temploid='A2FADC1B1F6A4b3494706A0E4DBE968B'>
+<DATAOBJ oid='B269EFBA9F3D4fef91D2E97798440E13' temploid='80F821F04D184bb7A767ED51D3B5B2D4' spec='no' dtref='_000001B1ADB64FE0'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</POS>
+<NEG oid='4E454A1D5B7D46ee92806FCB4DF0067D' temploid='7D6BA10ECD2B4e2aAE9ED1DB1F18ABCD'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE2CCB0' oid='C41D7AC3AE794869930C6B5D07947EF0' temploid='5B62EDF016704b7183ADFC3FEF43C2B3' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE29D30' oid='57E0D5FDD62A48d0B34A46B6612ACAE1' temploid='BD8CDF2A52104427BDA6103EB21B3F7A' must='1' spec='sid' bl='8' v='134'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2CDE0' oid='25B083C6688F4c76BBB96FABFB453870' temploid='9BCEFE8399D9472dBE898E44B0A28CF9' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF140A0' oid='9DA769C49261417b9D9209717ABBB2C8' temploid='687885D2A0F94595A6AFA3FE1ED121CA' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($86) ResponseOnEvent - clearResponseOnEvent</TUV>
+</NAME>
+<QUAL>_86_ResponseOnEvent_clearResponseOnEvent</QUAL>
+<REQ oid='C3A0D594149B46aa922421F70300B6F9' temploid='4F85409A88D244c68DE8C5D5C2C67D3F'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE2A910' oid='5977210FA5654d86AFCD18F60CA614DE' temploid='244F93CC99FA4e41AC987305B06C4B35' must='1' spec='sid' bl='8' v='134'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2C590' oid='7D35DD7EFCF54f2785CFA9D9436EAA5F' temploid='037DFB3F470549a892E0D8F8A64AAE66' must='1' spec='sub' bl='8' v='6' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventType</TUV>
+</NAME>
+<QUAL>EventType</QUAL>
+</CONSTCOMP>
+<CONTENTCOMP id='_000001B1AD92E3A0' oid='83159C6B045B4d2e8165A20CC40C8A8E' temploid='F0BD84FE8AEB4bc89BD52D6540860DC4' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+<SIMPLECOMPCONT oid='C55C6CEEF8794c938EA7D4CFB28EE991' temploid='0F59EBB5C355429e98F0310DD3DFCC6F'>
+<DATAOBJ oid='A38E7F186FC442099CBEF09308A4A339' temploid='FB57E6CE4463441bAA9E430C6E9AC80F' spec='no' dtref='_000001B1ADB64FE0'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</REQ>
+<POS oid='AB9306E4B4EE4372A557114C96F9B7A9' temploid='358CE1941B8B481b8E64D85B8169B51F'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2AB70' oid='6262E2A3E0C0472e9884D0D29615D2FD' temploid='589CDE5682444de0B1E5EA94A65C9210' must='1' spec='sid' bl='8' v='198'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2B880' oid='0CD1B1F24B9845ceAD5CFC74253CD482' temploid='E1B6DAD70A5548cbAC8FDDFC38C864F2' must='1' spec='sub' bl='8' v='6'>
+<NAME>
+<TUV xml:lang='en-US'>EventType</TUV>
+</NAME>
+<QUAL>EventType</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE29020' oid='BB7B57B1448849469200D132E4468F92' temploid='45E5CBEDC08B4f9cB02AD28B7C25BE21' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>numberOfIdentifiedEvents</TUV>
+</NAME>
+<QUAL>numberOfIdentifiedEvents</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92D140' oid='5FDC1E3B5D3646d18D8779FE066E8ECA' temploid='26858B77243645a6AA78318E2E17B751' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+<SIMPLECOMPCONT oid='0C30F91CDB3944b5A7CFB5EF7F0E7DDD' temploid='85B5E4EA6CDE48a08156E8085FF445AA'>
+<DATAOBJ oid='1EE580AFF64F424d8DD011912FAF32E4' temploid='AC51A68F787C48b9BB32AB2CC35E3CFC' spec='no' dtref='_000001B1ADB64FE0'>
+<NAME>
+<TUV xml:lang='en-US'>EventWindowTime</TUV>
+</NAME>
+<QUAL>EventWindowTime</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</POS>
+<NEG oid='008950987AC940a6AA8F89D51FB553CC' temploid='0C60BF8F8C8F461eACDF72837FC6550A'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE2C7F0' oid='461DD67AFE774e0dA6B10BE16EC9D740' temploid='F94945DB4376427d81A2D8F3CC65BB90' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE29150' oid='7C09F341BC884597825010430F20316C' temploid='2FABAA9601BC4a2f909B217B435C68D9' must='1' spec='sid' bl='8' v='134'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2A1F0' oid='607B3ACE3FC847519C7051427248873A' temploid='592CC333125E44388C3F78A20EAE5C7B' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF142E0' oid='DF3ED08127B44d5cABE45A4F22BE5E8D' temploid='589350F28CDD422090D60D2888E2CF7D' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($87) LinkControl - Transition baudrate</TUV>
+</NAME>
+<QUAL>_87_LinkControl_Transition_baudrate</QUAL>
+<REQ oid='B33EA8CBA4674ab78DAA7758C37CE758' temploid='06BEE3F9997D444287B5384D9A66CB47'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE2B160' oid='3C901AFD6E744d988EE278D0A1CA98BF' temploid='8E67DD26E64F4631920E56745C1982DE' must='1' spec='sid' bl='8' v='135'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2B9B0' oid='CCB5926B178548328C2A6CA1E265D0A2' temploid='91FFEC78470942ba88C0AD497AE95C91' must='1' spec='sub' bl='8' v='3' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>linkControlType</TUV>
+</NAME>
+<QUAL>linkControlType</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='08E534398E4A4b4b8BEF8DAC4039B1C6' temploid='474E7075DCC4446dA8A78C2F8F03ADCA'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2CF10' oid='CF5CA872DFCC495e85B616F2A2B8AF5A' temploid='8DCBECA3DACF42baA359E76AC1696472' must='1' spec='sid' bl='8' v='199'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2ACA0' oid='0538C6F83D134ad7B7FB3767B187B565' temploid='69A3D763C22C458f9B6CD9C8B90704F6' must='1' spec='sub' bl='8' v='3'>
+<NAME>
+<TUV xml:lang='en-US'>linkControlType</TUV>
+</NAME>
+<QUAL>linkControlType</QUAL>
+</CONSTCOMP>
+</POS>
+<NEG oid='9CCD7FD55B3A41218AC236127C78A588' temploid='6ABBFBA4BEC84790890B4AD385E9F516'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE2A320' oid='26557548692F486fACE84338F0241718' temploid='28116BBEC662466e93DD89FBBE6D5654' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2ADD0' oid='738D868736E049648C25F1C2F696414D' temploid='88606135759B4ffcA371AA600C0E1ABD' must='1' spec='sid' bl='8' v='135'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2AF00' oid='277C7EDE24814df1A2694450A88A4BF9' temploid='4699A4C4411C498d823232BC36608A2C' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF15960' oid='10567D6FCE114f7093F5E5F7695E427C' temploid='847EA850E7CB4f06B44F5616D4D5D060' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($87) LinkControl - Verify with fixed baudrate</TUV>
+</NAME>
+<QUAL>_87_LinkControl_Verify_with_fixed_baudrate</QUAL>
+<REQ oid='BC9D10BFFE5948208B141C23D22BAAFE' temploid='8826184FB56843238952B3A0E4270493'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE2B290' oid='894489CF735E4be38135221EC1C2523F' temploid='73698A29AA0E4c7f9C0C3B94BF882CAA' must='1' spec='sid' bl='8' v='135'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2BE70' oid='07F4FBFC2F5442a8AF6405FD30337805' temploid='79574C84FC78440aB5A07CEFB11437E9' must='1' spec='sub' bl='8' v='1' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>linkControlType</TUV>
+</NAME>
+<QUAL>linkControlType</QUAL>
+</CONSTCOMP>
+<CONTENTCOMP id='_000001B1AD92D920' oid='5A4E714DEB75438c88EFA0E22015FA92' temploid='5AB9986D1FB44ceaB34F7A7FE159FAB1' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>baudrateIdentifier</TUV>
+</NAME>
+<QUAL>baudrateIdentifier</QUAL>
+<SIMPLECOMPCONT oid='05FD7050765A4959A0493C3A4D643C15' temploid='28E3982A994A494097B4F583587CCCBE'>
+<DATAOBJ oid='2E6DBCC879A44fbf806DB37359DE0D69' temploid='5419AE45CE8D4f09AA5C444FCA3342DF' spec='no' dtref='_000001B1ADB65960'>
+<NAME>
+<TUV xml:lang='en-US'>baudrateIdentifier</TUV>
+</NAME>
+<QUAL>baudrateIdentifier</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</REQ>
+<POS oid='5FF91ADC792244f3A6ECE54A65D9026A' temploid='9C83F11192E7483bAA6A1654EB3D595E'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2B3C0' oid='6367041A4C524eab934F9EDCE7F7E718' temploid='440423FA702649508B3E0C0B7D99AE06' must='1' spec='sid' bl='8' v='199'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2BD40' oid='0B942161BF634bf1945DE5901A43B4B1' temploid='357BA190E76F49f6A6BB7C8BB9359993' must='1' spec='sub' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>linkControlType</TUV>
+</NAME>
+<QUAL>linkControlType</QUAL>
+</CONSTCOMP>
+</POS>
+<NEG oid='11EF30E4E82F489f84E6C43FA0B3AA32' temploid='AF6596B8DC4A4a22AC8F767214DEF2D5'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE2BFA0' oid='E56CDFA1886A414c9BB5A7C08FE32447' temploid='A5CA8AAD067C42659085EBE357EB9100' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2C0D0' oid='2B9F42C815A14ef6A7C0B60E81ACEA6A' temploid='25C26D1AD8D146be940B4CAB61C2070E' must='1' spec='sid' bl='8' v='135'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2C460' oid='9287D3FA1A9648758E0F1095BA1B841D' temploid='465EAD21D0F646deB54619C84C7B37DB' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF15BA0' oid='4389DAB012AE4854BAEFD27250A243CB' temploid='B5A2E7D8B2AB4b87B76234C829A46EA0' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($87) LinkControl - Verify with specific baudrate</TUV>
+</NAME>
+<QUAL>_87_LinkControl_Verify_with_specific_baudrate</QUAL>
+<REQ oid='4017B9CA2A3442ff9427A4C0D2A3C451' temploid='F5EEBC3EEA8B4f2eA3BC4E8A16A422BB'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE2D040' oid='29C328D17EA4473dA5C930A0997385F8' temploid='3E227A8825814f6f94DE6DE36133124F' must='1' spec='sid' bl='8' v='135'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2D170' oid='8957B5952DFB4e1eA7E32363BA8886BF' temploid='480236B3179949a5BA18CFFBC60F3B4F' must='1' spec='sub' bl='8' v='2' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>linkControlType]</TUV>
+</NAME>
+<QUAL>linkControlType</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2D3D0' oid='DBD4ECDF15454b5d95D492FC1231AD57' temploid='7AA27189AAC84d8a9E4640D6C62AFE7A' must='1' dest='data' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>linkRecord</TUV>
+</NAME>
+<QUAL>linkRecord</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='C29CB8ADE5DC45679EB618958BBBC224' temploid='E065ED703ADD4053AAE5458465C152B1'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2D500' oid='A8D82920D33F466c9F6F66C30589CCC2' temploid='6F82B61695A049e98199EB74EAE61C60' must='1' spec='sid' bl='8' v='199'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE28DC0' oid='BB1C898E36B947aa81EC7AC3D9B90472' temploid='495210F212D44a13B0BFE58A1286DB0A' must='1' spec='sub' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>linkControlType</TUV>
+</NAME>
+<QUAL>linkControlType</QUAL>
+</CONSTCOMP>
+</POS>
+<NEG oid='BE5CBD0829A34c2bB9B204D1674249EF' temploid='F5F03896A5064f43990BDEBAFCACEB73'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE2F180' oid='2D7234C40A74477c8592F86460CE8244' temploid='35AB213D494249ebA7D77A8F6BCA20A6' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE312C0' oid='104761592A9244faB651A936092D8CFC' temploid='58D3AD7D92A14983A8B52F5C9E3F62F0' must='1' spec='sid' bl='8' v='135'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2E340' oid='6BE9928FE5E44c35A498876FB8BC094F' temploid='480B5099078F4d618DDEAAAFE2585F8E' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF14520' oid='6E09DC02D37C43d5859C74A0385599F6' temploid='1195918252C849b19BBA4A7D5B5876D3' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($28) CommunicationControl - EnhancedAddressInformation</TUV>
+</NAME>
+<QUAL>_28_CommunicationControl_EnhancedAddressInformation</QUAL>
+<REQ oid='508BE52F611745efA8AD9D9358E30EBE' temploid='144572939C3D426f9E0D61216A7476C6'>
+<NAME>
+<TUV xml:lang='en-US'>CC-RQ</TUV>
+</NAME>
+<QUAL>CC_RQ</QUAL>
+<CONSTCOMP id='_000001B1AFE2F510' oid='C2738E1D7D55435c975C5A30F626B383' temploid='BA3F313CBB06446f8086AC8902CE051E' must='1' spec='sid' bl='8' v='40'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE308C0' oid='A4A1682FCEC34c8eAB30F1ED78A9A0F4' temploid='02F36EB478514c88AA27B3FFD89783DD' must='1' spec='sub' dtref='_000001B1ADBDEF40' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>ControlType</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2F2B0' oid='262C68246CB14e7fB445875D02E7BC7B' temploid='952CDC58752244adB0A4FFA458B7143E' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>CommunicationType</TUV>
+</NAME>
+<QUAL>CommunicationType</QUAL>
+</SIMPLEPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2F3E0' oid='9401BFB7A2344d4fBBB55262BAF5430E' temploid='807D8EA8FE954a47A0E1FB030C2C5CA2' must='1' dest='data' minbl='16' maxbl='16'>
+<NAME>
+<TUV xml:lang='en-US'>NodeIdentificationNumber</TUV>
+</NAME>
+<QUAL>NodeIdentificationNumber</QUAL>
+</SIMPLEPROXYCOMP>
+</REQ>
+<POS oid='86C2EDBB360543c7A1529EEC56A69EC2' temploid='CFA1615D05D84757B46423B065C0D658'>
+<NAME>
+<TUV xml:lang='en-US'>CC-PR</TUV>
+</NAME>
+<QUAL>CC_PR</QUAL>
+<CONSTCOMP id='_000001B1AFE31D70' oid='CB481DA0A4E341a7B946D97AF8E66599' temploid='DA7960E8853449f3A216EE7B091B4811' must='1' spec='sid' bl='8' v='104'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33DE0' oid='9A6508E5410B4fd188D0D9D7745A8D59' temploid='DB329E94A8EC46b299E166405923E3B1' must='1' spec='sub' dtref='_000001B1ADBDEF40'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>ControlType</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='9E9CE366E9644e3d96D888F5C00E62C4' temploid='FA1CBFDE3633466098C7F182856769ED'>
+<NAME>
+<TUV xml:lang='en-US'>CC-NR</TUV>
+</NAME>
+<QUAL>CC_NR</QUAL>
+<CONSTCOMP id='_000001B1AFE31190' oid='F0EA3F9566B54ca0854A5F0B54CA4F30' temploid='7A23A44999E7410dB3B0F1B056E1679E' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2FC30' oid='F73802C8E06D49bfAE102F25A871A47C' temploid='75BD92A405B7455684BD46F5848A1BFB' must='1' spec='sid' bl='8' v='40'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2E210' oid='C98D692D532E4a4cAFEFB0BC6921A81C' temploid='EC61C870E9FB459aBF3125CF0C60BC93' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF178E0' oid='23E4BB19F1E14df8A29BC01DF2203D00' temploid='BD1C7F33FC24404496693B82298692B3' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($01) RequestCurrentPowertrainDiagnosticData - ReadPIDData</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of the service, RequestCurrentPowertrainDiagnosticData ($01), is to provide access to emission-related data values, including analog inputs and outputs, digital inputs and outputs, and system status information. It is required to retrieve the supported PIDs as well as to retrieved the actual data.
+Note, it is possible to send up to six PID requests in one request message.</TUV>
+</DESC>
+<QUAL>_01_RequestCurrentPowertrainDiagnosticData_ReadPIDData</QUAL>
+<REQ oid='4FFFF1BDDD154ad2926DF405455E6E5B' temploid='F49AB26CC50E4ccaB2F1F9C1C15B5572'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE31650' oid='FC4630CD4D8C4d878F4464C64CD8C1A4' temploid='48A3C95DEDE34579911D2E8C4866B885' must='1' spec='sid' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33450' oid='BC0C56E7476342cf98EB27B6069072AC' temploid='0318BE0E7A824c2dB737C71FFBAAD0D1' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The PIDs $00, $20, $40, $60, $80, $A0, $C0, $E0 result in a response that contains the supported PIDs in the respective range (e.g. $40 -&#62; response describes the PIDs in range $41-$60.
+Note, in this case one PID is mandatory and at most 6 PIDs are allowed.
+Each other PID results in a response that contains the corresponding PID data (e.g. $14 -&#62; response has two bytes the Bank1-Sensor1 Oxygen Sensor Output Voltage and Short-Term Fuel Trim).
+Note, in this case also one PID is mandatory and at most 6 PIDs are allowed.</TUV>
+</DESC>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='7EE4109E258943409FA1BB27F164FD16' temploid='E945BFD1516E4c03BBC3201B36E583A9'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE31520' oid='4D7D6DBDA46F4ecdA16939CD6EC2D563' temploid='95C892AEEA2A41ce88271B35F06FE9F9' must='1' spec='sid' bl='8' v='65'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE30E10' oid='6F5E90AEBB234c258ABA5AB6B62E0EB4' temploid='D61BEBA58B6D442c84EF7656788A0570' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The response contains either an echo of the range PID or an echo of the supported PID for which data were requested.</TUV>
+</DESC>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE30A70' oid='D082E9F1078C4ece9A739B39D1265810' temploid='BB9F95E214924f5aB97B0C2AE6E142F3' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Supported PIDs or PID Data</TUV>
+</NAME>
+<QUAL>Supported_PIDs_or_PID_Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1ADF15DE0' oid='425862A6AD22451bA226D609461DFCB2' temploid='6ACB55037E1848caBA6CAB9412A73004' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($01) RequestCurrentPowertrainDiagnosticData - ReadSupportedPIDs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of the service, RequestCurrentPowertrainDiagnosticData ($01), is to provide access to emission-related data values, including analog inputs and outputs, digital inputs and outputs, and system status information. It is required to retrieve the supported PIDs as well as to retrieved the actual data.
+Note, it is possible to send up to six PID requests in one request message.</TUV>
+</DESC>
+<QUAL>_01_RequestCurrentPowertrainDiagnosticData_ReadSupportedPIDs</QUAL>
+<REQ oid='95531ACE0AD9469e98540514B3198C84' temploid='0D063F62E60C415f97ADBBECFFE18618'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE313F0' oid='FB9E82566F284e4f849C01009A4095B1' temploid='9D93FE2A2A394b1d8936A17BD4EA0533' must='1' spec='sid' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33230' oid='9AB862871C654c98A2E0B5EE8A722027' temploid='0FDED227B60B4d65B001EA13D7DEEE74' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The PIDs $00, $20, $40, $60, $80, $A0, $C0, $E0 result in a response that contains the supported PIDs in the respective range (e.g. $40 -&#62; response describes the PIDs in range $41-$60.
+Note, in this case one PID is mandatory and at most 6 PIDs are allowed.
+Each other PID results in a response that contains the corresponding PID data (e.g. $14 -&#62; response has two bytes the Bank1-Sensor1 Oxygen Sensor Output Voltage and Short-Term Fuel Trim).
+Note, in this case also one PID is mandatory and at most 6 PIDs are allowed.</TUV>
+</DESC>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='23C4748FB2654777A179222CD3F40A41' temploid='E056792A82584895AA1841E3B35507A7'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2EB90' oid='31CD49BA6CE4468d9E11FDDFFC7F20EF' temploid='12B7AED689244ea7985AAE15BD8124AE' must='1' spec='sid' bl='8' v='65'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32240' oid='DDC77D5B4DB94a85A71D5BEE07FDF95B' temploid='FFD0008165934a8eB1FAE23BA4E3A722' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The response contains either an echo of the range PID or an echo of the supported PID for which data were requested.</TUV>
+</DESC>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE32360' oid='52E13FADF04742dbBD4916C6935564DB' temploid='816908946EAF48b1BEB8D48765351E81' must='1' dest='data' minbl='32' maxbl='32'>
+<NAME>
+<TUV xml:lang='en-US'>Supported PIDs or PID Data</TUV>
+</NAME>
+<QUAL>Supported_PIDs_or_PID_Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7A2B0' oid='D755DA77048A4197AB0D95A8C806DD99' temploid='7A2C8ABAA3E145d797CD456EAC9797C0' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($02) RequestPowertrainFreezeFrameData - ReadPIDData</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of the service, RequestPowertrainFreezeFrameData ($02), is to provide access to emission-related data values in a freeze frame.
+Note, it is possible to send up to six PID requests in one request message.</TUV>
+</DESC>
+<QUAL>_02_RequestPowertrainFreezeFrameData_ReadPIDData</QUAL>
+<REQ oid='D0472080A56349279ECD4E1C3579A8D9' temploid='247CCD87AEAF4ecdBC5C4D4A43D0CE08'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE2EDF0' oid='BDB942FCA0F34b5b944A316D31769A79' temploid='6574C7E8A7884ef29F713B09DBE21D28' must='1' spec='sid' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33CD0' oid='23927019EC494937B22470CC36D19EA2' temploid='CAC9A3190EFA43b0AFEF80FDC890D60F' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The PIDs $00, $20, $40, $60, $80, $A0, $C0, $E0 result in a response that contains the supported PIDs in the respective range for a specific Freeze Frame (e.g. $40 -&#62; response describes the PIDs in range $41-$60.
+Note, in this case one PID is mandatory and at most 3 PIDs are allowed.
+Each other PID results in a response that contains the corresponding PID data for specific Freeze Frame (e.g. $14 -&#62; response has two bytes the Bank1-Sensor1 Oxygen Sensor Output Voltage and Short-Term Fuel Trim).
+Note, in this case one PID is mandatory and at most 3 PIDs are allowed.</TUV>
+</DESC>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1AFE32100' oid='539039ADBC1345f4B81FCCAE8CC8D943' temploid='D82709E3E88B40d18BB74CCA80AB105B' must='1' spec='id' bl='8' v='0'>
+<NAME>
+<TUV xml:lang='en-US'>FrameNumber</TUV>
+</NAME>
+<QUAL>FrameNumber</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='35B68AC6E0CE4d04A85360B71090B8A2' temploid='29BB908B2CDA430bBB3DE296D43976E6'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2EA60' oid='EAB2328CE51243ab95629CC92A9A73FA' temploid='074E470554184ed1990F3C9CFB530812' must='1' spec='sid' bl='8' v='66'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32790' oid='E3191DE55A054b92B98071EA0055619D' temploid='D0E87B76148847aaA42D21859482638E' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The response contains either the supported PIDs for the requested PID range or the PID data for a requested PID - in respect of the Freeze Frame.</TUV>
+</DESC>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1AFE2DFB0' oid='44B052CEE4A84dd79EFD3DE55E4A7F62' temploid='9F7EF2E4292245a6AB1CFACE86CA9CCD' must='1' spec='id' bl='8' v='0'>
+<NAME>
+<TUV xml:lang='en-US'>FrameNumber</TUV>
+</NAME>
+<QUAL>FrameNumber</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2ECC0' oid='A16050D4D6C74caaB5CDBD263D9A8E81' temploid='B92FF6AD4BB647d98A7B3B9D59C8B8A2' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Supported PIDs or PID Data</TUV>
+</NAME>
+<QUAL>Supported_PIDs_or_PID_Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7B930' oid='5AE17697D4D0432bB379D13B934F20F7' temploid='56F5122E3ABE4783B6360C4DECD2BE70' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($02) RequestPowertrainFreezeFrameData - ReadSupportedPIDs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of the service, RequestPowertrainFreezeFrameData ($02), is to provide access to emission-related data values in a freeze frame.
+Note, it is possible to send up to six PID requests in one request message.</TUV>
+</DESC>
+<QUAL>_02_RequestPowertrainFreezeFrameData_ReadSupportedPIDs</QUAL>
+<REQ oid='5FB07C02FADA44449CD38341562ED2DE' temploid='487EEB70476D491dBEDA9E8F78A77C17'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE31FD0' oid='FE37DEF758514e4e8B7C209959BCA07E' temploid='340CC3B828F54357968F0EE94000A9E9' must='1' spec='sid' bl='8' v='2'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32F00' oid='59D310A8618C4523A53B585FCB22254D' temploid='8F8DA4D8856043d1BEB62396CB09896C' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The PIDs $00, $20, $40, $60, $80, $A0, $C0, $E0 result in a response that contains the supported PIDs in the respective range for a specific Freeze Frame (e.g. $40 -&#62; response describes the PIDs in range $41-$60.
+Note, in this case one PID is mandatory and at most 3 PIDs are allowed.
+Each other PID results in a response that contains the corresponding PID data for specific Freeze Frame (e.g. $14 -&#62; response has two bytes the Bank1-Sensor1 Oxygen Sensor Output Voltage and Short-Term Fuel Trim).
+Note, in this case one PID is mandatory and at most 3 PIDs are allowed.</TUV>
+</DESC>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1AFE2F8A0' oid='109A69B85C6240d2B771B6DDDA217CD6' temploid='A87C844016344b3489AE26F4138B643B' must='1' spec='id' bl='8' v='0'>
+<NAME>
+<TUV xml:lang='en-US'>FrameNumber</TUV>
+</NAME>
+<QUAL>FrameNumber</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='3A7465B885724ef7AE5C22D78331B33D' temploid='B2078C5AEF0A42a5B4F388B0A9DDC27C'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2E470' oid='5CA8BAFBD5BE4acf8F8B7CE23B782986' temploid='47AF82D7C59245eeB81A35B9A039320C' must='1' spec='sid' bl='8' v='66'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE32350' oid='EFFA3AC10ED4409485A3A9A391CE8DF4' temploid='60DD6DDEFF66414e92B60A97AE4C4049' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The response contains either the supported PIDs for the requested PID range or the PID data for a requested PID - in respect of the Freeze Frame.</TUV>
+</DESC>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+<CONSTCOMP id='_000001B1AFE31780' oid='951D1CBF74C74dd5884E48085B1E7168' temploid='270267D7003B42deB0151E21B31FC68F' must='1' spec='id' bl='8' v='0'>
+<NAME>
+<TUV xml:lang='en-US'>FrameNumber</TUV>
+</NAME>
+<QUAL>FrameNumber</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE318B0' oid='3AB92AEA6CA44d50A996A7261ADCA4A9' temploid='E9C3AC1504294675A4839A1292F32051' must='1' dest='data' minbl='32' maxbl='32'>
+<NAME>
+<TUV xml:lang='en-US'>Supported PIDs or PID Data</TUV>
+</NAME>
+<QUAL>Supported_PIDs_or_PID_Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7ADF0' oid='C591ACAF97784e06895E52BE665FA278' temploid='4983D81190974be0837B586CB3E2B6E3' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($03) RequestEmissionRelatedPowertrainDTCs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of the service is to enable external test equipment to obtain stored emission-related powertrain DTCs</TUV>
+</DESC>
+<QUAL>_03_RequestEmissionRelatedPowertrainDTCs</QUAL>
+<REQ oid='3DBFD6FCE8AA4c90AF68B1C7F296DDAA' temploid='15E4A14FB1574ca2BB334FAA08EBF9A7'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE2F640' oid='2FFDBF531AE348a888CDCE17F04865EB' temploid='12BB6B10DB974826806716D44AD18986' must='1' spec='sid' bl='8' v='3'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='DDCA0F50AC834dce928C55747AD87057' temploid='B0B92B05878A426bA055B3B69F7AFE37'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2F770' oid='D72FD8057E484ad6AF15A37384B9117A' temploid='EC3F04B7FD3E4ea8851BC0BAC5E53A48' must='1' spec='sid' bl='8' v='67'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2EF20' oid='E4C25D83516E460e9D16CB9BB35209AD' temploid='0123FD4EBC334e9eB1F926A1C5C24AA8' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Number Of DTC</TUV>
+</NAME>
+<QUAL>Number_Of_DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<NUMITERCOMP id='_000001B1ADA6D940' oid='1A13E5A384DC4751933413772D4A9565' temploid='88A6E43B8BB946d39AF22C848A86DDED' must='1' selref='_000001B1AFE2EF20' selbm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>List of DTC and DTC Status</TUV>
+</NAME>
+<QUAL>List_of_DTC_and_DTC_Status</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1AFE319E0' oid='708EA3AF6A9E4cdbA3F541C1FB6E048D' temploid='20F73BF8F0BE4bcaA05CFD3095FC5A06' must='1' dest='obdDtc' minbl='16' maxbl='16'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+</NUMITERCOMP>
+</POS>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7C470' oid='58A431AC01C04eed8A04A5ABAECA8885' temploid='F65D744749824bc7A254351D62766D50' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($04) ClearEmissionRelatedDiagInfo</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of the service, ClearEmissionRelatedDiagInfo ($04), is to provide a means for the external test equipment to command ECUs to clear all emission-related diagnostic information.</TUV>
+</DESC>
+<QUAL>_04_ClearEmissionRelatedDiagInfo</QUAL>
+<REQ oid='4807ED763D8F4eb2BE906ACB587D9635' temploid='89743E21BA80458eBEC971225ED2E12B'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE2F9D0' oid='AD975B69CFA54b8b895F6D73F8DA2DB4' temploid='AEB92E1F91244c189041A5513AEB4773' must='1' spec='sid' bl='8' v='4'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='D46E8F966C2C4b6a9DE4BA22CBA1D320' temploid='A1F28688EA0A4e929D27B4836EEDAB12'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE30BA0' oid='AAD9FEFD504B4084AC2A7862547334D8' temploid='0F0865994C8C4c59953879386EB9CB21' must='1' spec='sid' bl='8' v='68'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+</POS>
+<NEG oid='C961733EE42C44ecB4834F1220B5F465' temploid='6FF4C4ABB5784f64905590C4879EE58F'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE2F050' oid='6892550FAE27469e917BAEF889186637' temploid='CD5477A6D1E24ab7B82D38FA1F97732E' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2D9C0' oid='FD1AA316C6DB43e2BDA6BAF1D1416018' temploid='2BD1EC68B1534dba85F328A27841EFAE' must='1' spec='sid' bl='8' v='4'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2FB00' oid='E9F05AC2A1A54c65968E000CDD615B9B' temploid='B8BD89520B444c7490AF10D01F6F98CE' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7CD70' oid='7FF6817107AE4653A1587A08B3CEE36A' temploid='C7B62D0269E5484d9732FEFFF1C09A3C' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($06) RequestOnboardMonitoringTestResult - ReadOBDMIDData</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of this service is to provide access to the results for on-board diagnostic monitoring tests of specific components/systems that are continuously monitored (e.g. misfire monitoring) and non-continuously monitored (e.g. catalyst systems).</TUV>
+</DESC>
+<QUAL>_06_RequestOnboardMonitoringTestResult_ReadOBDMIDData</QUAL>
+<REQ oid='9113E4ED567E40db9EB2193B8B7D444E' temploid='A4240AC9D40B4b1bB1963ECF312B4E9B'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE2E5A0' oid='F45B91BFAD1F44e59A11F4DF8F5A7838' temploid='1D15E0C44E1942b0BCC52C66C0CAC9A7' must='1' spec='sid' bl='8' v='6'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33120' oid='F4E8B3D7176A4883B5732C4FC9CF394B' temploid='5105A5B12CF24d6b9DF5EB10AA9433A1' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The OBDMIDs $00, $20, $40, $60, $80, $A0, $C0, $E0 result in a response that contains the supported OBDMIDs in the respective range. (e.g. $40 -&#62; response describes the PIDs in range $41-$60.
+Note, in this case one OBDMID is mandatory and at most 6 OBDMIDs are allowed.
+Each other OBDMID results in a response that contains the corresponding OBDMID data (e.g. $03 -&#62; response contains info about Oxygen Sensor Monitor Bank1-Sensor3).
+Note, in this case exactly 1 OBDMID is required/allowed.</TUV>
+</DESC>
+<QUAL>OBDMID</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='C3EE3DE8D2504c9dA29FC0D4D1D1454F' temploid='2CE254CA433E4164B8AFFBB186FEAC68'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2E930' oid='BEE680BA11B24a1dB2B427C733F3C0A4' temploid='1E08D430179248969C5CDD26820E9CC9' must='1' spec='sid' bl='8' v='70'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33890' oid='88EBECD48BD84602B840DB6EB06FE5B8' temploid='32A6CB24CFA94efe88D476B4A122F4BD' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Request's OBDMID echo</TUV>
+</DESC>
+<QUAL>OBDMID</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2E6D0' oid='3FC46A5DE6864d65A0E11BB9A9C55E94' temploid='A1DF66B5967B4a8dBE21B488DA9DD513' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The response contains either the supported OBDMIDs for the requested OBDMID range (in case of a request with the OBDMIDs $00, $20, $40, ...) or the Test ID value structures for the supported TIDs (in case of a request with the OBDMIDs $01, $02, ...).</TUV>
+</DESC>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7A730' oid='1639C6AFAD6B471eBA75334B01289886' temploid='BF66C35CE5FA42219718A47DFA87C3E6' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($06) RequestOnboardMonitoringTestResult - ReadSupportedOBDMID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of this service is to provide access to the results for on-board diagnostic monitoring tests of specific components/systems that are continuously monitored (e.g. misfire monitoring) and non-continuously monitored (e.g. catalyst systems).</TUV>
+</DESC>
+<QUAL>_06_RequestOnboardMonitoringTestResult_ReadSupportedOBDMID</QUAL>
+<REQ oid='CA2BAE40397B4fef8386EE52FD6B6D24' temploid='9BB7D0DDEDE34ebf96366626FC603432'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE31B10' oid='E8154654EA0D4ad89D5649849DA0DD71' temploid='26C34875006247219CE003F023E439ED' must='1' spec='sid' bl='8' v='6'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33560' oid='9DC7B0876AAF4c54AF5DA5664AB39B9D' temploid='64D93A3C4C274e748E2A47F844AF6117' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The OBDMIDs $00, $20, $40, $60, $80, $A0, $C0, $E0 result in a response that contains the supported OBDMIDs in the respective range. (e.g. $40 -&#62; response describes the PIDs in range $41-$60.
+Note, in this case one OBDMID is mandatory and at most 6 OBDMIDs are allowed.
+Each other OBDMID results in a response that contains the corresponding OBDMID data (e.g. $03 -&#62; response contains info about Oxygen Sensor Monitor Bank1-Sensor3).
+Note, in this case exactly 1 OBDMID is required/allowed.</TUV>
+</DESC>
+<QUAL>OBDMID</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='53BEC3E1182440459494DE59F45CFEC8' temploid='5C73142DDC9549f38380A9D8199CB26B'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2D890' oid='585BFDE47F9D4bd0A54D7BB7F794C48D' temploid='6E3447054A7E45f297FF7B92E16142BE' must='1' spec='sid' bl='8' v='70'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33670' oid='8A745A2AD9A14da9BF2987C4943A1BF0' temploid='E6122688D5614ff085B41AAAAB2F3709' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Request's OBDMID echo</TUV>
+</DESC>
+<QUAL>OBDMID</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2E0E0' oid='5E86780D19414bbe988A1A74C3DEB730' temploid='AC10209346F242c2A86C848BBBE2133C' must='1' dest='data' minbl='32' maxbl='32'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The response contains either the supported OBDMIDs for the requested OBDMID range (in case of a request with the OBDMIDs $00, $20, $40, ...) or the Test ID value structures for the supported TIDs (in case of a request with the OBDMIDs $01, $02, ...).</TUV>
+</DESC>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7A070' oid='286E0608E6FF4c87A894553C999BD156' temploid='09DCB37CE7054cb8BF75D69EC4D871AC' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($07) RequestEmissionRelatedDTCsDetectedDuringCurrentOrLastCompletedCycle</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of this service is to enable the external test equipment to obtain "pending" diagnostic trouble codes detected during current or last completed driving cycle for emission-related components / systems that are tested or continuously monitored during normal driving conditions (assist service technician after a vehicle repair, and after clearing diagnostic information, by reporting test results after a single driving cycle)</TUV>
+</DESC>
+<QUAL>_07_RequestEmissionDTCsDetectedDuringCurrentOrLastCompletedCycle</QUAL>
+<REQ oid='00D6B446AB0840428C7BC040C7F59900' temploid='429A92EE17E14277AC6FBD15DE760230'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE2FD60' oid='736C33A289AB40a8A46BB15E72B6FF3B' temploid='AFB18F1961D648f2A9277431CB5AFC13' must='1' spec='sid' bl='8' v='7'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='0AED42D86B6645f48A8CD561690374CB' temploid='110D769B0D6342b783CDAB4799CE9B76'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2DE80' oid='E2393262C3E54263BDBA518C58440891' temploid='4C80745146344f5eAA0C11D5D013109F' must='1' spec='sid' bl='8' v='71'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2FE90' oid='BAE0EEC78DC24e42AAFB916F99323A4C' temploid='9006DCC1E48F415aB0006754584F02E1' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Number of DTC</TUV>
+</NAME>
+<QUAL>Number_of_DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<NUMITERCOMP id='_000001B1ADA6D880' oid='B141680C596349fd9197402DAB306E67' temploid='4FDEC626EB5644668363B75A9DEE36AB' must='1' selref='_000001B1AFE2FE90' selbm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>List of DTC and DTC Status</TUV>
+</NAME>
+<QUAL>List_of_DTC_and_DTC_Status</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1AFE30940' oid='3120597ECDE641bfA3412163F41145E7' temploid='6FCA1E26A3734c04945D05803A2E712C' must='1' dest='obdDtc' minbl='16' maxbl='16'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+</NUMITERCOMP>
+</POS>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7ABB0' oid='F4C570E83172472aA7D7B76481548A1A' temploid='E313A19A06C84770B4994125E447223F' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($08) RequestControlOfOnBoardSystemTestOrComponent - ControlTID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of this service is to enable external test equipment to control the operation of an on-board system, test or component. This specific sub-service is responsible for transferring the TID data of the supported TIDs. This sub-service allows all TIDs, except of $00, $20, $40, $60, ....</TUV>
+</DESC>
+<QUAL>_08_RequestControlOfOnBoardSystemTestOrComponent_ControlTID</QUAL>
+<REQ oid='62FB6DAACEFA4a7cAEB97387253751DE' temploid='EDD37B0AA2AC4fbcA6BCC590CA25CDB7'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE2DAF0' oid='86723ADAFDD349ff9D167A32145637F8' temploid='CA6450A8618B4007A8C8FF36B10F1A61' must='1' spec='sid' bl='8' v='8'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE339A0' oid='F72692E4939F40e1B300D09881613CA5' temploid='9D3F92662F1E4732B9019F9F68D7EC60' must='1' spec='tid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>TID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Specifies the TID for which the TID data shall be transferred.</TUV>
+</DESC>
+<QUAL>TID_SPEC</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='93655C5589AC41bfB818291968679A3E' temploid='D3301102493745b9932D754AC6100441'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE31060' oid='CC94C8EEEEA34be7B0E6CB71DE63678D' temploid='215C10C357324f9dA9458FE7778524AA' must='1' spec='sid' bl='8' v='72'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33AB0' oid='35D12902A8F147ca9BACD8016852A905' temploid='7B4D5E67E7D9471eA5A186D65A5D2490' must='1' spec='tid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>TID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Specifies the TID for which the TID data shall be transferred.</TUV>
+</DESC>
+<QUAL>TID_SPEC</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='96EB1AFF241E499bABE5C0F5CB418D23' temploid='89625D01D86548298749464FF082B014'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE31EA0' oid='D3E0522764E14ef0B4C1288E173A6527' temploid='0FBCC8B4A12D41de937E29BB2970A584' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE2DC20' oid='C947AD970C534bc6AE529F96F313FB5D' temploid='89309CC48ED94c27BA5038F89C285BA5' must='1' spec='sid' bl='8' v='8'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE30E00' oid='84B4A063CD834c85BFAAD7EE4DF7F460' temploid='8D08888F70B4470290CFB7CC53FDF0A4' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7CB30' oid='6FC2C7975F954e129FC5470B33644B8B' temploid='31B7EFD5336D495498090111295CDBDB' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($08) RequestControlOfOnBoardSystemTestOrComponent - ReadSupportedTIDs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of this service is to enable external test equipment to control the operation of an on-board system, test or component. This specific sub-service is responsible for reading the supported TIDs. This sub-service allows TIDs such as $00, $20, $40, $60, ....</TUV>
+</DESC>
+<QUAL>_08_RequestContrOfOnBoardSystemTestOrComponent_ReadSupportedTIDs</QUAL>
+<REQ oid='B6291292C696421a84C9640061646A3D' temploid='65E74EA53E254c59AFC97C1E0FFCB7F1'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE31C40' oid='762372478DE84d5bA5A2EDFE83D1CA89' temploid='A0F840F7527447de85A23F96160A0C37' must='1' spec='sid' bl='8' v='8'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE33EF0' oid='95CB6A0A9991492f9E015DDC04706B02' temploid='588DC6FDACA14658BE2719FF7EF067EB' must='1' spec='lid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>TID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Only the TIDs $00, $20, $40, $60, $80, $A0, $C0, $E0 are allowed in this sub-service. They result in a response that contains the supported TIDs in the respective range. (e.g. $40 -&#62; response describes the supported TIDs in range $41-$60.
+Note, in this case one TID is mandatory and at most 6 TIDs are allowed per request.</TUV>
+</DESC>
+<QUAL>TID</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='1F13731E0B334811980832F53BAE75D0' temploid='0C131945E8E3402596607716C3300D21'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE2FFC0' oid='F7F40D32E9484dc0A9B31BAB2BEA49E0' temploid='85C255FDF06541b69AB9B89B58906C7D' must='1' spec='sid' bl='8' v='72'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE30BF0' oid='57A115B73CC947d49C7AF8AD8B0CB89B' temploid='F543E58DCEC44dd0B935F945888D6100' must='1' spec='tid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>TID</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Request's TID echo.</TUV>
+</DESC>
+<QUAL>TID</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE300F0' oid='4F0755B5006E4250B824F1E7BB7A3078' temploid='C703AC2C987742e988E9B73BF1A2AF3E' must='1' dest='data' minbl='32' maxbl='32'>
+<NAME>
+<TUV xml:lang='en-US'>Supported TIDs</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>This sub-service response contains the supported TIDs for the specified TID range.</TUV>
+</DESC>
+<QUAL>Supported_TIDs</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='7D9480CB2A344fb890BAD57899851F78' temploid='0938998C61974216860C067BDCBCDD0A'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE2E800' oid='52C6200FC29D488bAB5B32A00C1D1382' temploid='E727D27F60244b8f8E293AA23CA46BCE' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE32230' oid='962D7B488E804117BDD8CA97B1AFD1A5' temploid='E219EB21A5A44329AEE570BA1C3F755F' must='1' spec='sid' bl='8' v='8'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE30220' oid='AE09629689454c9a8B65F5B42289E9AC' temploid='50AF5B4C981643138B9105240278130D' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7CFB0' oid='E696782875664d13B2ABD711C6AE8B3A' temploid='9C4ED9113A0A4b4e8966CEAAE9C44A9B' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($09) RequestVehicleInformation - ReadInfoTypeData</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of this service is to enable the external test equipment to request vehicle information such as "Vehicle Identification Number".</TUV>
+</DESC>
+<QUAL>_09_RequestVehicleInformation_ReadInfoTypeData</QUAL>
+<REQ oid='DEB3DC52DA874a20BB563D2391F53763' temploid='DB7D0DDF4AD74712A4830B463F2194F6'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE30350' oid='45A3DA0E4E634635AFE6F434BDB01B42' temploid='8F34C1894FBC44e5B0ECA9D8852C3998' must='1' spec='sid' bl='8' v='9'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE30F20' oid='10AE64C4532C4148BE69C6E470F2E0D6' temploid='6B6554AE70BB40dfBBFE361766E1A46D' must='1' spec='info' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>InfoType</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The InfoTypes $00, $20, $40, $60, $80, $A0, $C0, $E0 result in a response that contains the supported InfoTypes in the respective range (e.g. $40 -&#62; response describes the InfoTypes in range $41-$60.
+Note, in this case one InfoType is mandatory and at most 6 InfoTypes are allowed.
+Each other InfoType results in a response that contains the corresponding InfoType data.</TUV>
+</DESC>
+<QUAL>InfoType</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='6092A65988EE4380BD789F2DC08C29F0' temploid='2AFB5A086CE74abb956E0E1CCBEF494D'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE30CD0' oid='1A1CF17CD6084d0b8CFB2E8244BC1B81' temploid='756226ADA882445282140A15FCAF820C' must='1' spec='sid' bl='8' v='73'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2C7F0' oid='87D7BAE568964a13BAE95B74AF586D9C' temploid='AF7DFD986A764a18A0EEDC4A3E9A4131' must='1' spec='info' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>InfoType</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Echo of request InfoType.</TUV>
+</DESC>
+<QUAL>InfoType</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE2DD50' oid='AA76A277327941f693723CA6E8177C4C' temploid='A5225BCEB3704c0881A2919462905897' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>InfoTypeData</TUV>
+</NAME>
+<QUAL>InfoTypeData</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7DD30' oid='7F8250B9F967403dBD562DDFD775E459' temploid='B925A829EC164368805C0B33D5E296EB' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($09) RequestVehicleInformation - ReadSupportedInfoTypes</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of this service is to enable the external test equipment to request vehicle information such as "Vehicle Identification Number".</TUV>
+</DESC>
+<QUAL>_09_RequestVehicleInformation_ReadSupportedInfoTypes</QUAL>
+<REQ oid='0FB23440730848649C1CA018F9E69B2C' temploid='A2978C5BD4BE4e83BF7782B9301D7040'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE30480' oid='BEAE094A842F485493CBD17C38437BA7' temploid='FA5401DA6BF84811AC490A21030BCEAB' must='1' spec='sid' bl='8' v='9'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2F380' oid='6677C92593F0470483916C3092C9317A' temploid='8EC03EAAA9A043ddBD72EA4C695931A3' must='1' spec='info' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>InfoType</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The InfoTypes $00, $20, $40, $60, $80, $A0, $C0, $E0 result in a response that contains the supported InfoTypes in the respective range (e.g. $40 -&#62; response describes the InfoTypes in range $41-$60.
+Note, in this case one InfoType is mandatory and at most 6 InfoTypes are allowed.
+Each other InfoType results in a response that contains the corresponding InfoType data.</TUV>
+</DESC>
+<QUAL>InfoType</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='E202F2C207CF437dBF7EF7C6D8DAC676' temploid='26EF7FA505874fcf80DD1270396893AF'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE306E0' oid='3D00139AD9954a83B37E078A373319C5' temploid='9E504FC3F6B24e1e806846B668E4F057' must='1' spec='sid' bl='8' v='73'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2E170' oid='D8D744D97A434f6b9ADC6F2C1449CDFF' temploid='90A1292B986844f0B56303B560C80159' must='1' spec='info' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>InfoType</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>Echo of request InfoType.</TUV>
+</DESC>
+<QUAL>InfoType</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE30810' oid='3A7DFF519C27438f95B9963E1F551A2E' temploid='12C11CF518204782856BB8D4CF028B3E' must='1' dest='data' minbl='32' maxbl='32'>
+<NAME>
+<TUV xml:lang='en-US'>InfoTypeData</TUV>
+</NAME>
+<QUAL>InfoTypeData</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7B6F0' oid='E51F63408F9A4354920FB70B5BAA3AFC' temploid='863B3472F98A4d10A8DBD86470960E34' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($0A) Emission-Related DTC With Permanent Status</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>The purpose of this service is to enable the external test equipment to obtain all DTCs with "permanent DTC" status.
+These are DTCs that are "confirmed" and are retained in the non-volatile memory of the server until the appropriate monitor for each DTC has determined that the malfunction is no longer present and is not commanding the "MIL on" monitor for each DTC has determined that the malfunction is no longer present and is not commanding the "MIL on".</TUV>
+</DESC>
+<QUAL>_0A_Emission_Related_DTC_With_Permanent_Status</QUAL>
+<REQ oid='B900482FEA914b9e850C95F853182793' temploid='3B772547548744799AC4717557582BED'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE32A80' oid='EA60C42F24EE49cc9FFD5B6E132C41F6' temploid='2238E40D4B8B4a16842A16447102A9C7' must='1' spec='sid' bl='8' v='10'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='4CF395CAB997426d841358F7ACA1F6AE' temploid='038EB511F0FB424d806E62EEBAF66BDA'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE332D0' oid='4E4E7B83C8C448f4AE44288BE8E46460' temploid='8030D6BBE5D94b869DD4030055FE633C' must='1' spec='sid' bl='8' v='74'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE326F0' oid='44DB7B9289B349088B978742D202DDB2' temploid='C32B34A7ACB14b33BB10FABAEFCDD859' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Number of DTC</TUV>
+</NAME>
+<QUAL>Number_of_DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<NUMITERCOMP id='_000001B1ADA6DA00' oid='58D389B2976C4c5d9A726DE524E81588' temploid='709081CC60FA43efB430813C17220E0E' must='1' selref='_000001B1AFE326F0' selbm='4294967295'>
+<NAME>
+<TUV xml:lang='en-US'>List of DTCs with Permanent Status</TUV>
+</NAME>
+<QUAL>List_of_DTCs_with_Permanent_Status</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1AFE33400' oid='3915B89823674781AF566EB170CAC63B' temploid='291BD6A6F7FC4a318D9E98C98140770B' must='1' dest='obdDtc' minbl='16' maxbl='16'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+</NUMITERCOMP>
+</POS>
+<NEG oid='433B0A491E7644d9B127812FFF6E92AC' temploid='A706BE4C8A9A4ef58BC61E5B5DC29BEF'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE33660' oid='FF2A9D01D9184d9a944425F3F6A3B77E' temploid='6CECD5EBB3F9480d82DE6C4ACB7FAC34' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE33070' oid='16255435A3F744dd985CE71F4ABAD217' temploid='1A8AC3E05A11414fA54BD2B1A2C16C95' must='1' spec='sid' bl='8' v='10'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE33D80' oid='D039E9A902274ede9089A40EF1FD8397' temploid='04E94596A857433588452328FC447178' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7D430' oid='2FD7BACBDA3644d08616D86EF0A5D4ED' temploid='2A5926179BD740d4AECBADB877381EA4' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($22) ReadDataByIdentifier (Infotype)</TUV>
+</NAME>
+<QUAL>_22_ReadDataByIdentifier_Infotype</QUAL>
+<REQ oid='553B4A1A9FC2480b8F7F4C9E6C5B260D' temploid='88B7F4DBB5BC43a8B9C4EAC0DF7550A2'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE32E10' oid='E14D26BF936A49a585C06067C4AF2DEE' temploid='83B824FF3A4E4eee93434FBF2E7ED998' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE32950' oid='F47C08C091654e7495D1029C1F8643A8' temploid='C7E81D3B5D6F4b13A8948857B3B098E6' must='1' spec='id' bl='8' v='248'>
+<NAME>
+<TUV xml:lang='en-US'>Infotype_Prefix</TUV>
+</NAME>
+<QUAL>Infotype_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2CA10' oid='4F58EE816FE94a0bAF33AAC12F4A7B9C' temploid='19EF9E206BA34ae99EECB89091238E26' must='1' spec='info' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Infotype</TUV>
+</NAME>
+<QUAL>Infotype</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='EFFFC73B7C7F44669351BC5C97ED83AD' temploid='A65B472A17814b06BAFEBF76D79C1F64'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE32BB0' oid='317B97590B99488fAC68820B48BB33DC' temploid='CCFA1B7B56C5459bB9974964E4AE7F40' must='1' spec='sid' bl='8' v='98'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE33530' oid='B300A90D078A4ff6B395C185C355C393' temploid='43464410FC0847ca970BDE3E542AA53D' must='1' spec='id' bl='8' v='248'>
+<NAME>
+<TUV xml:lang='en-US'>Infotype_Prefix</TUV>
+</NAME>
+<QUAL>Infotype_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2C4C0' oid='4A5EDC3848184cb48697AF915D12FAB2' temploid='8D492FF35BD44366A3C91F4925867E2E' must='1' spec='info' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Infotype</TUV>
+</NAME>
+<QUAL>Infotype</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE32CE0' oid='C38742C3330F4f4595E4DDE7891BAF51' temploid='D326E59D9A9F485681A35078CB0A5FF4' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='BC914A45C29C4296891CFCE13C17E9DE' temploid='7FDD807D78164ce2BD5657455CF54C4A'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE32F40' oid='B48EEBE801964efdAC63E08288499465' temploid='1E5F26CC4AC44c7dAED4089224110962' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE33790' oid='2AFC046FC9CF4a8e872FFE323EC68C4F' temploid='D55A8835A7DD47efBA2D493A888B20D6' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE338C0' oid='AE50043F604742d699FEE465E5D03CB3' temploid='CF6781B18AB74fd399261859A82575BF' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7B030' oid='A578471CFEF748d1AE82FA6C3A25527B' temploid='81475D2B985B43349E7050788CBD6EE5' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($22) ReadDataByIdentifier (OBDMIDs)</TUV>
+</NAME>
+<QUAL>_22_ReadDataByIdentifier_OBDMIDs</QUAL>
+<REQ oid='F7D649E8AE064b8eBD5AC742B5DF7F43' temploid='501D7C8231E249338300C1DF6974EDE3'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE339F0' oid='3441A187B5284ca089428D85777C49E6' temploid='6B45E149CB094d3aB46760BABE131D30' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE331A0' oid='D596A20469CF4f0983DE53B8E106F1AE' temploid='DB498DC96F964c86873429C8C637336F' must='1' spec='id' bl='8' v='246'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID_Prefix</TUV>
+</NAME>
+<QUAL>OBDMID_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2F160' oid='D50CA338A94148539E30F93BCB832853' temploid='D09B7B1A2C8A4497993FB2753259ABA0' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID</TUV>
+</NAME>
+<QUAL>OBDMID</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='88DC4C5C85B745bb8A1EBBDCE3F3F98B' temploid='A7CCED8F4D1649e885656E4C5D94A0E6'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE33B20' oid='2B90EA0BFC7A458286F14921B974D043' temploid='B26D036A01074dcf96BBD7AE5B2667C6' must='1' spec='sid' bl='8' v='98'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE33C50' oid='FEA4B9F4A1A84624A1312C7B89EB20B9' temploid='C7CDF393E02445deB5777143F6F6B082' must='1' spec='sub' bl='8' v='246'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID_Prefix</TUV>
+</NAME>
+<QUAL>OBDMID_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2C3B0' oid='A33284E4DC18488aBBC08C2C8DA3A36A' temploid='1E86B1C7A29F4cffA1D22E66B7AA62C0' must='1' spec='mode' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID</TUV>
+</NAME>
+<QUAL>OBDMID</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE33EB0' oid='3C65530438E440c0BAED0F9F716D8783' temploid='127F87DB0F754188896DD59B6A9819BE' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID Data</TUV>
+</NAME>
+<QUAL>OBDMID_Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='1BCC3B62F8954dd8B1DC7930E098A2DB' temploid='1620C8664E4F40f9AE5181CBFED6B791'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE32490' oid='4E45A7EAF6A64d85877F4AA805A51EA8' temploid='4A78325A537E41c58E4B29B86FFF6B51' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE32820' oid='DC48C7C64DC24b7b851F8AC215B7FF2C' temploid='33806894F48E4d95BD126BE2B918ED01' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE325C0' oid='62721115099A4dfbB3B4DC615F9E226A' temploid='2C6368B787504d8eA5680762102394A2' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7A970' oid='3670F4ADDF8844ebAAD3698FBB3064DB' temploid='9FAF7F008E3D4e0d90005A5E977FBA6D' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($22) ReadDataByIdentifier (PIDs)</TUV>
+</NAME>
+<QUAL>_22_ReadDataByIdentifier_PIDs</QUAL>
+<REQ oid='28923B4140A84a7cA14C64EB648A905F' temploid='94A5D08650B940b7BDA652741F0D6E77'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE26DB0' oid='29751380B68A43e0974D6FBC27FBBFEC' temploid='54AF492A5BF44f08874395BE9F8039CB' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE261D0' oid='5947B0DE715A4565BD0ADE4F3B9AF24C' temploid='97C3ABEF5CCF486984C3B7215435EC84' must='1' spec='id' bl='8' v='244'>
+<NAME>
+<TUV xml:lang='en-US'>PID_Prefix</TUV>
+</NAME>
+<QUAL>PID_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2D6D0' oid='DC014719B1BB4b92A0A9521ABD1A291C' temploid='AC72A38A302A4d9f91D19F302F2418ED' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='49150A3F82854a40901F7EC8B3A49A1B' temploid='B0CF9A1727924882B1477CA95E2832A4'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE25F70' oid='9F9294C695B842feA60750D7C57422D7' temploid='A94090E94BBD416dB11AA87528E9C4BA' must='1' spec='sid' bl='8' v='98'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE25260' oid='0EB73FA3E42A4dc5B0212FDFCD9DA3C9' temploid='3F036C627CCE45cf9B607DAA9930D946' must='1' spec='id' bl='8' v='244'>
+<NAME>
+<TUV xml:lang='en-US'>PID_Prefix</TUV>
+</NAME>
+<QUAL>PID_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2D7E0' oid='E3F8E6F772DF4fbfB3DC58C041EDF1B0' temploid='F6E5154DB14A432e98AD0889B857914E' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE28900' oid='FFF3D9CD39C14b01BA3CBE1797C680AC' temploid='ADF9E66B802244cb9147978FA00EB65E' must='1' dest='data' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='2627B3893C98440e81B1D8C08FA5544B' temploid='203AC3E7F497464e935BE48BB1C4B312'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE25000' oid='D7234436DE404addA41C042C853EE51C' temploid='CBF0A4F951D34cc787C7CD17581F75B1' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE27AC0' oid='547DC31012794a4387B0F032AA6195F0' temploid='0A8F97E38E4F41d89890A6537005E297' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE27E50' oid='81AF306A73974581B265EE5D23C75A12' temploid='642095A8BF6846c8AC268FAC5C962BC7' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7BB70' oid='505E888BCACB43a595FEC80DE63965BD' temploid='736B9C9CFB6C44d99BF29AA3B49F1B44' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($22) ReadDataByIdentifier (SupportedInfotype)</TUV>
+</NAME>
+<QUAL>_22_ReadDataByIdentifier_SupportedInfotype</QUAL>
+<REQ oid='A5DCD9721AA84df8A594A29CEBA45B4C' temploid='4F14755E983B4637BED14D4633B0E394'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE25E40' oid='D53FEC9A069D4cdd95DB2E8AE3EA04EA' temploid='328DEA0B81A248e1AF7E3131569A0E1C' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE25390' oid='0EE9028D121343fd86303D585F569874' temploid='335B82DB8CD1457eBE747799BA986AC3' must='1' spec='id' bl='8' v='248'>
+<NAME>
+<TUV xml:lang='en-US'>Infotype_Prefix</TUV>
+</NAME>
+<QUAL>Infotype_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2FC00' oid='6768A5CF19FC45f19130EA863C3D73CE' temploid='E0CD733672634dcb8FEE4B4A23DD1755' must='1' spec='info' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Infotype</TUV>
+</NAME>
+<QUAL>Infotype</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='FB3D2208FB04487c935C815982C3539D' temploid='39CDBE22B05A46198C0ED173E717716E'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE247B0' oid='AE172988ED0744bd8755BFAC38CD45E4' temploid='F0918E73F87B4ea69945B7CEC836E16E' must='1' spec='sid' bl='8' v='98'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE25130' oid='FA5966B445574a04B94AE383EF9CED61' temploid='55F6EDADDB314c6d8840F2420D47A8D2' must='1' spec='id' bl='8' v='248'>
+<NAME>
+<TUV xml:lang='en-US'>Infotype_Prefix</TUV>
+</NAME>
+<QUAL>Infotype_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2E280' oid='9228217714E04bc097A60EB8B598240F' temploid='5B05CDCA334F4f8d967D3ECE4F427235' must='1' spec='info' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>Infotype</TUV>
+</NAME>
+<QUAL>Infotype</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE281E0' oid='07B78DEBE3D8400c8703770916FDF544' temploid='F77751E275444074919F0C90A6EC85DB' must='1' dest='data' minbl='32' maxbl='32'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='3F957C37689A4ed589FBDC28F004061D' temploid='551A73299EE945f1BD3305DAB2D724B5'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE24ED0' oid='D1769BD3A6EC481eA8ED619B707CEC9B' temploid='9FE3A64D008043a1B168B66B55E912DA' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE26B50' oid='7545F93D36EA4be99E6866E0F3DB4292' temploid='9F9FD3749A2B46f5AB77452519AA85F5' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE25AB0' oid='AB7F923F24E24de4BC22DB17CF0B3672' temploid='463808CFBD0E4f5d977587EC50A7D183' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7B270' oid='256FE2EF5ABF45499DDF18573D4A0420' temploid='9798F63F9142498bA671A6B7CDB0B67A' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($22) ReadDataByIdentifier (SupportedOBDMIDs)</TUV>
+</NAME>
+<QUAL>_22_ReadDataByIdentifier_SupportedOBDMIDs</QUAL>
+<REQ oid='526F44BBCA4D4c83B0C5635A2C87955C' temploid='9EE4BEC55CAD49a9B350B852DE65FF04'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE254C0' oid='13BE94D47F4F463eAEEBA493E845C99D' temploid='EF0A8D0354564343A072AF3507EE6CE7' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE27990' oid='3D7C727946FA4d29A1F134177365D84F' temploid='57A5CDEC19EF432bBBD2B146BBD62329' must='1' spec='id' bl='8' v='246'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID_Prefix</TUV>
+</NAME>
+<QUAL>OBDMID_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2F490' oid='4A2DE6039851470bBC5C5192DD92DA34' temploid='A366217F361C4914A5C9EB8E8998461B' must='1' spec='id' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID</TUV>
+</NAME>
+<QUAL>OBDMID</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='9EC0A726402446e7BF598F42A4738033' temploid='9929CCC2920F4fa49E9478A6EA55BC6A'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE26EE0' oid='7D44540294E44db7A5C191E650969C43' temploid='B275E7E92FB3402fBD245D4360EAF175' must='1' spec='sid' bl='8' v='98'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE286A0' oid='F1D98919A31C440580585C433E571BE9' temploid='AD1E1BCD90AB4e1fB279715617747D15' must='1' spec='sub' bl='8' v='246'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID_Prefix</TUV>
+</NAME>
+<QUAL>OBDMID_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2F5A0' oid='B983D70DCDC6478eAB5B7564103045BC' temploid='69FAF6BA93E44641A07F8DEECC032A6E' must='1' spec='mode' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID</TUV>
+</NAME>
+<QUAL>OBDMID</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE248E0' oid='5A23F47F0F28495fB509339F88607E01' temploid='5425FC308476455eA30AEEC7700CF521' must='1' dest='data' minbl='32' maxbl='32'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID Data</TUV>
+</NAME>
+<QUAL>OBDMID_Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='CCEC3E636F804f2bA026B8D39E4E55FC' temploid='1C85744F5C9846e69524D5036F38025E'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE26300' oid='E15EA1B90BAA471d8B48F1C711D07607' temploid='231C91C5AF90482391E2F6A1BA66B083' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE260A0' oid='2688ADDB7D614cc79D7C6894CDF85B33' temploid='09788F8E05DB4ab4865CBE4396B2AE68' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE25BE0' oid='B4EFF732278E4462BF3AE59AC76141DC' temploid='1E14082A44594e3a9BFCBF62506F3A3B' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7BDB0' oid='F6AB842282E84f8c8739EC1572100594' temploid='2D38384CB24E444f9E6DB0057F5EDA21' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' maycombcont='1'>
+<NAME>
+<TUV xml:lang='en-US'>($22) ReadDataByIdentifier (SupportedPIDs)</TUV>
+</NAME>
+<QUAL>_22_ReadDataByIdentifier_SupportedPIDs</QUAL>
+<REQ oid='2A37EAB33AC843d290EF860BD72F42CD' temploid='E52D786176434283A60C95D6193C43A9'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE27270' oid='4E6C50B34340443f85C720A686AD2839' temploid='43FDE1A276084cb5B8215C3529A7FFA1' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE26430' oid='BCE400C59C8F4b949F0E66D5F50341BB' temploid='8156333EF4E943bcA473A0330C37D41D' must='1' spec='id' bl='8' v='244'>
+<NAME>
+<TUV xml:lang='en-US'>PID_Prefix</TUV>
+</NAME>
+<QUAL>PID_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2E4A0' oid='99AB39218D1D4cf0AA64A088109C41F1' temploid='CB96B643B6BD45609BB710A433705EBD' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='5300F55F6D5F4006846AFA2FE82AF0EE' temploid='6E851C6BE52A45f28CB76E91FC869A8D'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE26560' oid='7EE3AC54FE6D47ac87E0DFB82F5E3DA4' temploid='7206D61F3A994459BF14BCEC2876B138' must='1' spec='sid' bl='8' v='98'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE255F0' oid='5AEC86012366413fA067C773DC5EE1E1' temploid='68DE055BEF4949f39ACE2F2949A8F3E0' must='1' spec='id' bl='8' v='244'>
+<NAME>
+<TUV xml:lang='en-US'>PID_Prefix</TUV>
+</NAME>
+<QUAL>PID_Prefix</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2E5B0' oid='9F0EB71FF69F4f4e9781979C9B94E952' temploid='9F3CCB1847E14e46A44B4BA8A62D4EAE' must='1' spec='pid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<QUAL>PID</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE26690' oid='93EDB7FFB7DE4b73A3D9FFB557D7FED0' temploid='145106E631C446898791260942C5A39B' must='1' dest='data' minbl='32' maxbl='32'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='408D11CE89D44cbdB0D1647A14C4B586' temploid='04139DBA463B4b2e8C2B9902B4D767EF'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE242F0' oid='16A6641E4F0D470cB9A1ECCD1016B708' temploid='C7090BDC52DB4e209ECCBD83BEA2DCBA' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE267C0' oid='6B18C534B7ED4963A44D6F05120B3A74' temploid='8503DE18A65540e996CEB73299AAEF0B' must='1' spec='sid' bl='8' v='34'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE25720' oid='FE0B85CE180748cc984890D57EB7F401' temploid='D8AEDC935A874e6eA517606CCF4DDB81' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7D8B0' oid='1AFFB06E30224fccACB302F7F73D2D43' temploid='6301B8BF8C9D47a4909532D3D7B8CF0E' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($31) RoutineControl - OnBoardSystemTestOrComponent</TUV>
+</NAME>
+<QUAL>_31_RoutineControl_OnBoardSystemTestOrComponent</QUAL>
+<REQ oid='5D6DB60A14C8431cBC1F366CD17CE7BD' temploid='FB7F969552764843A8D160AA2F20974F'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE25850' oid='62E267495ACF4fdb94C1EF0FD1EE722E' temploid='3D06C9A0C2714b30ADBB42070A36AF46' must='1' spec='sid' bl='8' v='49'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE287D0' oid='DE521C2E44C1413cB09444E8323A6813' temploid='29FF122143274b9c80592C4313286723' must='1' spec='sub' bl='8' v='1' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>StartRoutine</TUV>
+</NAME>
+<QUAL>StartRoutine</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE28B60' oid='2945413A18D2470c875BD0743F74FFE6' temploid='470B0C26EB9B40f1B6F260A141420781' must='1' spec='id' bl='8' v='224'>
+<NAME>
+<TUV xml:lang='en-US'>OBDTestIds</TUV>
+</NAME>
+<QUAL>OBDTestIds</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE30040' oid='B1F0FB9373434cff9779A85A03D248D7' temploid='2931E3BE00884d15950771F6D4D69101' must='1' spec='tid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>RID</TUV>
+</NAME>
+<QUAL>RID</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='2AE5D4E6CB784f79BFFB67A38A2EC6FD' temploid='55429EDEB2224ab0A3EE36E1B5324B06'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE27600' oid='B5E3FB124E764fbdA588C4C5E44E882C' temploid='1D70D68AFF8F4e4e827ECDA930420CF6' must='1' spec='sid' bl='8' v='113'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE27140' oid='13F60EB1106040019B9D9951E0892B6E' temploid='9DEDCF829C5C4f498D5030C3B8DDB7D9' must='1' spec='sub' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>StartRoutine</TUV>
+</NAME>
+<QUAL>StartRoutine</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE24A10' oid='FA6DD15052E048c1A7AB39761894BF77' temploid='AD0196C6C12B4ee48DBB4B1CF1E5F2B1' must='1' spec='id' bl='8' v='224'>
+<NAME>
+<TUV xml:lang='en-US'>OBDTestIds</TUV>
+</NAME>
+<QUAL>OBDTestIds</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2C5D0' oid='0BD3624CD2CE4befB7990C091140D343' temploid='3ADDD5DB2F454946B09865873F6FAB79' must='1' spec='tid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>RID</TUV>
+</NAME>
+<QUAL>RID</QUAL>
+</STATICCOMP>
+</POS>
+<NEG oid='6761B66803EB41969C37A8E68B350159' temploid='AB1C27F82FE74682BCD72F1074981EAF'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE24B40' oid='D8DFC07ECDC642ba9123B164AAC81228' temploid='75892DBA22E84009A2E42BB114077B61' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE27BF0' oid='02B346AD14FD4885B1870FB1760601DC' temploid='5AD0EECF868449929D7FF6E45E27D30E' must='1' spec='sid' bl='8' v='49'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE24C70' oid='1D23043DE71741359FDCB89B1CE2EA7D' temploid='51225EFB268A409885649351F05D5A91' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7B4B0' oid='17E3A16450ED4ab9A2782564261BD22E' temploid='A393FBD64C6F4c6aAE95F2FF6875DF5A' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($31) RoutineControl - ReadSupportTIDs</TUV>
+</NAME>
+<QUAL>_31_RoutineControl_ReadSupportTIDs</QUAL>
+<REQ oid='3833BA40CF1E4ef69D84C7649B9D83D8' temploid='FB14B7C5AB0142f8BD12B936DF8744F2'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE27010' oid='127C3ED63D0747d9B0BB8CC09E5DF271' temploid='8652D9A35F3C418481F44958128B3DB5' must='1' spec='sid' bl='8' v='49'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE268F0' oid='56782F638C10435582EAE0A1C494639A' temploid='83E5E2C1F9964b72B54B0F9418207E1F' must='1' spec='sub' bl='8' v='1' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>StartRoutine</TUV>
+</NAME>
+<QUAL>StartRoutine</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE26A20' oid='AC9774B503C0487e84DFABACC882F21E' temploid='335E33BDFBB64e3cAD36F3F1BF113E6B' must='1' spec='id' bl='8' v='224'>
+<NAME>
+<TUV xml:lang='en-US'>OBDTestIds</TUV>
+</NAME>
+<QUAL>OBDTestIds</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2DE40' oid='F0C40D7FFECE473bA8ABE44D2819B891' temploid='D44D3427F5FA4107867F890853301DEC' must='1' spec='tid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>RID</TUV>
+</NAME>
+<QUAL>RID</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='8016565D27714e07A825F78676CC67E8' temploid='E9B9CBF4FEAC4877AA99C40410E27186'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE273A0' oid='1FD770DF272C4a79986AE02858AE98C2' temploid='5B0C8A7908AD41a3838C4F5AB49B3520' must='1' spec='sid' bl='8' v='113'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE25980' oid='7EF8E2ACDDA74e2c892C3CAE96F1AB89' temploid='08CBF6B6EF72494e8F00D5EA4ED0F939' must='1' spec='sub' bl='8' v='1'>
+<NAME>
+<TUV xml:lang='en-US'>StartRoutine</TUV>
+</NAME>
+<QUAL>StartRoutine</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE27F80' oid='4E7D749318E2441787F33D9B63200640' temploid='9F174906DDEA4af694E9751495045C9B' must='1' spec='id' bl='8' v='224'>
+<NAME>
+<TUV xml:lang='en-US'>OBDTestIds</TUV>
+</NAME>
+<QUAL>OBDTestIds</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE30370' oid='D4513D1469F54007A0129A1058A1451D' temploid='68FDE1329EA444969744F47DCC632C43' must='1' spec='tid' dtref='_000001B1AD974DB0'>
+<NAME>
+<TUV xml:lang='en-US'>RID</TUV>
+</NAME>
+<QUAL>RID</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE27730' oid='8566CA0954DD44bcBEA64ABE9373F9DD' temploid='3034C2E5D3D54f4586EA02CB71B098A4' must='1' dest='data' minbl='32' maxbl='32'>
+<NAME>
+<TUV xml:lang='en-US'>Data</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+</SIMPLEPROXYCOMP>
+</POS>
+<NEG oid='F2A8C340C81846d28EDCC27E04C1F4C6' temploid='D6C510CC7691402094FBEDA12D75C7FA'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE27860' oid='E96960E6DEFC46f292CE49171D2D6D88' temploid='DEC7BBFD39E34e2e8E27658334D4DC34' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE28570' oid='30C92E00A8DE43d497C2E3EFD97BD9D8' temploid='31ECFA1E3EF64bd6A9DD4B9C30C23E81' must='1' spec='sid' bl='8' v='49'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE24DA0' oid='36AA06D554C343ae9E4DF49588399A09' temploid='FD2C9B3A5D47446dA6AB33F5C6132D2A' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7BFF0' oid='6EB2610EFA80420095FAAEDFFD6DE9A4' temploid='EEA501819765411aB9317F822C2180CD' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - ReportDTCWithPermanentStatus</TUV>
+</NAME>
+<QUAL>_19_ReadDtcInformation_ReportDTCWithPermanentStatus</QUAL>
+<REQ oid='2659F46E5CE14919BE179B0523A13342' temploid='FA926D0AE5374c41AB02B1024B74999E'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFE25D10' oid='F24C0C6746144885AF71ADBB8B9FD638' temploid='4F49317D9FA64f47B1C28D8D34F1A759' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE28A30' oid='A9D05CB432C34a2b8E6EF82D7EA9AFA9' temploid='473230D1CB014859BFABBD5734CFF4C4' must='1' spec='sub' bl='8' v='21' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction</TUV>
+</NAME>
+<QUAL>Subfunction</QUAL>
+</CONSTCOMP>
+</REQ>
+<POS oid='B27CB6B271E94ab9AB6BF6BD7E084A57' temploid='958843A2D07C4bb7AFA4B7ADE43316FD'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFE26C80' oid='9BBA35E632C14752A9A5FF5DCE17654B' temploid='3529258BE587441f84C29F5388BF4256' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE28310' oid='177C3E1E7FD141939F10248F89DAB72C' temploid='208ACC93D0EF482e937EAF8E03DD1304' must='1' spec='sub' bl='8' v='21'>
+<NAME>
+<TUV xml:lang='en-US'>Subfunction</TUV>
+</NAME>
+<QUAL>Subfunction</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFE280B0' oid='60EF981E86BF4f588F39A9F1729F89AF' temploid='3F9E99B7921146d5A69DA62509EFECBF' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DtcAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAEE70' oid='9951418A839F42acBBA92FA8F8463482' temploid='A78986EAE3664f2fB314F5A353C53C34' must='1' minNumOfItems='0' maxNumOfItems='1'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfDTC</TUV>
+</NAME>
+<QUAL>ListOfDTC</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1AFE274D0' oid='14725EAD6BC84b2995B874936273D495' temploid='932750D0B7584ce5A0F0874C4CE81FBA' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFE27D20' oid='4AF2DAA0BEEB496080D014E51FE940B8' temploid='4BF7BA873C8D411aB2E16568293EA6C1' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDTC</TUV>
+</NAME>
+<QUAL>StatusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='D74CEB03D1144b049D35C1565C34380C' temploid='C8D5130D9E09450a920DE4F27AD996A0'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFE24090' oid='6F8927D011424043A0D04E2125D62F94' temploid='223E4349C2B14efe8ED4269D7D0BACDA' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE28440' oid='6E3E8EFD12E34845B9220A5B43A5FB90' temploid='340B2BCD1D2041bb85306696B151D686' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFE241C0' oid='F6D8B5999201448eA32C931BA2637149' temploid='3F7205F2C5D24e3eA98967191A191E7E' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7C230' oid='99D3B9AEACC24a6b9DA0B24CC0C95BFE' temploid='5FC2BA4D138F41ab9BADAB37B9F1ABE0' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report emission OBD DTC by status mask</TUV>
+</NAME>
+<QUAL>_19_ReadDtcInformation_Report_emission_OBD_DTC_by_status_mask</QUAL>
+<REQ oid='C7B71252072E4d1a98B242601D9AF6F5' temploid='3B2D32BD972446abA2DBA4EBADC94BFC'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-RQ</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_RQ</QUAL>
+<CONSTCOMP id='_000001B1AFE24420' oid='CB8E0C236F7D449b86B26FB385E24722' temploid='6A03DF6706A54262A0BDA61822D5C486' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFE24550' oid='49EB5646C5164e1d9D7ABA61728976FB' temploid='500628C13F844686B1B331FBDDB4DA73' must='1' spec='sub' bl='8' v='19' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcByStatusMask</TUV>
+</NAME>
+<QUAL>ReportDtcByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFE24680' oid='427F9BCE7525499f806F5847386D6A61' temploid='C9B8E50ECC80468eBF03F60ECBA0887D' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusMask</TUV>
+</NAME>
+<QUAL>DTCStatusMask</QUAL>
+</STATUSDTCPROXYCOMP>
+</REQ>
+<POS oid='62651C93E0CF435dB3A66C34FE8134E6' temploid='C6BB497C0D65400988718D3B61E91FC4'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-PR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_PR</QUAL>
+<CONSTCOMP id='_000001B1AFF140B0' oid='909AFDEA0989482f868A7EEE0082693B' temploid='4EB1789959664a46AAE2D7BAF3BF1CC0' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF127C0' oid='A5545DBC8B314f3e80991B2B42B50D9E' temploid='34EEC0B097504aa484FA8B403C34258B' must='1' spec='sub' bl='8' v='19'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcByStatusMask</TUV>
+</NAME>
+<QUAL>ReportDtcByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF15610' oid='FAF0DD8AE3C14b7aA3D52F49268E82A6' temploid='B9852F0CA7414c3789C3D17219D1B923' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DtcAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAB0270' oid='4EEE6C0E3EE3424dBC57983C3F22854B' temploid='7D565ED9CEA44f1f9918AE284B91DE36' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfDTC</TUV>
+</NAME>
+<QUAL>ListOfDTC</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1AFF14B60' oid='384AB470916845e983BC957FFA5B5A57' temploid='63E545E9711B4f03B131B6673BFC1CE5' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF13D20' oid='159357BF13FA4755964D1C75D8F748BD' temploid='7F3A9E3093E64e11B22EC5D9B72A70C8' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDTC</TUV>
+</NAME>
+<QUAL>StatusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='607EF98382F6403fBE371224EB92B749' temploid='7728AA3FBFDE4ffc85EB442BACC00793'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-NR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_NR</QUAL>
+<CONSTCOMP id='_000001B1AFF14310' oid='F65BFC94592645daA1F0F1C594EB5646' temploid='BCC6CCC5B4854ebe9062F03AD2DCB38B' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF11F70' oid='8DAEE7B8A4B34b1396B69AC0F317DAD1' temploid='F2CE18008365451684A7D8A4C3C6F456' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF13010' oid='12A7B9B9D74C4ab68EDFD7B1C15E908C' temploid='2FDFDDF04B874b789CCC23109003B7ED' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7C6B0' oid='9278A7CE50E644acAD52D3ADFDA3C891' temploid='1542E01B9B6F4e44BA2B78A13AFCB5E8' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report number of emission OBD DTC by status mask</TUV>
+</NAME>
+<QUAL>_19_ReadDtcInformation_Report_number_of_emission_OBD_DTC_by_stat</QUAL>
+<REQ oid='3D2E7E769648447dA00E7CC912D76C71' temploid='1D13E5DFB6A44064BC1660766DF10C31'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSM-RQ</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSM_RQ</QUAL>
+<CONSTCOMP id='_000001B1AFF120A0' oid='7C6F9F77CC42414dA8D28D54E69DA965' temploid='58AF2419EF3D4d8286AAA7017C1BCD29' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF15740' oid='C98D4295B07946caA35410C0A487015D' temploid='953A98CE11E54148868B3881E7B954EA' must='1' spec='sub' bl='8' v='18' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportNumberOfDtcByStatusMask</TUV>
+</NAME>
+<QUAL>ReportNumberOfDtcByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF11130' oid='3801991B21014dcb85E4856475C93263' temploid='9A95BC3F0A8C456fB01931B5245B0268' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusMask</TUV>
+</NAME>
+<QUAL>DTCStatusMask</QUAL>
+</STATUSDTCPROXYCOMP>
+</REQ>
+<POS oid='F4B6988426434fe1BB98139FD55AC527' temploid='C648B1D07E4D4b849110365EDC6522E5'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSM-PR</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSM_PR</QUAL>
+<CONSTCOMP id='_000001B1AFF13270' oid='6A9AE0622ED74abfA2E02FC7D557C702' temploid='7CC79E1214614960946FF951CCA9C263' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF13E50' oid='6E9C2237DE624c3792ED5951FA9A309F' temploid='E572ADD60DE44540A87A0AAFD5ECD6E8' must='1' spec='sub' bl='8' v='18'>
+<NAME>
+<TUV xml:lang='en-US'>ReportNumberOfDtcByStatusMask</TUV>
+</NAME>
+<QUAL>ReportNumberOfDtcByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF121D0' oid='F31CA4830385456eB0EC8864718BE4BB' temploid='693F43A5C3884b22BB32F651D3047186' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCStatusAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF11260' oid='AA31243E8F254fc1AFBDB7F179732F37' temploid='E2140EFD35934d0f8D93033F26E22CCB' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFormatIdentifier</TUV>
+</NAME>
+<QUAL>DtcFormatIdentifier</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92DAE0' oid='3E21033BD26B49d49076CF73DB5EA009' temploid='C71C3F66A84F4f948891806EA408C667' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCCount</TUV>
+</NAME>
+<QUAL>DTCCount</QUAL>
+<SIMPLECOMPCONT oid='ED04872C005B40bb8AEA786001F9B06B' temploid='2B63549A91C14fe78F312EC5C127983F'>
+<DATAOBJ oid='891F702EA7A649aaA6D64516541B599E' temploid='AD2F3A9254BE406e9D7A2714AD4C4F49' spec='no' dtref='_000001B1ADB62B20'>
+<NAME>
+<TUV xml:lang='en-US'>DTCCount</TUV>
+</NAME>
+<QUAL>DTCCount</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</POS>
+<NEG oid='5EEAB44EF6BF4b439DBB2E0CCFE1331C' temploid='F6CFD1D87E1949089C22545021C2C15F'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSM-NR</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSM_NR</QUAL>
+<CONSTCOMP id='_000001B1AFF12300' oid='01427191EE9A4332893DB414C5D396DA' temploid='C3B21956A1A24103A265FAD288AAEE7D' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF141E0' oid='AC9DF70180EF4fb389C3BF3C2677BA6D' temploid='FDADD77D309B4811AF959B0BABB18DAA' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF14440' oid='D42A09EEAAE446b0BFA3982EC52D009C' temploid='1BCE5788B7764aeeA24CB55E0A5FE0F7' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7C8F0' oid='0FF7B216E99D4770BC51AC6663082BDC' temploid='41B73B2EC37C4b9cA074E4780CE9E812' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report mirror memory DTC by status mask</TUV>
+</NAME>
+<QUAL>RDI_RMMDTCBSM</QUAL>
+<REQ oid='B1F610F5A6D34b8aB6401657FFA1F8B1' temploid='8EBB9CC2B3F64944B67C91038EEDC4C4'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-RQ</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_RQ</QUAL>
+<CONSTCOMP id='_000001B1AFF12430' oid='BA8F6370C5C64e2dA51246C170EA3DEF' temploid='5FE2774711814dfb9A89AF84767C7B21' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF14900' oid='8DAB88AF2AED460fA804D3A48C652D07' temploid='6D89E07D0F0045edBE6AC66F9E5061C4' must='1' spec='sub' bl='8' v='15' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportMirrorMemoryDTCByStatusMask</TUV>
+</NAME>
+<QUAL>ReportMirrorMemoryDTCByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF13140' oid='D097416F6AAF4babB8ED846617CC98E8' temploid='954C3971C33440dfAF5E364C63539C5C' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusMask</TUV>
+</NAME>
+<QUAL>DTCStatusMask</QUAL>
+</STATUSDTCPROXYCOMP>
+</REQ>
+<POS oid='2275662DBE654a15839430A0DF747E9F' temploid='C9B208BA4B844a9bB9DBBAE99F48DB8D'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-PR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_PR</QUAL>
+<CONSTCOMP id='_000001B1AFF12690' oid='C64C51F39AB547d6AA3628D98FEE6C3A' temploid='A7A23A295D214dcdA46D7AB5D7832EAB' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF14570' oid='27DAB71E3F2C4c06AC348AADA65D8034' temploid='EF383E2729854c4dBD72DA1432D0D42C' must='1' spec='sub' bl='8' v='15'>
+<NAME>
+<TUV xml:lang='en-US'>ReportMirrorMemoryDTCByStatusMask</TUV>
+</NAME>
+<QUAL>ReportMirrorMemoryDTCByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF14A30' oid='3F34E2E9AFAD491b9F3A7A8865CE2974' temploid='014ACAE9D7C94535A3FBB6444F30D980' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DtcAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAE670' oid='FB436CE87B8C4f599F002B993538FD9D' temploid='BCB662459AA44eb6A5AD31219518572B' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfDTC</TUV>
+</NAME>
+<QUAL>ListOfDTC</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1AFF128F0' oid='B236F171C3BC40378C884E241BD5A62E' temploid='EAC708508C114024966CE26E39B9B3AC' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF15280' oid='0CBE63743AF541c7AC6C33855DE60B16' temploid='54E0A6ECD26F46939B324D27E274300C' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDTC</TUV>
+</NAME>
+<QUAL>StatusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='2D604ADE77984278B5FEF77B53DDC1C2' temploid='5014C95C201941b39AF4BC0FC10B0B3F'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-NR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_NR</QUAL>
+<CONSTCOMP id='_000001B1AFF146A0' oid='A110A5EEDD404b46A7564177B77ECFD5' temploid='F6F3624B86DE449f82B855A433697328' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF12A20' oid='DFF513E85E3B49359A9E9216D5381902' temploid='9936E82396DD493692AE8A17CF946960' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF13730' oid='32FAD6B214CC44bd9036C10BD4270960' temploid='14873B4C8E564aabB2C8364343B59231' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7D1F0' oid='80592CDD4A8042e79AF497AC0B046B8E' temploid='F663D2EF8F96404aB78BF391A32353E9' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report number of mirror memory DTC by status mask</TUV>
+</NAME>
+<QUAL>RDI_RNOMMDTCBSM</QUAL>
+<REQ oid='605D79E677B34e4a8369E691B1100C97' temploid='BE78999CF3FA4cf1B249ABF5E57B0F4A'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSM-RQ</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSM_RQ</QUAL>
+<CONSTCOMP id='_000001B1AFF147D0' oid='491D0A8ED118484a81F7CB676F8D79FD' temploid='2DD24972A081435684636F43C0FAC278' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF12560' oid='4D7E54DFF94B4197BDEC02CA0473DD07' temploid='4EEF3AE02BC148c3B4B02FC58DD48EAF' must='1' spec='sub' bl='8' v='17' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportNumberOfMirrorMemoryDTCByStatusMask</TUV>
+</NAME>
+<QUAL>ReportNumberOfMirrorMemoryDTCByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF10C70' oid='8025A8E8A56C45e499254FDA14A4C5BE' temploid='4EEAACD460D44df1939EFDBDA472982F' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusMask</TUV>
+</NAME>
+<QUAL>DTCStatusMask</QUAL>
+</STATUSDTCPROXYCOMP>
+</REQ>
+<POS oid='493CD1907A3F4c87ABCFB8628AA36C56' temploid='3B605C9D629646edA9957A3504182E61'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSM-PR</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSM_PR</QUAL>
+<CONSTCOMP id='_000001B1AFF12B50' oid='B12F33E2DE0B4f1c8B70D9169663A99F' temploid='BBFAEF396C584244B0CC09A7CAF29ECD' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF153B0' oid='BD42230D7D7A47f7B9C0B3463361083B' temploid='12A6BFCA165841a6A51E7E93FF6E4034' must='1' spec='sub' bl='8' v='17'>
+<NAME>
+<TUV xml:lang='en-US'>ReportNumberOfMirrorMemoryDTCByStatusMask</TUV>
+</NAME>
+<QUAL>ReportNumberOfMirrorMemoryDTCByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF10DA0' oid='27FCD6E7732A4da0AC7F318212CA49DD' temploid='D12AFB372FE04f7789F71C37480B5F59' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCStatusAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF12C80' oid='005EA54F86DD4613BCBF711068D959B2' temploid='A856E2F2913C4f0d9D16038CC96B3EE9' must='1' dest='data' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFormatIdentifier</TUV>
+</NAME>
+<QUAL>DtcFormatIdentifier</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD92DCA0' oid='35CC5BCBF7134ae480DE12BB9F8C23DB' temploid='446D8F0CE04546019E6CDEDBD7543EBC' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCCount</TUV>
+</NAME>
+<QUAL>DTCCount</QUAL>
+<SIMPLECOMPCONT oid='8A74BB5D4CE7447dB967166722BFA2EF' temploid='B4EB40C6FD514a3cA980F2F1385D263E'>
+<DATAOBJ oid='6BC646954F464921A7425BB27E7E131A' temploid='89D1C764D2234948976D8FE75EA7C120' spec='no' dtref='_000001B1ADB62B20'>
+<NAME>
+<TUV xml:lang='en-US'>DTCCount</TUV>
+</NAME>
+<QUAL>DTCCount</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+</POS>
+<NEG oid='9A6C8AC98F9142ddBF2CF9F083226323' temploid='687780B851FA49a19D3C0811391B712F'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RNODTCBSM-NR</TUV>
+</NAME>
+<QUAL>RDI_RNODTCBSM_NR</QUAL>
+<CONSTCOMP id='_000001B1AFF12DB0' oid='5525FBC2D7A54639B6E644CAEE8ECA96' temploid='F633D277F0E948f1B1B34C6DE902C876' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF14C90' oid='8A979B6F73374a26A5484FD436CFDFD2' temploid='26F7EDF18BA94fb288D961A678CDB689' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF154E0' oid='8D7FE489B56D49a19EF169C4E8DF4524' temploid='C792EFD83C0B4aa195D46F7B1893A59C' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7A4F0' oid='2E4AAB64E10A4e708565B43005230B11' temploid='60289C37C04A4edf8084F08D552DC855' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report mirror memory DTC extended data record by DTC number</TUV>
+</NAME>
+<QUAL>RDTCI_RMMDTCEDRBDN</QUAL>
+<REQ oid='220FDFA22A65448289C696E6C4692B5A' temploid='F287FE578EA44fd698BFD483A4C84D7B'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFF11000' oid='113B89F87F2943d694138BC78E5F6895' temploid='F459C3F83FE44e5fA81CE8BAD72A10B4' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF14DC0' oid='1A3DB0E8511E4684A5818B1D31B01940' temploid='82B74D173E5E44e4A8CF879222A05C5E' must='1' spec='sub' bl='8' v='16' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportMirrorMemoryDTCExtendedDataRecordByDTCNumber</TUV>
+</NAME>
+<QUAL>ReportMirrorMemoryDTCExtendedDataRecordByDTCNumber</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF12EE0' oid='64A8D31BA38046909464054A52869FA3' temploid='2C09FA84AEF84accB7C7DBE7DBCCC685' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<MUXCOMP id='_000001B1AFF14EF0' oid='8773A130533B464d926E9DF931F26BFD' temploid='CDA79C654AA54d85A4C0D39F958286CB' must='1' selref='_000001B1AFF12EE0' selbm='4294967295' dest='envData' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>AvailableExtendedDataRecordNumbers</TUV>
+</NAME>
+<QUAL>AvailableExtendedDataRecordNumbers</QUAL>
+</MUXCOMP>
+</REQ>
+<POS oid='75ABB32E3A954e969BC270CB9F700CD3' temploid='EAB88434ABF7457e8E1CC9D55520C5D9'>
+<NAME>
+<TUV xml:lang='en-US'>Positive Response</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFF11720' oid='80E5828DFD09435aAD6C02E2EDE41E5C' temploid='50CDDEE321234c0a83E22869A9AD2904' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF11390' oid='9B0C360BB9F746348127F719E80A7C49' temploid='431970FB3845422f8A2FB57E673236A2' must='1' spec='sub' bl='8' v='16'>
+<NAME>
+<TUV xml:lang='en-US'>ReportMirrorMemoryDTCExtendedDataRecordByDTCNumber</TUV>
+</NAME>
+<QUAL>ReportMirrorMemoryDTCExtendedDataRecordByDTCNumber</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF11AB0' oid='2007F54DB29B4d59911E454D4280D0EB' temploid='2C9DA426AE3A47fd92FBEE609D1925F3' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF115F0' oid='9C4354F126C04660A6BB64FAD61392EA' temploid='84036889A4004f40834D9AFFEFA3D9F9' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Status Of Dtc</TUV>
+</NAME>
+<QUAL>Status_Of_Dtc</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAF070' oid='405812E622D84781929C0EAAA42101B7' temploid='58C45722C7144fd192254282E5A2BBE3' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>EndOfServiceIteration</TUV>
+</NAME>
+<QUAL>EndOfServiceIteration</QUAL>
+<CONTENTCOMP id='_000001B1AD920800' oid='9D7E266A59444810BAC168AABF103546' temploid='BC93C2D7063E438b8C4553E96DDA23EE' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>ExtendedDataRecordNumber</TUV>
+</NAME>
+<QUAL>ExtendedDataRecordNumber</QUAL>
+<SIMPLECOMPCONT oid='C1FA1546CFB440bcB813F9E269E61611' temploid='674A477C41A84eb9BB1CD66BA1546F7E'>
+<DATAOBJ oid='6D1C3DE5EF634e4dB993036A9A0A1962' temploid='FF65D80785714b79951ECABE97322840' spec='no' dtref='_000001B1ABDEBD60'>
+<NAME>
+<TUV xml:lang='en-US'>ExtendedDataRecordNumber</TUV>
+</NAME>
+<QUAL>ExtendedDataRecordNumber</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<MUXCOMP id='_000001B1AFF114C0' oid='D227809725304b7f9C1DC427C315A8D2' temploid='38E1BC7E79B04a6eBDCB9325522840B6' must='1' selref='_000001B1AD920800' selbm='4294967295' dest='envData' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>ExtendedDataRecord</TUV>
+</NAME>
+<QUAL>ExtendedDataRecord</QUAL>
+</MUXCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='FAA9F96462614a3f8BA0BF8A75EE80F4' temploid='5F37014379E84ec686DB80C3E811804B'>
+<NAME>
+<TUV xml:lang='en-US'>Negative Response</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFF134D0' oid='736A0BE5273E4eeaBDB75ADE7DAFE5D4' temploid='3D69CAEF8229408384EA62DF1F82B071' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF11980' oid='0BBEBAA8A17C474a9E96BDA7F5863A11' temploid='8D9D0CE0932C4bd1AF61F51D52AB5BA7' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF15020' oid='F3A7DADFC78046a7B8AB13BFA06BFC9B' temploid='82FC93C1E2D242bbB938B1FA89A5246A' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7D670' oid='49C6A8F0E8754830A6D4CA88423B48C5' temploid='F4AC825D90D44800898FEE743FD77DF4' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report DTC snapshot record by DTC number</TUV>
+</NAME>
+<QUAL>RDI_RDTCSRBDTCN</QUAL>
+<REQ oid='E557E5F3DABF4f4bB2B6EB9314C9D052' temploid='2DA69A41B8C14ff2AC61221FF0D28D0E'>
+<NAME>
+<TUV xml:lang='en-US'>Req</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFF13600' oid='8841BF87A2634bf198C37CDBB130011D' temploid='32EFE1152CA4434cB3129755EF53957D' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF15150' oid='990DF67719A249d899A2F92C24ADFB82' temploid='03803DF4A3AD4beaAC8AF080419C58A1' must='1' spec='sub' bl='8' v='4' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDTCSnapshotRecordByDTCNumber</TUV>
+</NAME>
+<QUAL>ReportDTCSnapshotRecordByDTCNumber</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF11850' oid='E682E04DA081482eA5FEA6EF9F22AEA1' temploid='37A876D3A62E4a0795DA5BDEA7181425' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTCMaskRecord</TUV>
+</NAME>
+<QUAL>DTCMaskRecord</QUAL>
+</SIMPLEPROXYCOMP>
+<DOMAINDATAPROXYCOMP id='_000001B1AD91F220' oid='2A334B24426E443e90CA65DA0D3ACD95' temploid='12EA477F038043829984D5F139AADDCE' must='1' dest='srn'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordNumber</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordNumber</QUAL>
+</DOMAINDATAPROXYCOMP>
+</REQ>
+<POS oid='7254916E82214475B583536158D502AE' temploid='79C2C6C15DBA491aA800DD5A3DD8BF1D'>
+<NAME>
+<TUV xml:lang='en-US'>Pos</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFF11BE0' oid='E1DF0B40A7214f8aA96EF42156C1900C' temploid='3F20B119B6DA4980B2ADD9510ECD2D6D' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF11D10' oid='E87EC9CD76B248e7B06911BD9F3658C2' temploid='6909DC5F6C1C403c9C2AC3AA96DCB0D4' must='1' spec='sub' bl='8' v='4'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDTCSnapshotRecordByDTCNumber</TUV>
+</NAME>
+<QUAL>ReportDTCSnapshotRecordByDTCNumber</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF11E40' oid='588CBB0A604B407d98123DFD49DED94B' temploid='AB96AF7C977F425183FD2B412A7F3969' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF13860' oid='B2AB9CBD176A44278B831AC35A863B91' temploid='6870572AF0A84741A63ABBE6B42BA38C' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDTC</TUV>
+</NAME>
+<QUAL>StatusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAF670' oid='E30E511C94B2433294D77AA0601D4FC7' temploid='A104FA381EDD4a3eAABB2D220818FE41' must='1' minNumOfItems='1'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfDTCSnapshotRecord</TUV>
+</NAME>
+<QUAL>ListOfDTCSnapshotRecord</QUAL>
+<DOMAINDATAPROXYCOMP id='_000001B1AD921440' oid='BBFC93A7F5D04349A8D5D2EC695B95EC' temploid='930A34F3BC1D4fa4BB75084D7F1C27DA' must='1' dest='srn'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordNumber</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordNumber</QUAL>
+</DOMAINDATAPROXYCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF13990' oid='042D04F4EBBD4d6584CAD2243A0376A3' temploid='B9CD12421C4F46ab9B4DE5A16193101C' must='1' dest='any' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordNumberOfIdentifiers</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordNumberOfIdentifiers</QUAL>
+</SIMPLEPROXYCOMP>
+<DOMAINDATAPROXYCOMP id='_000001B1AD922080' oid='B803AE05CAC84d76A804B9F6BA044E34' temploid='B8334773F79D47649DD0A0B243AA547C' must='1' dest='sd'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordData</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordData</QUAL>
+</DOMAINDATAPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='0578258395E547ddBDF6F7A5664543D2' temploid='D058646132744f03B89DA817FFE9FAAE'>
+<NAME>
+<TUV xml:lang='en-US'>Neg</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFF13AC0' oid='FED0E6293DD94ffaB18ACB1E09B763B8' temploid='BF434B2E876846f2B538A9F290D28636' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF13BF0' oid='011B21C8F06C47caAF13456790E5B152' temploid='1B34B516248044d18135077E72045790' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF15F90' oid='AF0614BC421C4d628AB92C14B40249D8' temploid='066FD5D60B4D4c2d9E4AD574C2F3B3A0' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFE7DAF0' oid='AAE8B8C0D9074034BCECDAB6D3EC743D' temploid='9854C368D1D9437299617DD6A87B8931' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - Report DTC extended data record by DTC number</TUV>
+</NAME>
+<QUAL>RDI_RDTCSRBDTCN_1</QUAL>
+<REQ oid='678366502CB64c9f88F47A26AF85C794' temploid='75D1B7DB04B24b08BA36836CF34B8D37'>
+<NAME>
+<TUV xml:lang='en-US'>Req</TUV>
+</NAME>
+<QUAL>Req</QUAL>
+<CONSTCOMP id='_000001B1AFF160C0' oid='E475AAA0632A4f4fB4B07D14E9110157' temploid='A8821D4203204f4e8F3FC98299BCE188' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF187F0' oid='17D29808FE1448b7843DEFD46C39277C' temploid='825D31D117744128A871AA702951D8C6' must='1' spec='sub' bl='8' v='6' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDTCExtendedDataRecordByDtcNumber</TUV>
+</NAME>
+<QUAL>ReportDTCExtendedDataRecordByDtcNumber</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF17C10' oid='6F11F9F40C094b1488AB376E8BB289C6' temploid='072E0C8EB989489aA3CEE703DC053AC1' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<DOMAINDATAPROXYCOMP id='_000001B1AD9217C0' oid='8AE5DE9877374ef6A6AE6BF7041564DC' temploid='0FC2DCE9A2A0408eAC2C38F8EDE8898B' must='1' dest='edrn'>
+<NAME>
+<TUV xml:lang='en-US'>DTCExtendedDataRecordNumber</TUV>
+</NAME>
+<QUAL>DTCExtendedDataRecordNumber</QUAL>
+</DOMAINDATAPROXYCOMP>
+</REQ>
+<POS oid='CC26C3DBA2E043b3A0D834F911AD8058' temploid='458448DF6722425fA27176F5E31E282D'>
+<NAME>
+<TUV xml:lang='en-US'>Pos</TUV>
+</NAME>
+<QUAL>Pos</QUAL>
+<CONSTCOMP id='_000001B1AFF19170' oid='A4C61A63DDD84372BEB0FCBAEAF0DE3C' temploid='23AFD7BB664F435788473F93EEF5320D' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF1A0E0' oid='143902667EC14624AD53BF064C9604E6' temploid='3F0D11A070EB42d1B68BF64BF9DD5729' must='1' spec='sub' bl='8' v='6'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDTCExtendedDataRecordByDtcNumber</TUV>
+</NAME>
+<QUAL>ReportDTCExtendedDataRecordByDtcNumber</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF19500' oid='4D10C346D460445fA12C5A3ED8183D52' temploid='688F277F56B1409785834FAC903E6393' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTC</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF16A40' oid='B67F4F396EAB43d1A4E778E0BE0E63B1' temploid='E6FC736F495746dd9F4F7858AD856F97' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDTC</TUV>
+</NAME>
+<QUAL>StatusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAF470' oid='C3373C353B6F4c4aA706ED38585C784F' temploid='294F5889B0F64636B6CDE2036432BD2D' must='1' minNumOfItems='1'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfDTCExtendedDataRecord</TUV>
+</NAME>
+<QUAL>ListOfDTCExtendedDataRecord</QUAL>
+<DOMAINDATAPROXYCOMP id='_000001B1AD91FAE0' oid='148D1EA7E769429fA8075FE9C8CD9488' temploid='F62A7E93A98B4721BA65ACCD79BC6A1C' must='1' dest='edrn'>
+<NAME>
+<TUV xml:lang='en-US'>DTCExtendedDataRecordNumber</TUV>
+</NAME>
+<QUAL>DTCExtendedDataRecordNumber</QUAL>
+</DOMAINDATAPROXYCOMP>
+<DOMAINDATAPROXYCOMP id='_000001B1AD921A60' oid='2EFFB4D9D5264a0a860C4B623C1CE6A7' temploid='94EFC1DFC8F54920B16ABAEFE2F66E44' must='1' dest='ed'>
+<NAME>
+<TUV xml:lang='en-US'>DTCExtendedDataRecordData</TUV>
+</NAME>
+<QUAL>DTCExtendedDataRecordData</QUAL>
+</DOMAINDATAPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='13AC97CBD4184339A32E6AE41E7F6DAF' temploid='112505E2223B48be8F33E093ECB57EF4'>
+<NAME>
+<TUV xml:lang='en-US'>Neg</TUV>
+</NAME>
+<QUAL>Neg</QUAL>
+<CONSTCOMP id='_000001B1AFF19630' oid='4E9C120526BA4885BB8F7F7B368CA912' temploid='17CB586468854bdcB849BC3DDC36AC15' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF17620' oid='647FDA48814A41a5B5BA28A6C05588EB' temploid='2174E41BDCDC4901B0842B304FEFC150' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF19760' oid='66E9486415794b5b814B5D8B965DCC60' temploid='C99FFCB425E748a9B15F27873EF58655' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFF3EDF0' oid='23498312A8414a3b9C1302C470BBE72C' temploid='B995E5523F794ac68657EAFA62CA044E' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' sprmibonfunc='never' sprmibonphys='never'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - ReportUserDefMemoryDTCByStatusMask</TUV>
+</NAME>
+<QUAL>_19_ReadDtcInformation_ReportUserDefMemoryDTCByStatusMask</QUAL>
+<REQ oid='061A3BD5E55E4fe7A95B12B648E5F8F3' temploid='B664A2CD22A94265B6A986CF9944F45C'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-RQ</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_RQ</QUAL>
+<CONSTCOMP id='_000001B1AFF19890' oid='9B48E103C7054e638A10048193BFD349' temploid='75DD0A586AA44c02BAF1767E3295D79D' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF19D50' oid='80046C9F06CD4576AB93C94A20455D5B' temploid='C281CA25B4804cfd99B75C7DA51C772F' must='1' spec='sub' bl='8' v='23' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcByStatusMask</TUV>
+</NAME>
+<QUAL>ReportDtcByStatusMask</QUAL>
+</CONSTCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF161F0' oid='5F505BEBCF244b5399D258371E29BE70' temploid='83592CD8EDC2456eBB77A79154DDC458' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Status Mask</TUV>
+</NAME>
+<QUAL>DTC_Status_Mask</QUAL>
+</STATUSDTCPROXYCOMP>
+<STATICCOMP id='_000001B1ADE2CF60' oid='CDEDC780606349438F65FF7F7927B198' temploid='39F7C94FC4B44e3b84BDC09DA0CDA93C' must='1' spec='id' dtref='_000001B1ADBDDFD0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory Selection</TUV>
+</NAME>
+<QUAL>Memory_Selection</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='9349D719B2EA4099A388748D2282FD0F' temploid='AE1EF91DB4174eb4879699E128C97B2A'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-PR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_PR</QUAL>
+<CONSTCOMP id='_000001B1AFF19040' oid='C9065B591F3E4b7f83D75ACC36E97491' temploid='A9C5656F82B2412cBF91530CD988FA5E' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF17D40' oid='510A7356EFC544d7868ACEC8C79CC96E' temploid='60C6477D929649ee9EA9AAE1FF3A626E' must='1' spec='sub' bl='8' v='23'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcByStatusMask</TUV>
+</NAME>
+<QUAL>ReportDtcByStatusMask</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2D5C0' oid='45FCD0A1C8F1444a90DA6ABC80C0B4A3' temploid='43E2162582064ca391F6735AF251D063' must='1' spec='id' dtref='_000001B1ADBDDFD0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory Selection</TUV>
+</NAME>
+<QUAL>Memory_Selection</QUAL>
+</STATICCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF19E80' oid='B387DCFC5FE64297B63038AAF339E0D6' temploid='91F67D83E9174266926469073CBDB91D' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCAvailabilityMask</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAB0470' oid='95BAC65CD90948b2AEFECE5BE862DB98' temploid='98A690F92BB947b7B1AB6CB79A491626' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>DTCAndStatusRecord</TUV>
+</NAME>
+<QUAL>DTCAndStatusRecord</QUAL>
+<SIMPLEPROXYCOMP id='_000001B1AFF199C0' oid='340D72C1E45B443d9D4DD81DE3924CAD' temploid='CCA94E3D4D4F4615AB6C6B98156FFBD5' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTCRecord</TUV>
+</NAME>
+<QUAL>DTCRecord</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF17750' oid='BCDBF2B8325949dd82275CE0447A7429' temploid='F591938809B945e2A17A6A2C87CD3D42' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDTC</TUV>
+</NAME>
+<QUAL>StatusOfDTC</QUAL>
+</STATUSDTCPROXYCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='EC385C2E6DD841e39218F80CF68F2DF9' temploid='192F4579B56B417898B543426CA4AFED'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCBSM-NR</TUV>
+</NAME>
+<QUAL>RDI_RDTCBSM_NR</QUAL>
+<CONSTCOMP id='_000001B1AFF1A340' oid='02216B4F7B594d33888898D8A9FE6A98' temploid='C37F2CD501D14f51A2E79069D669387B' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF18920' oid='987E9729DCFE41489DF0714CB78A859B' temploid='ECA69C4E8E0D421cA07F6B77DF7CA298' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF19AF0' oid='C79E96C0A91D48a19A574F9B091B533B' temploid='E09C3BF04C4E4830BE29AD57105676EB' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Response Code</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFF3FFF0' oid='1DAF448534B94c6a86DFFE19473375FE' temploid='5598E5BB53FB47a09D177E164AD26FDE' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' sprmibonfunc='never' sprmibonphys='never'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - ReportUserDefMemoryDTCSnapshotRecordByDTCNumber</TUV>
+</NAME>
+<QUAL>_19_ReadDtcInformation_ReportUserDefMemoryDTCSnapshotRecordByDTCNumber</QUAL>
+<REQ oid='201F140B45B64b29BBE5FB0A35872C8D' temploid='6BB115945AEE4c1b929D7E3BA44FEE4B'>
+<NAME>
+<TUV xml:lang='en-US'>_19_ReadDtcInformation_ReportDtcSnapshotRecordByDtcNumber-RQ</TUV>
+</NAME>
+<QUAL>_19_ReadDtcInformation_ReportDtcSnapshotRecordByDtcNumber_RQ</QUAL>
+<CONSTCOMP id='_000001B1AFF15870' oid='40EAD620794C444cB417DC29F4D36DA9' temploid='947E167A642B428880A81C9F22D27A40' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF173C0' oid='D0A896F0D7F04d75A5BBCB622AFF0632' temploid='64AAD0F2F707472180E92D90E00C59D5' must='1' spec='sub' bl='8' v='24' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcSnapshotRecordByDtcNumber</TUV>
+</NAME>
+<QUAL>ReportDtcSnapshotRecordByDtcNumber</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF16B70' oid='239C7CB2D2D544e7AFF2BEB465FDC7D3' temploid='FD2C32183ED441df86807A49712AD92B' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTCRecord</TUV>
+</NAME>
+<QUAL>DTCRecord</QUAL>
+</SIMPLEPROXYCOMP>
+<CONTENTCOMP id='_000001B1AD922160' oid='9DD5A9E7320B402eACF87E29E0B19D2B' temploid='652C6BE6568542169C1052C3516FC7ED' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordNumber</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordNumber</QUAL>
+<SIMPLECOMPCONT oid='F2F3A85C3737443399C1C82EA4658318' temploid='59C9DE86423A40948EBDE9833D2025FB'>
+<DATAOBJ oid='C6B2B7D63A9A4fff89B1CC4289694958' temploid='7F0A6009E82F42ca880406E9DB0747D2' spec='no' dtref='_000001B1ADBDD060'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordNumber</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordNumber</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<STATICCOMP id='_000001B1ADE2D070' oid='B56EA8AA32104b748D7CC0762D7D8768' temploid='8FD145467ECE48c3850FDC23B28AFC6C' must='1' spec='id' dtref='_000001B1ADBDDFD0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory Selection</TUV>
+</NAME>
+<QUAL>Memory_Selection</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='D37EAD0344694fb2A88D2CBF1C2547AF' temploid='E26004C962E044b69AD295CFA7C67FA9'>
+<NAME>
+<TUV xml:lang='en-US'>_19_ReadDtcInformation_ReportDtcSnapshotRecordByDtcNumber-PR</TUV>
+</NAME>
+<QUAL>_19_ReadDtcInformation_ReportDtcSnapshotRecordByDtcNumber_PR</QUAL>
+<CONSTCOMP id='_000001B1AFF192A0' oid='76709AFEA3664683A0C670794746E4B6' temploid='8297D75ED846450bBE703C864ABD044F' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF19FB0' oid='F7BB948892D344898A716DD1121F0D8B' temploid='43032E66F0FA45f0AA07C3523D00A93C' must='1' spec='sub' bl='8' v='24'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcSnapshotRecordByDtcNumber</TUV>
+</NAME>
+<QUAL>ReportDtcSnapshotRecordByDtcNumber</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2F7C0' oid='F15FFF8F073E4efd96379DCFC6D5C726' temploid='89A7D7BC103544949395552C2B2D5982' must='1' spec='id' dtref='_000001B1ADBDDFD0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory Selection</TUV>
+</NAME>
+<QUAL>Memory_Selection</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF193D0' oid='2319630393E14b94BF5BBC97FAB25CE1' temploid='79D93DC8894241a79437C9FB8352F308' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTCRecord</TUV>
+</NAME>
+<QUAL>DTCRecord</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF17E70' oid='471F7CE278DA4ea48909439A73EF8595' temploid='EB4D16122D704cb2B12DE072181DEA5B' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDtc</TUV>
+</NAME>
+<QUAL>StatusOfDtc</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAB0670' oid='181B372B90A24bbcACAD20223AE89FB9' temploid='3301648B2DB94c2aB6F6488FA38398BE' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>Parameter</TUV>
+</NAME>
+<QUAL>Parameter</QUAL>
+<CONTENTCOMP id='_000001B1AD920560' oid='61EDA5ED957E4f2aA04C1B61C352BD80' temploid='C513F1B451B544f89581CD646FB0B57C' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordNumber</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordNumber</QUAL>
+<SIMPLECOMPCONT oid='92C36F723EAF42eeA957E7C29B2B64D5' temploid='841045F718B342429BE06CE2F6A67471'>
+<DATAOBJ oid='98BB9955DE4B4e879B3C54F8DA484B91' temploid='88BC76FDD9564485919368E1F845BAE0' spec='no' dtref='_000001B1ADBDBE90'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordNumber</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordNumber</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<CONTENTCOMP id='_000001B1AD921DE0' oid='0994E42E1A54405fAA7306A50FFC454E' temploid='8A7983DB8C33413e8B05A27A16B93E03' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordNumberOfIdentifiers</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordNumberOfIdentifiers</QUAL>
+<SIMPLECOMPCONT oid='A43F24D3F254487eB8A91F5151655B8F' temploid='AC946A5DDE374449A8156A8D092F693C'>
+<DATAOBJ oid='C9720D14A8174b80B8A5BEE893AC9EF4' temploid='9C8D943FE010476aBAB668FB0FC01AC3' spec='no' dtref='_000001B1ADB61FE0'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecordNumberOfIdentifiers</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecordNumberOfIdentifiers</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<MUXCOMP id='_000001B1AFF16CA0' oid='9793AF74B37743fcB4DE87818AE3A5EC' temploid='646E7F93242549e88342F9D4901BB5DF' must='1' selref='_000001B1AFF193D0' selbm='4294967295' dest='envData' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecord</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecord</QUAL>
+</MUXCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='2B9BB857CB9246ce9BA5480B264FFF76' temploid='C0B9CC6F9E91490f806A66C5EDE0AF64'>
+<NAME>
+<TUV xml:lang='en-US'>_19_ReadDtcInformation_ReportDtcSnapshotRecordByDtcNumber-NR</TUV>
+</NAME>
+<QUAL>_19_ReadDtcInformation_ReportDtcSnapshotRecordByDtcNumber_NR</QUAL>
+<CONSTCOMP id='_000001B1AFF18A50' oid='D73BC25E6BFD4652B1488838162E9BEA' temploid='AE448EF346DF4cbeB2B6E9E694356F71' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF18B80' oid='EE671803769947599C7E17125C0093AF' temploid='A98015A036374c7eAB1D7EFA28B769E0' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ-NR</TUV>
+</NAME>
+<QUAL>SID_RQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF159A0' oid='EC39D14672984c928BA284202EB76E7C' temploid='3D90534177A74a7f8C7EB44459321C5D' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>RESPONSE CODE</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+<PROTOCOLSERVICE id='_000001B1AFF3E4F0' oid='3BCD279F3AF14f7fB5057C3B074A3CA9' temploid='BBE496D512D540168A01B5CB313B6726' func='1' phys='1' mresp='0' respOnPhys='1' respOnFunc='1' sprmibonfunc='never' sprmibonphys='never'>
+<NAME>
+<TUV xml:lang='en-US'>($19) ReadDtcInformation - ReportUserDefMemoryDTCExtendedDataRecordByDTCNumber</TUV>
+</NAME>
+<QUAL>_19_ReadDtcInformation_ReportUserDefMemoryDTCExtendedDataRecordByDTCNumber</QUAL>
+<REQ oid='435A359F8E7B411e807F60C2FB56A8D1' temploid='6B472EE739B94bb59C6FFD53D94B4B76'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCEDRBDN-RQ</TUV>
+</NAME>
+<QUAL>RDI_RDTCEDRBDN_RQ</QUAL>
+<CONSTCOMP id='_000001B1AFF17290' oid='567E4ED3E1B94a729573AEB261F6AA4D' temploid='FC639110705D4865883A942EE58FEF77' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SID-RQ</TUV>
+</NAME>
+<QUAL>SID_RQ</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF15AD0' oid='8090ABEFC4AC47e0A83458764D66452A' temploid='71ECD9663FC74de38CBFFC52F5F46504' must='1' spec='sub' bl='8' v='25' respsupbit='1'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcExtendedDataRecordByDtcNumber</TUV>
+</NAME>
+<QUAL>ReportDtcExtendedDataRecordByDtcNumber</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF16DD0' oid='F96904D672A24355B42E34CFAEAF1649' temploid='BCD97579DADF4946A1080B9799143194' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTCRecord</TUV>
+</NAME>
+<QUAL>DTCRecord</QUAL>
+</SIMPLEPROXYCOMP>
+<MUXCOMP id='_000001B1AFF179B0' oid='0EF992CFC8774145AEF50C9747DD01B3' temploid='8079DBCD096D43d9A677F00EC97D4DCE' must='1' selref='_000001B1AFF16DD0' selbm='4294967295' dest='envData' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCExtendedDataRecordNumber</TUV>
+</NAME>
+<QUAL>DTCExtendedDataRecordNumber</QUAL>
+</MUXCOMP>
+<STATICCOMP id='_000001B1ADE2E060' oid='0685CF1A3A4A46f9BB7AF3243D4A934E' temploid='062573C977C648a4BDC846B0F195AE84' must='1' spec='lid' dtref='_000001B1ADBDDFD0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory Selection</TUV>
+</NAME>
+<QUAL>Memory_Selection</QUAL>
+</STATICCOMP>
+</REQ>
+<POS oid='E451A55341C24e1e9BA42DD0C1D8C023' temploid='8B477DB303134576A53ECB003F17C90F'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCEDRBDN-PR</TUV>
+</NAME>
+<QUAL>RDI_RDTCEDRBDN_PR</QUAL>
+<CONSTCOMP id='_000001B1AFF15C00' oid='0A99478A4629490fB47D126CE90E03B5' temploid='66CDD17CDF1C44968F9D10DBA497CAC9' must='1' spec='sid' bl='8' v='89'>
+<NAME>
+<TUV xml:lang='en-US'>SID-PR</TUV>
+</NAME>
+<QUAL>SID_PR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF15D30' oid='0913B1A8D98742fbA2A57609AA0D96FC' temploid='B779D9FF2A574ae4AE2471A9C8C09A8B' must='1' spec='sub' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>ReportDtcExtendedDataRecordByDtcNumber</TUV>
+</NAME>
+<QUAL>ReportDtcExtendedDataRecordByDtcNumber</QUAL>
+</CONSTCOMP>
+<STATICCOMP id='_000001B1ADE2D290' oid='C9C7198E4AB34b06B9AD227E57823886' temploid='3831DA50943D47deAF3E72E75AC1E0D2' must='1' spec='lid' dtref='_000001B1ADBDDFD0'>
+<NAME>
+<TUV xml:lang='en-US'>Memory Selection</TUV>
+</NAME>
+<QUAL>Memory_Selection</QUAL>
+</STATICCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF15E60' oid='521426680702458f9C604F9B86441757' temploid='580041096AD345d093BC416D87D00A2E' must='1' dest='dtc' minbl='24' maxbl='24'>
+<NAME>
+<TUV xml:lang='en-US'>DTCRecord</TUV>
+</NAME>
+<QUAL>DTCRecord</QUAL>
+</SIMPLEPROXYCOMP>
+<STATUSDTCPROXYCOMP id='_000001B1AFF16F00' oid='FCC6FEA04E4A4ccd9FC7D0E55D5C16A4' temploid='B59350351AC94e839E69991291B24F18' must='1' dest='dtcStatus' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDtc</TUV>
+</NAME>
+<QUAL>StatusOfDtc</QUAL>
+</STATUSDTCPROXYCOMP>
+<EOSITERCOMP id='_000001B1ADAAF970' oid='ED9CE808E5014ced8EE06669707EDC84' temploid='602939A0BAFD441090D348A060CB5099' must='1' minNumOfItems='0'>
+<NAME>
+<TUV xml:lang='en-US'>ListOfExtendedDataRecords</TUV>
+</NAME>
+<QUAL>ListOfExtendedDataRecords</QUAL>
+<CONTENTCOMP id='_000001B1AD9211A0' oid='43F0FA8C583143f79435FBA91CFDB397' temploid='5E81E0A0699A402b996F0A72B0459089' must='1'>
+<NAME>
+<TUV xml:lang='en-US'>ExtDataRecordList</TUV>
+</NAME>
+<QUAL>ExtDataRecordList</QUAL>
+<SIMPLECOMPCONT oid='D87D76F514394a2e8E8ECEA5C1E60B06' temploid='5BC6A0667FCE49af8D39A3569C126D83'>
+<DATAOBJ oid='C3621E3AD3704c469B682E580A94FAE8' temploid='5797D3ABB8014dca89D29EBB5E5A7DE9' spec='no' dtref='_000001B1ADBDC6E0'>
+<NAME>
+<TUV xml:lang='en-US'>ExtendedDataRecordNumber</TUV>
+</NAME>
+<QUAL>ExtendedDataRecordNumber</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+</CONTENTCOMP>
+<MUXCOMP id='_000001B1AFF16320' oid='DDF302DA514B4c9585A5C365294448CE' temploid='73D8E0F5E0884fb39A30FDEE17ACA91A' must='1' selref='_000001B1AD9211A0' selbm='4294967295' dest='envData' minbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>DTCExtendedDataRecord</TUV>
+</NAME>
+<QUAL>DTCExtendedDataRecord</QUAL>
+</MUXCOMP>
+</EOSITERCOMP>
+</POS>
+<NEG oid='C4ED9B2368B049b88533E53156019FB9' temploid='92D549295DEF4cea8FD9C8A3171CBD3A'>
+<NAME>
+<TUV xml:lang='en-US'>RDI_RDTCEDRBDN-NR</TUV>
+</NAME>
+<QUAL>RDI_RDTCEDRBDN_NR</QUAL>
+<CONSTCOMP id='_000001B1AFF17AE0' oid='E7489E00A7B24bb9BD1066883B9C03F9' temploid='CA5072ADD9C74d56AE22F2179060CCE0' must='1' spec='sid' bl='8' v='127'>
+<NAME>
+<TUV xml:lang='en-US'>SID-NR</TUV>
+</NAME>
+<QUAL>SID_NR</QUAL>
+</CONSTCOMP>
+<CONSTCOMP id='_000001B1AFF18DE0' oid='FDDE85341807467d8FA9C9E0634B0086' temploid='A4885AC6F0E94ed29112A8F3E41731F8' must='1' spec='sid' bl='8' v='25'>
+<NAME>
+<TUV xml:lang='en-US'>SIDRQ-NR</TUV>
+</NAME>
+<QUAL>SIDRQ_NR</QUAL>
+</CONSTCOMP>
+<SIMPLEPROXYCOMP id='_000001B1AFF16450' oid='A5698304E29F4068AF03A4EF3EFDF819' temploid='D2D7326F7F7D4692A98FED8BB24BB119' must='1' dest='resCode' minbl='8' maxbl='8'>
+<NAME>
+<TUV xml:lang='en-US'>Response Code</TUV>
+</NAME>
+<QUAL>RC</QUAL>
+</SIMPLEPROXYCOMP>
+</NEG>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02A50'/>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+</NEGRESCODEPROXIES>
+</PROTOCOLSERVICE>
+</PROTOCOLSERVICES>
+<DCLTMPLS>
+<DCLTMPL id='_000001B1ADAAD770' oid='017FCE71817E4e8eB20342629762BE90' temploid='{F1B56AC3-6C42-4eec-9A8B-D24398DA03A6}' cls='ses' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Sessions</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US'>This Diagnostic Class is describing the use case of the Session Management.</TUV>
+</DESC>
+<QUAL>Sessions</QUAL>
+<DCLSRVTMPL id='_000001B1ADCB8E20' oid='EC0638ED827C467bA763ED1F1F9B7AF9' temploid='{1CD54262-F5DA-45b8-921D-DD37B699FAC7}' tmplref='_000001B1ABFA3530' dtref='_000001B1ADB667A0' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Start</TUV>
+</NAME>
+<QUAL>Start</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1ADA6D580' oid='CE98E513E7334208BB0B8E948FAE9F2F' temploid='{C2610F08-4AEA-45c1-8172-A7974B2D8A81}' spec='sub'>
+<NAME>
+<TUV xml:lang='en-US'>DiagnosticSessionType</TUV>
+</NAME>
+<QUAL>DiagSessionType</QUAL>
+<STATICCOMPREF idref='_000001B1AD93B7F0'/>
+<STATICCOMPREF idref='_000001B1AD93B2A0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1ADAAF570' oid='97C8EA7AE310495cBE4B8DDD6C28F919' temploid='{36CA474D-6F99-4fc3-9B56-E1488457B5A2}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Start NR</TUV>
+</NAME>
+<QUAL>Start_NR</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD59F70'/>
+</SHPROXY>
+<SHPROXY id='_000001B1ADAAF770' oid='EABD40277EC74528879970697492E1D8' temploid='BDCC1DE56C8C4a728A9C5BD776804979' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>SessionParameterRecord</TUV>
+</NAME>
+<QUAL>SessionParameterRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD5AC80'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B187F9ECC0' oid='87CE8F9B998640bc9210B6643CA46F0F' temploid='8F4210B1844C4efa8EAB55A0AA3E0D2E' cls='fun' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Ecu Reset</TUV>
+</NAME>
+<QUAL>Ecu_Reset</QUAL>
+<DCLSRVTMPL id='_000001B1ADCB9A80' oid='B799BCA46AA346a2A4F11B106EDFBE7F' temploid='B327065BFCF94124ABFFA2DB31EA32F6' tmplref='_000001B1ADF15060' dtref='_000001B1ADB67120' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Reset</TUV>
+</NAME>
+<QUAL>Reset</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1ADA6D700' oid='20F5629157454225B03D0B7E14F89E6F' temploid='ACB617C75EB34821B6C9478D85834386' spec='sub'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>ResetType</QUAL>
+<STATICCOMPREF idref='_000001B1ADE318B0'/>
+<STATICCOMPREF idref='_000001B1ADE328A0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B18D00EC90' oid='B847C6218E5847d69AFC9702D3A0EEF9' temploid='79D42B4DD2734a709D7F89B0731C319F' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Reset</TUV>
+</NAME>
+<QUAL>Reset</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB1170'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAA870' oid='F5BC6D11DC6147b69BB0DFCDC9AD3A6A' temploid='EB2893A0023F4633A3F09FBA3B64B360' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>PowerDownTime</TUV>
+</NAME>
+<QUAL>PowerDownTime</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEAFFA0'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFAC270' oid='736AFFDCD17B4044A6D0055FCC94FAF3' temploid='{72324404-D520-4b1d-9019-282F6AD789A4}' cls='sec' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Security Access</TUV>
+</NAME>
+<QUAL>SecurityAccess</QUAL>
+<DCLSRVTMPL id='_000001B1ADCB9DE0' oid='E1FA125813834cc49BB29B134284FD38' temploid='{9933B22A-9141-47c7-B14A-D480660BFAC1}' tmplref='_000001B1ABFA4BB0' dtref='_000001B1ADB66C60' conv='optyes' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Request</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADCB8AC0' oid='864885CFEC3D4eae87E0A842A2B64EDF' temploid='{B2F65C91-A27E-4e68-84FB-0EC00EBA2209}' tmplref='_000001B1ABFA3770' dtref='_000001B1ADB66C60' conv='optyes' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Send</TUV>
+</NAME>
+<QUAL>Send</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1ADA6E000' oid='6CBE0F7E13274673ACB9AAD9E76F0677' temploid='{0529D1DD-0ED7-4034-9CE4-2C16A2C067D9}' spec='sub'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>SecurityAccessType</QUAL>
+<STATICCOMPREF idref='_000001B1AD93AA20'/>
+<STATICCOMPREF idref='_000001B1AD93D280'/>
+<STATICCOMPREF idref='_000001B1AD93D4A0'/>
+<STATICCOMPREF idref='_000001B1AD93BA10'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1AFFABC70' oid='E42A6E905F3448eaA1D03B7D218788E4' temploid='{159C9069-133D-48bf-8090-D1D396BAF165}' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>Seed</TUV>
+</NAME>
+<QUAL>Seed</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD5B860'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAAC70' oid='977BB18E517944e5858D4A9970F1232F' temploid='{C9F1BB2C-8095-4179-B55D-D39456642CF3}' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Key</TUV>
+</NAME>
+<QUAL>Key</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD5AEE0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAC070' oid='E52CD484B7A24ae38F20CF58076E0592' temploid='{82029372-9968-47a3-84F2-939A51AD8A69}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Anfordern</TUV>
+</NAME>
+<QUAL>Request</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD5B990'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAB070' oid='E9A6CA205D7A4d54B909A23BFEC74BA9' temploid='{7D08A41D-D439-4233-BB8B-C0E7070854CD}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Senden</TUV>
+</NAME>
+<QUAL>Send</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD5B4D0'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFAC170' oid='295187893F744a778209659C01D9450A' temploid='06C3B19BBB66496cACA6BF7749A77E73' cls='com' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Communication Control</TUV>
+</NAME>
+<QUAL>Communication_Control</QUAL>
+<DCLSRVTMPL id='_000001B1ADCB9600' oid='6901BF153A314786A2223C60AB01CA63' temploid='1AAA0A2A20EE4d9dBF125B4064DD645D' tmplref='_000001B1ABFA39B0' dtref='_000001B1ADB65E20' conv='req' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Control</TUV>
+</NAME>
+<QUAL>Control</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1ADA6DC40' oid='2894E985877A4ae798FE3166DD855155' temploid='B920CF457C1B4237A5B0178A64317D95' spec='sub'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>ControlType</QUAL>
+<STATICCOMPREF idref='_000001B1AD93B3B0'/>
+<STATICCOMPREF idref='_000001B1AD93C4B0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1AFFACC70' oid='FDB6F5B569EC486fB9756AB05F856931' temploid='11F811C503404bccBA3CA58C9737193A' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>CommunicationType</TUV>
+</NAME>
+<QUAL>CommunicationType</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD58DA0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFABA70' oid='053C5B7F622D404b90C2E62F6E912DF4' temploid='52A5651FD1C84f07927D1D1E9C38784C' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Control</TUV>
+</NAME>
+<QUAL>Control</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD5BAC0'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFAC970' oid='4C329C2FBAE54bcfA9F1D6B032BBD8E1' temploid='65945036112F4685A8E583B1F5EEB95D' cls='com' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Communication Control - EnhancedAddressInformation</TUV>
+</NAME>
+<QUAL>Communication_Control_EnhancedAddressInformation</QUAL>
+<DCLSRVTMPL id='_000001B1ADCB9960' oid='9C43183D7353484089EC385F423E906E' temploid='D5E582409F9B44b0A665D964EAA112C3' tmplref='_000001B1ADF14520' dtref='_000001B1ADBDEF40' conv='req' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Control</TUV>
+</NAME>
+<QUAL>Control</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1ADA6D7C0' oid='92575D2276314e04BE45C1318846DE13' temploid='732E07E4507644d8926F22EE7ACC30B8' spec='sub'>
+<NAME>
+<TUV xml:lang='en-US'>Type</TUV>
+</NAME>
+<QUAL>ControlType</QUAL>
+<STATICCOMPREF idref='_000001B1ADE308C0'/>
+<STATICCOMPREF idref='_000001B1ADE33DE0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1AFFACE70' oid='D6190CE7D7D54da1BEF5844EC381B2B8' temploid='374DDEDC33EB4493A4719CC4315BABFF' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>CommunicationType</TUV>
+</NAME>
+<QUAL>CommunicationType</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2F2B0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAA270' oid='B6C12C02AAA246ca941C52CA5BCDFA96' temploid='EB20AAAC1F2E4262ADB94BE71549C44B' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>NodeIdentificationNumber</TUV>
+</NAME>
+<QUAL>NodeIdentificationNumber</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2F3E0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFACD70' oid='3C58C6ACE3AA4f718F48ABBB67A920CE' temploid='6827CFB885544d4aB61724A5210A3193' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Control</TUV>
+</NAME>
+<QUAL>Control</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2E210'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFAA670' oid='EA2C55D3FF6C471988933C6B61E952B7' temploid='{D3E9D1BC-56CE-44b4-AA33-F3B1681C7F94}' cls='tpr' single='1'>
+<NAME>
+<TUV xml:lang='en-US'>Tester Present</TUV>
+</NAME>
+<QUAL>TesterPresent</QUAL>
+<DCLSRVTMPL id='_000001B1AFFAE860' oid='2A45376DD86B4c1dB7D7E953ED8D9766' temploid='{481167C9-5F05-4127-A189-A2228CDDE0E9}' tmplref='_000001B1ABFA30B0' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Send</TUV>
+</NAME>
+<QUAL>Send</QUAL>
+</DCLSRVTMPL>
+<SHPROXY id='_000001B1AFFAA770' oid='DA21A77B17D7429d9D83CAEEC56691AE' temploid='{379093F8-67DF-41d5-B89C-4BB266F6736C}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Senden</TUV>
+</NAME>
+<QUAL>Send</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD5AA20'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFAAE70' oid='A6E0A146C58043ee801C7BD22CA63C9D' temploid='{0E0B0844-D4F4-4ae2-A5B8-2AD95E3823E7}' cls='fun' single='1'>
+<NAME>
+<TUV xml:lang='en-US'>Control DTC Setting</TUV>
+</NAME>
+<QUAL>ControlDTCSetting</QUAL>
+<DCLSRVTMPL id='_000001B1AFFAF160' oid='9B0141510C1C4a2f990C42EFE92CD48F' temploid='1304CA473F404be781310CA062D352A7' tmplref='_000001B1ADDCD030' conv='req' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>On</TUV>
+</NAME>
+<QUAL>On</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFAE620' oid='9CB6A478882248f596CE2130C093F56D' temploid='D62DF61D3F2C4054A8DE291E31423BF9' tmplref='_000001B1ADDCE470' conv='req' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Off</TUV>
+</NAME>
+<QUAL>Off</QUAL>
+</DCLSRVTMPL>
+<SHPROXY id='_000001B1AFFAA970' oid='9278178D75E44c2f8444BE87847B5ED5' temploid='CD34526B21BF45aa93D630B6FCB17C4B' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>New Service 1</TUV>
+</NAME>
+<QUAL>New_Service_1</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE647E0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAA470' oid='A90C628D8FC64e62A552C8E96B8179BE' temploid='AFE3E6CA7F1C4e02AC50E73B4CE448E3' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>New Service 2</TUV>
+</NAME>
+<QUAL>New_Service_2</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC9130'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAAD70' oid='6FF418089DD44e1e90B759B7BB101613' temploid='5B5A884BAE1C4fee939A31FAF8E2FFA8' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSettingControlOptionRecord</TUV>
+</NAME>
+<QUAL>DTCSCOR_</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE659B0'/>
+<PROXYCOMPREF idref='_000001B1ADDCBD20'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFAB970' oid='D9EC15B5F4C74fe781B364AD3EB2F750' temploid='B8B1269A4B93463184F80B2275102BC3' cls='fun' single='1'>
+<NAME>
+<TUV xml:lang='en-US'>Response on Event</TUV>
+</NAME>
+<QUAL>Response_on_Event</QUAL>
+<DCLSRVTMPL id='_000001B1AFFAE980' oid='9F401798B7BE4caf8EF86B45E64CF6E8' temploid='ECC290F553E245c3A089CEC0EF5FD765' tmplref='_000001B1ADF17460' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>On DTC Status Change</TUV>
+</NAME>
+<QUAL>On_DTC_Status_Change</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFAEAA0' oid='020F8DFCEF0E463aAD79B4C7427B2495' temploid='ADF7B44836D14e23A172476C555BD1CA' tmplref='_000001B1ADF176A0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Report Activated Events</TUV>
+</NAME>
+<QUAL>Report_Activated_Events</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFAE1A0' oid='D4E2EDB158654d86855DFCD609A80411' temploid='F8A88A2955994056914E19B84DCA355B' tmplref='_000001B1ADF16DA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Start</TUV>
+</NAME>
+<QUAL>Start</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFAF3A0' oid='38ACE5A372814e24BD71F951E9751D66' temploid='A5F7E2919F7F45a990C83C544553F4B3' tmplref='_000001B1ADF17220' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Stop</TUV>
+</NAME>
+<QUAL>Stop</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFAF700' oid='FBB19B7AEA3C421f8A6FDED189E18258' temploid='7061668DDC4A43f4BF4AC3ABE8EA63BB' tmplref='_000001B1ADF140A0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Clear</TUV>
+</NAME>
+<QUAL>Clear</QUAL>
+</DCLSRVTMPL>
+<SHPROXY id='_000001B1AFFACF70' oid='DE1E6E95192E44d0913487A90FCA48E7' temploid='8FE7BDA8F4A34907BB015F13F8FD2D35' dest='dtcStatus'>
+<NAME>
+<TUV xml:lang='en-US'>EventTypeRecord</TUV>
+</NAME>
+<QUAL>EventTypeRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEA8ED0'/>
+<PROXYCOMPREF idref='_000001B1AFE2AA40'/>
+<PROXYCOMPREF idref='_000001B1AFE2A0C0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAB270' oid='1BD0B74EE8EA41fcBFC5B83FC1EE8565' temploid='77BE722C0B7D4741979D10D90C29CE28' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>DTC StatusMask</TUV>
+</NAME>
+<QUAL>ServiceToRespondTo_DTCStatusMask</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEA9850'/>
+<PROXYCOMPREF idref='_000001B1AFE2A580'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFABD70' oid='459D17B9748F4d58BEAA51E0E13D3B36' temploid='4C51042528E54dd4B41DAA72B43EBA35' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>On DTC Status Change</TUV>
+</NAME>
+<QUAL>On_DTC_Status_Change</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE29E60'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAB870' oid='D4274374C66D4b15A9E7CCA42865F78C' temploid='F9267A605CF742f895B913B14280E468' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Report Activated Events</TUV>
+</NAME>
+<QUAL>Report_Activated_Events</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2CB80'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFADA70' oid='7F85C5EDCC254d2cAEA89B8BBE274189' temploid='EB2EA63AF9454bd38C44DD9A63DB3308' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Start</TUV>
+</NAME>
+<QUAL>Start</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2CDE0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAAA70' oid='BC6B566175174492A53D22FE4FF42B04' temploid='4B2E78BCF5A4449bB7DFE52448AF5378' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Stop</TUV>
+</NAME>
+<QUAL>Stop</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEA82F0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAA070' oid='A065D7616F4749beB24C546A7E00BC5F' temploid='16852B28FE064d2392446A5710CAA30A' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Clear</TUV>
+</NAME>
+<QUAL>Clear</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2A1F0'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFABB70' oid='BD425363619E45f6AA95103161B213EE' temploid='C826EFF5E8474bbdB24C839F5C4BEDAE' cls='act' single='1' isRelevantForReq='1'>
+<NAME>
+<TUV xml:lang='en-US'>LinkControl</TUV>
+</NAME>
+<QUAL>LinkControl</QUAL>
+<DCLSRVTMPL id='_000001B1AFFAEF20' oid='D6193675C7094531AC2219608559301B' temploid='18DCA3ABB6134c6e9835253B2BC4D49A' tmplref='_000001B1ADF142E0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Transition</TUV>
+</NAME>
+<QUAL>Transition</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFAF5E0' oid='C55EBB7EBBB141fc8C7D999FD6D7BE62' temploid='1B801018B99A4e5e8D8255A78A97F7AC' tmplref='_000001B1ADF15960' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Verify fixed</TUV>
+</NAME>
+<QUAL>Verify_fixed</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFAFEE0' oid='CB6F75B577AA449889C0C9F6B21C1664' temploid='2BED6FDB94CD4163A409667905BBAB93' tmplref='_000001B1ADF15BA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Verify specific</TUV>
+</NAME>
+<QUAL>Verify_specific</QUAL>
+</DCLSRVTMPL>
+<SHPROXY id='_000001B1AFFAB170' oid='6EDC03903B094c2b89F240492DEB7B56' temploid='8F0CBE00FBF74338B74B03797C0E17BF' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Verify fixed</TUV>
+</NAME>
+<QUAL>Verify_fixed</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2C460'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAAB70' oid='D19F14E6FB00415289D34A00CEC63BCD' temploid='F914086D210741138BE76274ED426B1E' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>linkRecord</TUV>
+</NAME>
+<QUAL>linkRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2D3D0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAC470' oid='DAEA830161A1450d925AA2D8E3117FD9' temploid='2983E1ADB45D4a11B90EFB53B801EECD' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Verify specific</TUV>
+</NAME>
+<QUAL>Verify_specific</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2E340'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAB570' oid='7C85589B113F4822BD00B0A1C74AE286' temploid='B6E197D725034eb9BFD7BC3E84892E6B' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Transition</TUV>
+</NAME>
+<QUAL>Transition</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2AF00'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFAD570' oid='084B5F01A3B54cf0803B9A1C1FB351BE' temploid='507EC60CD7C441cfB5565E1A2CCB54E0' cls='idn' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>ECU Identification</TUV>
+</NAME>
+<QUAL>ECU_Identification</QUAL>
+<DCLSRVTMPL id='_000001B1AFFAE080' oid='A5F904295EF94b8c88A333A4F74DA4B7' temploid='9B759C8326CC47118550F9C2602AF66C' tmplref='_000001B1ABFA4070' dtref='_000001B1ADB65370' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFD3380' oid='D49E1DC83F5D46a5827522C883107529' temploid='C9107A8336A84407BE7DF6FD59FE369A' tmplref='_000001B1ABFA4DF0' dtref='_000001B1ADB65370' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Write</TUV>
+</NAME>
+<QUAL>Write</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFD3800' oid='F0BA3B0DDE8C406b80B89D3E9CE871A7' temploid='65ACDD7C3C2D4c749CDC42EEA34E1D13' tmplref='_000001B1ADF16B60' dtref='_000001B1ADB64D80' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Get Scaling</TUV>
+</NAME>
+<QUAL>Get_Scaling</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AC05E260' oid='0023937B66E24792A64E794D0E7B9C36' temploid='AAFD71C9498F4c98B3A4C21BEAF0E0B9' spec='id'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RecordDataIdentifier</QUAL>
+<STATICCOMPREF idref='_000001B1AD939920'/>
+<STATICCOMPREF idref='_000001B1AD93CB10'/>
+<STATICCOMPREF idref='_000001B1AD93C7E0'/>
+<STATICCOMPREF idref='_000001B1AD93B4C0'/>
+<STATICCOMPREF idref='_000001B1ADE32CE0'/>
+<STATICCOMPREF idref='_000001B1ADE306A0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1AFFAA570' oid='0F5F55C899704cb981B8A25AAF4E8A05' temploid='BD80C01AAD3D48edB17C2B1F6C08A737' dest='data' spec='didDataReference' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD57710'/>
+<PROXYCOMPREF idref='_000001B1ADD554A0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAD070' oid='58D32F8098E3479d81E4D7528940B4F6' temploid='37E486CE9A36413b931BD076D64964DD' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD55960'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFABE70' oid='1B33C248D2494a00997AA40AB90F7DB4' temploid='D231681B4A9C474bA23597A61FA97D36' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Write</TUV>
+</NAME>
+<QUAL>Write</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD54530'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAAF70' oid='48A3DB57400C43feBB24A409ECCF185E' temploid='E974C90376C4474c9F10A4BBF33981B9' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Scaling data</TUV>
+</NAME>
+<QUAL>Scaling_data</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEA7AA0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAD370' oid='28E74EE74660446e9C51F05B670468C9' temploid='E1CEE3D06D5F4e218584CD52198C7A9D' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Get Scaling</TUV>
+</NAME>
+<QUAL>Get_Scaling</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEA6540'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFAB370' oid='FCFB3E4C675348ec9C87099381232843' temploid='B9334B557A1B40d1A659A8B2364BAC91' cls='vcd' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Variant Coding</TUV>
+</NAME>
+<QUAL>Variant_Coding</QUAL>
+<DCLSRVTMPL id='_000001B1AFFD3C80' oid='96A4CEE471CF46ca8642A49A7C1F8F0B' temploid='A63708B344A9413b9FEF3225EDBA8AE7' tmplref='_000001B1ABFA4070' dtref='_000001B1ADB65370' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFD3B60' oid='100E16B14766480c95D0C7EF4AA7A00B' temploid='C7C4350FD93E4f4788AD8969F93983E7' tmplref='_000001B1ABFA4DF0' dtref='_000001B1ADB65370' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Write</TUV>
+</NAME>
+<QUAL>Write</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AC05E020' oid='501192C1CF0844ecBAB19C9DA529A34B' temploid='40AD2344549C4d669437CFF0383EF1F2' spec='id'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RecordDataIdentifier</QUAL>
+<STATICCOMPREF idref='_000001B1AD939920'/>
+<STATICCOMPREF idref='_000001B1AD93CB10'/>
+<STATICCOMPREF idref='_000001B1AD93C7E0'/>
+<STATICCOMPREF idref='_000001B1AD93B4C0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1AFFAD670' oid='10AFED95C0B54b62A4CDD80268766446' temploid='116A81F3E3AC4034BAABE91F849B9E9E' dest='data' spec='didDataReference'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD57710'/>
+<PROXYCOMPREF idref='_000001B1ADD554A0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAB670' oid='D2E77BF6AEB94f1695FD8E237B0A0FE8' temploid='787C0131F7454545AA513B28CA480658' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD55960'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAC370' oid='870E6BF519CE479eAFC5813A059EC234' temploid='0F08A87DAF2249f6A19D3592F7E12019' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Write</TUV>
+</NAME>
+<QUAL>Write</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD54530'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFACA70' oid='EB1E0C03CAA4463fA7BBF5B42CD4F019' temploid='8BF6FD33C5E94f3e9D55F56CC68F1048' cls='std' single='0' isRelevantForReq='1'>
+<NAME>
+<TUV xml:lang='en-US'>Stored Data</TUV>
+</NAME>
+<QUAL>Stored_Data</QUAL>
+<DCLSRVTMPL id='_000001B1AFFD36E0' oid='B003728055A34f2e99BE2253BC82D182' temploid='84FF43EDED4C462cAED9B2E7DB5E6AC4' tmplref='_000001B1ABFA4070' dtref='_000001B1ADB65370' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFD23C0' oid='42C52C543800446dB16BFB8426F9F7C8' temploid='24AC5D6C7F1B4b98A2EC7A07AFA0673D' tmplref='_000001B1ABFA4DF0' dtref='_000001B1ADB65370' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Write</TUV>
+</NAME>
+<QUAL>Write</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFD24E0' oid='8FFAFE3E276649b0B9D348520B630B63' temploid='CBA129B3C9694a18BF592368B3AF8140' tmplref='_000001B1ADF16B60' dtref='_000001B1ADB64D80' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Get Scaling</TUV>
+</NAME>
+<QUAL>Get_Scaling</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE6420' oid='C6BC61BF41C347548D82BE4647E88169' temploid='FD272E82867447c2B5B7E4FA1776C602' spec='id'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RecordDataIdentifier</QUAL>
+<STATICCOMPREF idref='_000001B1AD939920'/>
+<STATICCOMPREF idref='_000001B1AD93CB10'/>
+<STATICCOMPREF idref='_000001B1AD93C7E0'/>
+<STATICCOMPREF idref='_000001B1AD93B4C0'/>
+<STATICCOMPREF idref='_000001B1ADE32CE0'/>
+<STATICCOMPREF idref='_000001B1ADE306A0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1AFFADE70' oid='3C884ED3530D49cbB16B863A3615FC17' temploid='96268EF8E073485888957BE84B3B4E4A' dest='data' spec='didDataReference' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD57710'/>
+<PROXYCOMPREF idref='_000001B1ADD554A0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAB470' oid='6F64A9927A6D42bdA71DE732B31317BA' temploid='0BDCE7653F1D40359928CD084BB1D1B0' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD55960'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAA170' oid='F895D6B71775486b8C668CF79813FB0F' temploid='79B46EBC183B4cb7A083D2236CEFC1BE' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Write</TUV>
+</NAME>
+<QUAL>Write</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD54530'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFADD70' oid='67D9DB5A6D2B4c0b9C712FEF084E0A59' temploid='F3ABE67458934c6eBAE7370757D4A4EE' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Scaling data</TUV>
+</NAME>
+<QUAL>Scaling_data</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEA7AA0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAB770' oid='4D3B6AC59B1D4ed29C6E31EB3216A4E3' temploid='46ED3650F82242589257A8FFC5FA7671' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Get Scaling</TUV>
+</NAME>
+<QUAL>Get_Scaling</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEA6540'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFAD970' oid='CCCF0FA3F48341d08C88792A419E3C46' temploid='E975B3E0E6644640893D486BFEF27AB8' cls='act' single='0' isRelevantForReq='1'>
+<NAME>
+<TUV xml:lang='en-US'>Dynamic Data</TUV>
+</NAME>
+<QUAL>Dynamic_Data</QUAL>
+<DCLSRVTMPL id='_000001B1AFFD3EC0' oid='016479AC3FDC44fd943EB657B12EA6CA' temploid='B25243A003074f20B4A28D79CB3BCAD9' tmplref='_000001B1ABFA4070' dtref='_000001B1ADB65370' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFD2960' oid='B2233DED563F4fc99AB68BF3B610F0DB' temploid='5F4B7622842A4eff9F5A1642C11C7544' tmplref='_000001B1ADF16B60' dtref='_000001B1ADB64D80' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Get Scaling</TUV>
+</NAME>
+<QUAL>Get_Scaling</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE6120' oid='B4C16EFA824643e79ACA7F75F1E70814' temploid='AC8F84C41E64404e845F3977E520CB33' spec='id'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RecordDataIdentifier</QUAL>
+<STATICCOMPREF idref='_000001B1AD939920'/>
+<STATICCOMPREF idref='_000001B1AD93CB10'/>
+<STATICCOMPREF idref='_000001B1ADE32CE0'/>
+<STATICCOMPREF idref='_000001B1ADE306A0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1AFFABF70' oid='6644B75AECF74771B9D050AE6B36470A' temploid='33626F6573E3483aA108B83C64CBC8EE' dest='data' spec='didDataReference' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD57710'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAC570' oid='A19EEA1B358B4bb6987CAB7EA6E7653B' temploid='9617E3BA7F334d81A72597D262D6ACBF' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD55960'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAC670' oid='2EB7B7E419DA4eb5ABB07F0923A64056' temploid='5614BA45472D4802B11D4019D5F8A26D' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Scaling data</TUV>
+</NAME>
+<QUAL>Scaling_data</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEA7AA0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFACB70' oid='2DF00F507D3B4b09AEB6DF6755698064' temploid='613534CF1A494870BFC691FFF88F8377' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Get Scaling</TUV>
+</NAME>
+<QUAL>Get_Scaling</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEA6540'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFAC770' oid='7A1538CE2B8E4a41AD667CCC2E1B8B92' temploid='F75C5BBD46584b449F64D79F29F725D2' cls='act' single='0' isRelevantForReq='1'>
+<NAME>
+<TUV xml:lang='en-US'>Periodic Data</TUV>
+</NAME>
+<QUAL>Periodic_Data</QUAL>
+<DCLSRVTMPL id='_000001B1AFFD3140' oid='AAE956055BCD45a9B18AA047A9B0C01C' temploid='786669C36E9943b6956E18CED4EA715E' tmplref='_000001B1ADDCC970' dtref='_000001B1AD974DB0' conv='req' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Send once</TUV>
+</NAME>
+<QUAL>Send_once</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1AFFD3260' oid='EDE794978C474b26BEA8C4D7EBF22A3B' temploid='29AA0B0A421847d1B23150B77F0AF802' tmplref='_000001B1ADDCED70' dtref='_000001B1AD974DB0' conv='optyes' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Send slow</TUV>
+</NAME>
+<QUAL>Send_slow</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7BBD0' oid='493D6D50BCE64e66A0DCDA252D2330EA' temploid='4A36F9A7D2FC42ab800C1D59D6DEA842' tmplref='_000001B1ADDCEB30' dtref='_000001B1AD974DB0' conv='optyes' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Send medium</TUV>
+</NAME>
+<QUAL>Send_medium</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7BAB0' oid='50630C08FFB6483c878DFCE728966761' temploid='B9538722FBE24dc9AF4F8068A2189788' tmplref='_000001B1ADDCE8F0' dtref='_000001B1AD974DB0' conv='optyes' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Send fast</TUV>
+</NAME>
+<QUAL>Send_fast</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7BCF0' oid='7CA5AE2B8E00464f9434BF07C7E93306' temploid='1B5E196B819741c0AEDBC1DCCA05E276' tmplref='_000001B1ADDCF430' dtref='_000001B1AD974DB0' conv='req' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Stop</TUV>
+</NAME>
+<QUAL>Stop</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7CCB0' oid='8ED8D2F3DA82464c9628F54C43C5BE6C' temploid='D0953C0D333D4f30A7F40F85B32FB52F' tmplref='_000001B1ADDCEFB0' conv='req' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Stop all</TUV>
+</NAME>
+<QUAL>Stop_all</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE6A20' oid='B6B6D14E1F9244e18301EF2D3A8AC405' temploid='FED59340E139441dBAA5BDB23358E316' spec='id'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+<STATICCOMPREF idref='_000001B1ADE31250'/>
+<STATICCOMPREF idref='_000001B1ADE33780'/>
+<STATICCOMPREF idref='_000001B1ADE329B0'/>
+<STATICCOMPREF idref='_000001B1ADE31360'/>
+<STATICCOMPREF idref='_000001B1ADE33010'/>
+<STATICCOMPREF idref='_000001B1ADE319C0'/>
+<STATICCOMPREF idref='_000001B1ADE30590'/>
+<STATICCOMPREF idref='_000001B1ADE33340'/>
+<STATICCOMPREF idref='_000001B1ADE31580'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1AFFAC870' oid='5D5E152743924a70A442C23CB125F0B5' temploid='567485846AD84d7d9211A27EBFD4701E' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Send fast</TUV>
+</NAME>
+<QUAL>Send_fast</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDCA0A0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAD170' oid='BDAE3B441F4E459c9FCBBEB3F3D172BF' temploid='A4C8884F13AE47a9B21177019B6DE773' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Send slow</TUV>
+</NAME>
+<QUAL>Send_slow</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE5FD10'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAD270' oid='0FEAFD8797B24949BE7AF65B1B34E906' temploid='1965B6C462A646a6B6FC7D31716B03CC' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Send medium</TUV>
+</NAME>
+<QUAL>Send_medium</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDCB4D0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFADB70' oid='2F0D452964BA448085346ACCB4D8D2AB' temploid='A6C3DC2CBEDF4e0180405F8AF4FB58F5' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Stop</TUV>
+</NAME>
+<QUAL>Stop</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE60690'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAD470' oid='0958073B82A24dce92C3E22F965E2C2A' temploid='EEBC70449BDD47cd80578C0E18276CA1' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Stop all</TUV>
+</NAME>
+<QUAL>Stop_all</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE61F80'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAD770' oid='2EC1EBC6A11D422dA664C4252C43AF51' temploid='7BA418DE7FB84df6BF0A9F73435311AF' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE5F000'/>
+<PROXYCOMPREF idref='_000001B1ADE61D20'/>
+<PROXYCOMPREF idref='_000001B1ADDCA1D0'/>
+<PROXYCOMPREF idref='_000001B1ADDC9BE0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1AFFAD870' oid='435E482349C64dd6988B8105CBC1E931' temploid='28D67DC85DDF48ca8AFCC394A51D49CC' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Send once</TUV>
+</NAME>
+<QUAL>Send_once</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE60560'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1AFFADC70' oid='D61ABBC843524674B858E255E799D1C1' temploid='BDE22F641EB74c36BF1797AB92533E0A' cls='fun' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Dynamically Define Periodic Data</TUV>
+</NAME>
+<QUAL>Dynamically_Define_Periodic_Data</QUAL>
+<DCLSRVTMPL id='_000001B1ADF797D0' oid='6980C5C60C1E4a90AD3DA36D65CF35F6' temploid='6562856E28FE4fba931A9C570BA708B9' tmplref='_000001B1ADDCDB70' dtref='_000001B1AD974DB0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7C5F0' oid='FA30AAD215AE41c9B967591F0F670A57' temploid='6959230EDF9745cd9A549683C6BA1138' tmplref='_000001B1ADDCF670' dtref='_000001B1AD974DB0' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Define By Identifier</TUV>
+</NAME>
+<QUAL>Define_By_Identifier</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7B510' oid='E9EAE82E1E954114A99786DFD9A86D33' temploid='4CB6E81FA2074b938986B17F03FE688B' tmplref='_000001B1ADDCE230' dtref='_000001B1AD974DB0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Define By Address</TUV>
+</NAME>
+<QUAL>Define_By_Address</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7A9D0' oid='7ECFF17FA6A64fe3B96217A0F6C4B2E6' temploid='9BC9E065E54D4f7d995A48C869CFFAA6' tmplref='_000001B1ADDCFAF0' dtref='_000001B1AD974DB0' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Clear</TUV>
+</NAME>
+<QUAL>Clear</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7A1F0' oid='55FE2EDD4CC545d1A910208747A32256' temploid='09595343A75748d4B57DEE6F37E307D6' tmplref='_000001B1ADF16260' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>ClearAll</TUV>
+</NAME>
+<QUAL>ClearAll</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7BE10' oid='08012B330FE34704B647A7CBD116F47B' temploid='D0A4029BC60B4bac9B90DF45DFAFF008' tmplref='_000001B1ADF154E0' dtref='_000001B1AD974DB0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Send slow</TUV>
+</NAME>
+<QUAL>Send_slow</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF798F0' oid='030A809FF8E048cd98375C7973854629' temploid='823E5C7C5F814d648790671D643475D9' tmplref='_000001B1ADF16020' dtref='_000001B1AD974DB0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Send medium</TUV>
+</NAME>
+<QUAL>Send_medium</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7CB90' oid='5B0A65AD52BD4b728CE6787B92AE6346' temploid='1C3E4508E2894590A27F36BC786A2BB1' tmplref='_000001B1ADF15720' dtref='_000001B1AD974DB0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Send fast</TUV>
+</NAME>
+<QUAL>Send_fast</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF79A10' oid='612B665EBC8F4a2597EBEE228108C05A' temploid='B216B28F8D464c64ACF0F8E0F5FBB394' tmplref='_000001B1ADDCF430' dtref='_000001B1AD974DB0' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Stop</TUV>
+</NAME>
+<QUAL>Stop</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7CEF0' oid='32DDF05CCB9E4ba082A1047BFFB2D687' temploid='F87DEDC321D34b0385CD87905492F449' tmplref='_000001B1ADDCEFB0' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Stop all</TUV>
+</NAME>
+<QUAL>Stop_all</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE6660' oid='13516150C0484f5c8C4A58CEFF2F9DB5' temploid='C9359CDBB95440d2B762898EFF6F6FF6' spec='id'>
+<NAME>
+<TUV xml:lang='en-US'>DynamicallyDefinedIdentifier</TUV>
+</NAME>
+<QUAL>DynamicallyDefinedIdentifier</QUAL>
+<STATICCOMPREF idref='_000001B1ADE30D00'/>
+<STATICCOMPREF idref='_000001B1ADE32BD0'/>
+<STATICCOMPREF idref='_000001B1ADE31470'/>
+<STATICCOMPREF idref='_000001B1ADE32680'/>
+<STATICCOMPREF idref='_000001B1ADE31140'/>
+<STATICCOMPREF idref='_000001B1ADE32DF0'/>
+<STATICCOMPREF idref='_000001B1ADE31360'/>
+<STATICCOMPREF idref='_000001B1ADE31690'/>
+<STATICCOMPREF idref='_000001B1ADE33BC0'/>
+<STATICCOMPREF idref='_000001B1ADE32570'/>
+<STATICCOMPREF idref='_000001B1ADE31E00'/>
+<STATICCOMPREF idref='_000001B1ADE32460'/>
+<STATICCOMPREF idref='_000001B1ADE32020'/>
+<STATICCOMPREF idref='_000001B1ADE32130'/>
+<STATICCOMPREF idref='_000001B1ADE30AE0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1AFFAA370' oid='6188F22CE2554d9d85B5F1EDB447C11C' temploid='22B29C4FE7574daeAD96CD4BD1255C07' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Clear</TUV>
+</NAME>
+<QUAL>Clear</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE62310'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000AF70' oid='F4DE49825319485f9C47BEBE347FBE1B' temploid='7FBA499ABCB442a2ADB30A82319091F2' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Define By Identifier</TUV>
+</NAME>
+<QUAL>Define_By_Identifier</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE5F5F0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B0009A70' oid='A97267CE974E4e8cB00AFCB8632C2252' temploid='05ED51AE880543e38871C1B63B77B528' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE5FF70'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000C670' oid='D333C1DD88BE48b1873348473B36A25F' temploid='8FC5A5ACB2C24c6dACEEDF0AF86AB941' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Stop all</TUV>
+</NAME>
+<QUAL>Stop_all</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE61F80'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000C970' oid='436203C9223942e4B4CD5023CD4A87B2' temploid='5EBCB88DBCED4283BD41C06D16A97860' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Stop</TUV>
+</NAME>
+<QUAL>Stop</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE60690'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000A270' oid='258AD0D4757541fbAE86B268B877551E' temploid='FCA881FE6CE84eae9A033DF68661E64A' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>ClearAll</TUV>
+</NAME>
+<QUAL>ClearAll</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEAD4E0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000B970' oid='D0A1A7EB0D7341ce8459D26075175E92' temploid='A05AC7AF4839485e8E3D5335658D2333' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Define By Address</TUV>
+</NAME>
+<QUAL>Define_By_Address</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEAE1F0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000B370' oid='F73E1A97232B480c9363BFEB1929F069' temploid='6C8F113A171D4ad99E1816DB0DE2206C' dest='envData'>
+<NAME>
+<TUV xml:lang='en-US'>MemoryParameters</TUV>
+</NAME>
+<QUAL>MemoryParameters</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEAADB0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000CB70' oid='8607CC57D51A4099BA4D8A36061956A3' temploid='E690E7FF19B74a8d81875C17687F05DB' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Send fast</TUV>
+</NAME>
+<QUAL>Send_fast</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEA74B0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000A870' oid='A150DDCC47034e51A6A2416485B0DDA0' temploid='6950D271D9EF4191A913E6FC6CD3C631' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Send medium</TUV>
+</NAME>
+<QUAL>Send_medium</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEAA0A0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B0009470' oid='3A0AE81215334932AF07134761D2C98A' temploid='5A64AE85234E4e73A1F8928D3707DBD3' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Send slow</TUV>
+</NAME>
+<QUAL>Send_slow</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEA61B0'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B000B570' oid='345DA64ED61C46769FA034BEE4863C4A' temploid='5D599F37CB74403fB2EBA31A0957C0B0' cls='fun' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Dynamically Define Non-Periodic Data</TUV>
+</NAME>
+<QUAL>Dynamically_Define_Non_Periodic_Data</QUAL>
+<DCLSRVTMPL id='_000001B1ADF7B630' oid='002832C35D284cdd98043E0565662CA8' temploid='270D3EBF303B48bf906F4414D22C7DDB' tmplref='_000001B1ADDCD270' dtref='_000001B1AD974DB0' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7B750' oid='88869A97052A4ba3B247BF4C9E011698' temploid='3106DD975B764606AE517C0B34BA49D5' tmplref='_000001B1ADDCD930' dtref='_000001B1AD974DB0' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Define By Identifier</TUV>
+</NAME>
+<QUAL>Define_By_Identifier</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7A0D0' oid='370918F3178B4ff894B34D5376B73CDC' temploid='E81BDF09F96747a294DE6C514D0F0B42' tmplref='_000001B1ADDCD6F0' dtref='_000001B1AD974DB0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Define By Address</TUV>
+</NAME>
+<QUAL>Define_By_Address</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF79B30' oid='B611F7E7E8B44c12B88B548A75F668E0' temploid='D43394E04E62445796F2BDF0F24CFC10' tmplref='_000001B1ADDCD4B0' dtref='_000001B1AD974DB0' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Clear</TUV>
+</NAME>
+<QUAL>Clear</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7B870' oid='645CA2F2CBA94a419287D21008FF7858' temploid='19CA0BEE15BF46ca8EBB22F7B29BF32A' tmplref='_000001B1ADF16260' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>ClearAll</TUV>
+</NAME>
+<QUAL>ClearAll</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE6720' oid='73300B4880DC4a7f84B585BCF04EA546' temploid='BB8C978D8CA64cadB103C83F3D8F786D' spec='lid'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>Identifier</QUAL>
+<STATICCOMPREF idref='_000001B1ADE317A0'/>
+<STATICCOMPREF idref='_000001B1ADE31030'/>
+<STATICCOMPREF idref='_000001B1ADE32AC0'/>
+<STATICCOMPREF idref='_000001B1ADE31BE0'/>
+<STATICCOMPREF idref='_000001B1ADE30480'/>
+<STATICCOMPREF idref='_000001B1ADE31CF0'/>
+<STATICCOMPREF idref='_000001B1ADE31F10'/>
+<STATICCOMPREF idref='_000001B1ADE309D0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1B000CD70' oid='1CD1A42189CA49efBE379E35E438FEAB' temploid='9879D71A18904fbcA6E73C3977638BD2' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEAB3A0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000A070' oid='5271AEE416254aa38029E69EB1A2574B' temploid='AC09BAF1F1FD47bbBDC50F267830FCEA' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Clear</TUV>
+</NAME>
+<QUAL>Clear</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEADC00'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000BC70' oid='F7B79F570C7A4d68A9A4592F72A70D40' temploid='CDE3BE204CAF43a29B7F265C81F76947' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Define By Identifier</TUV>
+</NAME>
+<QUAL>Define_By_Identifier</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEAC7D0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000C270' oid='7EE17168FDF848608A25E40015520A16' temploid='EEF7E6D3C140445d838D6986533273AB' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>ClearAll</TUV>
+</NAME>
+<QUAL>ClearAll</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEAD4E0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000A670' oid='894750452F7D49c7B71FC76409054B39' temploid='A36FB33F64BD4840A86B578209845B10' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Define By Address</TUV>
+</NAME>
+<QUAL>Define_By_Address</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEACDC0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000AD70' oid='BE3B8F5C9C1F47c0AC220B30253AF4CB' temploid='24203AFBC9D84524B80409057C914DF2' dest='envData'>
+<NAME>
+<TUV xml:lang='en-US'>MemoryAddressAndSize</TUV>
+</NAME>
+<QUAL>MemoryAddressAndSize</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEAB4D0'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B000C470' oid='328DAA360070443e9F0A6169D471199B' temploid='{E67C5940-EED8-46d2-B95B-83F60296C067}' cls='ctl' single='0' isRelevantForReq='1'>
+<NAME>
+<TUV xml:lang='en-US'>IO Control</TUV>
+</NAME>
+<QUAL>IOControl</QUAL>
+<DCLSRVTMPL id='_000001B1ADF7C050' oid='D90987A152504746B1F82B0E8A262A37' temploid='{5AE50C13-AB34-440b-A793-E6AAF18EC7E6}' tmplref='_000001B1ABFA4070' dtref='_000001B1ADB65370' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7B2D0' oid='92306499EF994d7b838CDD15B4575B63' temploid='B7F0F01B10484a659DEF2B1D99BCD1C6' tmplref='_000001B1ADDCE6B0' dtref='_000001B1ADB65370' conv='optyes' mayBeExec='(3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>ReturnControl</TUV>
+</NAME>
+<QUAL>ReturnControl</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7A430' oid='C5399F34229C4288845DF055AC23895D' temploid='5FBC9941A4834789BFD398257E457631' tmplref='_000001B1ADDCDDB0' dtref='_000001B1ADB65370' conv='optyes' mayBeExec='(3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Reset</TUV>
+</NAME>
+<QUAL>Reset</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF79D70' oid='EB977084942D425bA6C79FF32D975604' temploid='286F67BC6A0A4ac1A8D8047D0680DFEE' tmplref='_000001B1ADDCCBB0' dtref='_000001B1ADB65370' conv='optyes' mayBeExec='(3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Freeze</TUV>
+</NAME>
+<QUAL>Freeze</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1ADF7A8B0' oid='A74FCF20AA9E42688069CA1FE43BF0FB' temploid='4FA5564EF8114c85BF82763B638A996D' tmplref='_000001B1ADDCC730' dtref='_000001B1ADB65370' conv='optyes' mayBeExec='(3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Control</TUV>
+</NAME>
+<QUAL>Control</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE65A0' oid='FC903BD73A6E4d9fB6B3797F7E75A1F4' temploid='{F2101F93-EC40-456a-B3E8-6931FC469114}' spec='id'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>DataIdentifier</QUAL>
+<STATICCOMPREF idref='_000001B1AD939920'/>
+<STATICCOMPREF idref='_000001B1AD93CB10'/>
+<STATICCOMPREF idref='_000001B1AD93A1A0'/>
+<STATICCOMPREF idref='_000001B1AD93BB20'/>
+<STATICCOMPREF idref='_000001B1AD939E70'/>
+<STATICCOMPREF idref='_000001B1AD93BF60'/>
+<STATICCOMPREF idref='_000001B1AD93AB30'/>
+<STATICCOMPREF idref='_000001B1AD93C070'/>
+<STATICCOMPREF idref='_000001B1AD916380'/>
+<STATICCOMPREF idref='_000001B1AD9143A0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1B000C870' oid='542F7CCBF3E84bceBD3F251F31A4A534' temploid='{ECF53028-32E3-4915-98FD-6D975B4CB2E4}' dest='data' spec='didDataReference'>
+<NAME>
+<TUV xml:lang='en-US'>Control States</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD57710'/>
+<PROXYCOMPREF idref='_000001B1ADDC7E30'/>
+<PROXYCOMPREF idref='_000001B1ADDC4790'/>
+<PROXYCOMPREF idref='_000001B1ADDC68D0'/>
+<PROXYCOMPREF idref='_000001B1ADDC4530'/>
+<PROXYCOMPREF idref='_000001B1ADDC4B20'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000B670' oid='034628C80E32424c80F9F86F6E5CA1EB' temploid='{395DE34A-440C-4b3c-B26E-878A573DE334}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD55960'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B0009770' oid='6C0BF86CA35F4c77A62D9C80BBF31ABF' temploid='E0CD637E9F424de89E104E368C39E419' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>ReturnControl</TUV>
+</NAME>
+<QUAL>ReturnControl</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC7710'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000CC70' oid='AFB52F9A0D5D4ed7BF472068145B5BF6' temploid='B9D337ECD650416391064EB9D03DCBFA' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Reset</TUV>
+</NAME>
+<QUAL>Reset</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC75E0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000C770' oid='2AAE8329D0B44158A8BCAF8495614625' temploid='89B3EBD3254944aa99680EE7C06C9C0A' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Freeze</TUV>
+</NAME>
+<QUAL>Freeze</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC7AA0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000CA70' oid='C43B51663C014c0dA6AE0EA049D3B7BC' temploid='AAB349E5BD4C4c3aA387B80972B29973' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Control</TUV>
+</NAME>
+<QUAL>Control</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC55D0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000C570' oid='7A44D8E4AE8F482b841936383E5CB682' temploid='061CF044B88C489cA1D84AC87624BFF2' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>ControlEnableMaskRecord</TUV>
+</NAME>
+<QUAL>ControlEnableMaskRecord_3</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC8550'/>
+<PROXYCOMPREF idref='_000001B1ADDC74B0'/>
+<PROXYCOMPREF idref='_000001B1ADDC49F0'/>
+<PROXYCOMPREF idref='_000001B1ADDC81C0'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B0009870' oid='1BE4C0BD92A34137A7109D213BF622B1' temploid='{58823EA0-231D-44f0-9F48-50AE2CD224E0}' cls='rtn' single='0' isRelevantForReq='1'>
+<NAME>
+<TUV xml:lang='en-US'>Routine Control</TUV>
+</NAME>
+<QUAL>Routine_Control</QUAL>
+<DCLSRVTMPL id='_000001B1ADF7B1B0' oid='74C15BD99E9F48028067202BAE7D7356' temploid='{87A9D1F9-7A39-4966-959A-44B5835FA183}' tmplref='_000001B1ADDCCDF0' dtref='_000001B1ADB64790' conv='req' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Start</TUV>
+</NAME>
+<QUAL>Start</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000FA20' oid='BCE834490AEC4e6b83C0B5F3D0D9CE8F' temploid='{A52784C0-6CF6-4362-BDF9-DD5C7E803D3E}' tmplref='_000001B1ADDCF1F0' dtref='_000001B1ADB64790' conv='optno' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Stop</TUV>
+</NAME>
+<QUAL>Stop</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0010B00' oid='682252F8F3F8461b82C3FF5E22F493A5' temploid='{98D1C2DB-5FD7-4a54-8335-3CAD51D4FACC}' tmplref='_000001B1ADDCC2B0' dtref='_000001B1ADB64790' conv='optno' mayBeExec='(2,3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Results</TUV>
+</NAME>
+<QUAL>Results</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE6C60' oid='873257177D6D47deAE800AAEB59F1D86' temploid='{3C1E61D7-1D61-4693-B8EC-917FDE5F6D00}' spec='id'>
+<NAME>
+<TUV xml:lang='en-US'>Identifier</TUV>
+</NAME>
+<QUAL>RoutineIdentifier</QUAL>
+<STATICCOMPREF idref='_000001B1AD9144B0'/>
+<STATICCOMPREF idref='_000001B1AD9146D0'/>
+<STATICCOMPREF idref='_000001B1AD914D30'/>
+<STATICCOMPREF idref='_000001B18D0962F0'/>
+<STATICCOMPREF idref='_000001B1ADE307B0'/>
+<STATICCOMPREF idref='_000001B1ADE31AD0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1B000B170' oid='1B10285A708E406794810696A6A6E416' temploid='{67B5D0CB-B57E-44da-B712-86C2A716ACDD}' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>Control Options (Start)</TUV>
+</NAME>
+<QUAL>StartOptions</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC54A0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000CE70' oid='7FFA5268B16D4d2082B0342E7AEB69B8' temploid='{153674A2-D407-42fa-A8F5-1F35DBB2962C}' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>Status (Start)</TUV>
+</NAME>
+<QUAL>StartStatus</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC5A90'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000B770' oid='180FA927A25A44dd86A12DAA418B99E4' temploid='{8644FEFF-BBF9-41dc-A226-0B1A0058C31A}' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>Control Options (Stop)</TUV>
+</NAME>
+<QUAL>StopOptions</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC6080'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000BA70' oid='2987CCF7008C4f4cB6285C372B3C7FE0' temploid='{BACCC7BD-C5F4-4907-BD22-228C5E1B17A7}' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>Status (Stop)</TUV>
+</NAME>
+<QUAL>StopStatus</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC6540'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B0009E70' oid='2DB87129872E40c2A56E29AA1950AE37' temploid='{EB53AA46-6B76-4143-846E-347F856DCDAE}' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>Status (Results)</TUV>
+</NAME>
+<QUAL>Results</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC9F70'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000AC70' oid='14139025737F4f99BC17DD4CAF6F307A' temploid='{0CA510D0-2501-4e88-A7BB-7E3D164A093A}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Start NR</TUV>
+</NAME>
+<QUAL>Start_NR</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC5830'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000BB70' oid='1668A4273FCE43bf8754E5AC3F74EBD3' temploid='{AD7A6455-2DE7-4bd4-88A6-8F1AC333D77C}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Stop NR</TUV>
+</NAME>
+<QUAL>Stop_NR</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC9260'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000BD70' oid='179F036A874743888B466164D42265E4' temploid='{62C81E48-3115-478f-890F-973C15110A39}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Results</TUV>
+</NAME>
+<QUAL>RequestResults</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDCA7C0'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B0009C70' oid='653FF9815AA743c5AC7D2D6CAD008620' temploid='AA0BABB2A96D43f09D549D702A0AF4C8' cls='mem' single='1'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+<DCLSRVTMPL id='_000001B1B000DBC0' oid='3D161188D186463bA60F05BD5DA0EFD4' temploid='97996C140D4A4f639E16C7D955749F64' tmplref='_000001B1ADF14760' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0010680' oid='210D7886805D4dee98C6FC867D4779EC' temploid='5CC92E9DE4EE4a059651BD5510768DEE' tmplref='_000001B1ADF16FE0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Write</TUV>
+</NAME>
+<QUAL>Write</QUAL>
+</DCLSRVTMPL>
+<SHPROXY id='_000001B1B0009D70' oid='45F7BDDA825D42e1A1FF0B439E3E9A3B' temploid='4CECA4F5C79F473dAD3ED32B0C7B3A33' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB3640'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B0009070' oid='8761C06D67C1465fAEC221F4E925666F' temploid='1FCC5480529E451b9965CC1BB6D3C743' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB0920'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B0009F70' oid='463653C0F0AA40d883F2889D2658B895' temploid='5BBDAC46200A4682987275805C98A503' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Write</TUV>
+</NAME>
+<QUAL>Write</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB3180'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B0009170' oid='4C412D9C98E14274AB8DF022DFC50E7C' temploid='{5DB640FF-1DFD-4c18-BEA0-1A45600C9400}' cls='ftm' single='1' isRelevantForReq='1'>
+<NAME>
+<TUV xml:lang='en-US'>Fault Memory</TUV>
+</NAME>
+<QUAL>FaultMemory</QUAL>
+<DCLSRVTMPL id='_000001B1B0010320' oid='905897DDD81C4a929D04580FAC658E95' temploid='{F017E194-95D8-4e61-ACB5-943ADFBAFE8A}' tmplref='_000001B1ABFA44F0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - number of DTCs</TUV>
+</NAME>
+<QUAL>ReadNumber</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000E940' oid='CB4BA72F1E8D426eB4CBE097FC0BDAF0' temploid='{FE4A5618-FE0B-4a08-BF01-EB41C28D47B6}' tmplref='_000001B1ABFA3E30' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - DTCs by status mask</TUV>
+</NAME>
+<QUAL>ReadAllIdentified</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000E3A0' oid='AFDA3278870144d989B3159D74E2554F' temploid='B202A7D9F30E4f5883776D50E1CDCD44' tmplref='_000001B1AFE7DAF0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - extended data record</TUV>
+</NAME>
+<QUAL>Read_extended_data_record</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000F000' oid='E95ED2893A9145d0BFD4C2F1344F8AF7' temploid='7B0D9EA65BDB47a4965AD58287592405' tmplref='_000001B1AFE7D670' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - snapshot record</TUV>
+</NAME>
+<QUAL>Read_snapshot_record</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000E040' oid='0F046E96FE6249c592D64061FD2A1487' temploid='0AABEECE24C24fe9BAF63ABEB7106089' tmplref='_000001B1ADDCDFF0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - snapshot ID</TUV>
+</NAME>
+<QUAL>Read_snapshot_ID</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000D3E0' oid='75574F40A51E410085F105E766885769' temploid='645873D335BD41d39FE1DFFECC189217' tmplref='_000001B1ADDCFD30' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read - snapshot by record number</TUV>
+</NAME>
+<QUAL>Read_snapshot_by_record_number</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0010D40' oid='4DCE234F90134a45A43B20286953A380' temploid='326720F0441F49e7867BA38F19BDC8D6' tmplref='_000001B1ABFA4730' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - number of DTCs by severity</TUV>
+</NAME>
+<QUAL>Read_number_of_DTCs_by_severity</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000D080' oid='90084C283990480c985DC937733142DE' temploid='32C88D3609AE4a2bB22055218519C7EE' tmplref='_000001B1ABFA42B0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - DTCs by severity</TUV>
+</NAME>
+<QUAL>Read_DTCs_by_severity</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0010440' oid='457F3E6679ED4537B3578AA288EA8F60' temploid='BC88C22537034490B458B1AAAB5F6D58' tmplref='_000001B1ABFA4970' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - severity information</TUV>
+</NAME>
+<QUAL>Read_severity_information</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000F120' oid='23B350F206A4429bADE772F7F8392B4A' temploid='{52376BA0-8B0C-4565-8F40-50CCB76D0528}' tmplref='_000001B1ADDCF8B0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - supported DTCs</TUV>
+</NAME>
+<QUAL>ReadAllSupported</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000D980' oid='C97FF571CC1A46938E152715364494BA' temploid='666092D2C58E4c12905E5422EF9B5466' tmplref='_000001B1ADF149A0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - first test failed DTC</TUV>
+</NAME>
+<QUAL>Read_first_test_failed_DTC</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000F7E0' oid='C8704F075B1E47c7808B10CA45BAA559' temploid='EC4167AC4EE54e93BD02557FCB70A0E7' tmplref='_000001B1ADDCC4F0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - first confirmed DTC</TUV>
+</NAME>
+<QUAL>Read_first_confirmed_DTC</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B00107A0' oid='4100CDB1D3F940a8A72307CAC714F786' temploid='C3BC8FF0BAE148a6B256310BFFFFC0DA' tmplref='_000001B1ADF166E0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - most recent test failed DTC</TUV>
+</NAME>
+<QUAL>Read_most_recent_test_failed_DTC</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000F480' oid='0C3A7633B99F49ff9F5773729C477E4B' temploid='43FB66C9D995422d861B93A169C9435A' tmplref='_000001B1ADDCC070' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - most recent confirmed DTC</TUV>
+</NAME>
+<QUAL>Read_most_recent_confirmed_DTC</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000ECA0' oid='C0E207E24DDC4032A21B15CDA2B90B5A' temploid='35B483A2CB9E461294DACBDBFD0E36CD' tmplref='_000001B1AFE7C8F0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read -Mirror memory DTCs by status mask</TUV>
+</NAME>
+<QUAL>Read_Mirror_memory_DTCs_by_status_mask</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000D1A0' oid='40C57D0B57F347f2A43EEC64C5F280B3' temploid='E9611B3BF5DE45b883952D9DDB04A194' tmplref='_000001B1AFE7A4F0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - Mirror memory extended record</TUV>
+</NAME>
+<QUAL>Read_Mirror_memory_extended_record</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000F5A0' oid='5B8AFA9AA1C1414a85108F65C6874FA3' temploid='F1ED2756CB404d0e8694461CD018B3D0' tmplref='_000001B1AFE7D1F0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - number of mirror memory DTCs</TUV>
+</NAME>
+<QUAL>Read_number_of_mirror_memory_DTCs</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000FB40' oid='FFEA1F1EF541405aA077F80C3D993F68' temploid='9FBFD9607D154111AEE80C87045F14DB' tmplref='_000001B1AFE7C6B0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read - number emission DTCs</TUV>
+</NAME>
+<QUAL>Read_number_emission_DTCs</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000F6C0' oid='89A4D4B7B12742efBAB3BFE4D50ABCBC' temploid='B954D42972FE4939A1D8193536409BED' tmplref='_000001B1AFE7C230' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read - identified emission DTCs</TUV>
+</NAME>
+<QUAL>Read_identified_emission_DTCs</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000E5E0' oid='3FFF6E421BF94849BDBC61C48507EBE7' temploid='92AD9F5F34B04573AB6E263F3D308FE4' tmplref='_000001B1ADF17D60' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read - fault detection counter</TUV>
+</NAME>
+<QUAL>Read_fault_detection_counter</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B00108C0' oid='CF1930CD85DF4eeeBAD2A8E9FE074176' temploid='B14E0408866842df925BA0FF83C0A46B' tmplref='_000001B1AFE7BFF0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read - permanent DTCs</TUV>
+</NAME>
+<QUAL>Read_permanent_DTCs</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B000E820' oid='0E481A45EFF643e6B514E07D9F59CEE7' temploid='{353EACA4-B883-45ee-B854-8C93371FE384}' tmplref='_000001B1ABFA3BF0' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Clear DTC</TUV>
+</NAME>
+<QUAL>Clear</QUAL>
+</DCLSRVTMPL>
+<SHPROXY id='_000001B1B0009270' oid='A7B41A1E69B445a990E1F7485DF50198' temploid='{30365EBB-C406-4a31-B568-387024AF3E45}' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>Format Identifier</TUV>
+</NAME>
+<QUAL>FormatIdentifier</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD57AA0'/>
+<PROXYCOMPREF idref='_000001B1ADD57BD0'/>
+<PROXYCOMPREF idref='_000001B1AFF11260'/>
+<PROXYCOMPREF idref='_000001B1AFF12C80'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B0009370' oid='6FD9BC207D6E441bAAD3BCCDF093C6BE' temploid='{B1BE8AFD-5064-4668-B247-0F976D5D95CB}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - DTCs by status mask</TUV>
+</NAME>
+<QUAL>ReadAllIdentified</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD56D90'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000AE70' oid='E699D33E718F475996F2D1EEE3EA798C' temploid='{85C1CDB6-8037-49c8-A50A-45D02E1B265A}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - number of DTCs</TUV>
+</NAME>
+<QUAL>ReadNumber</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD56C60'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B0009570' oid='5D39C7A629A04a4b89DE7BF3B3730537' temploid='{542654CE-D104-4f3c-AF43-53346AAF2CF4}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - supported DTCs</TUV>
+</NAME>
+<QUAL>ReadAllSupported</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDCB140'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000BE70' oid='648336BFFF4D44cbB7D9434A6D30D7FF' temploid='{04E0DC14-6F8C-40ed-9CDD-1300D17EFA72}' dest='groupOfDtc'>
+<NAME>
+<TUV xml:lang='en-US'>GroupOfDtc</TUV>
+</NAME>
+<QUAL>GroupOfDtc</QUAL>
+<PROXYCOMPREF idref='_000001B1ADC19D30'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000B870' oid='09F82DF06BCF4503B504FC126970769F' temploid='{A73780BD-5017-421f-AA8E-9B9FE029E3C2}' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Clear DTC</TUV>
+</NAME>
+<QUAL>Clear</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD588E0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B0009670' oid='527B5F9E793947acB52BF734ED076626' temploid='48960145C22F49569A023BBDC0132A0D' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - DTCs by severity</TUV>
+</NAME>
+<QUAL>Read_DTCs_by_severity</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD55700'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B0009970' oid='000F283C2D574109AA120D4AACB8581A' temploid='FBCAB9182FD0415c92A23657EF11EC01' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverity</TUV>
+</NAME>
+<QUAL>DtcSeverity</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD58420'/>
+<PROXYCOMPREF idref='_000001B1ADDC8A10'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000BF70' oid='CF6A77C90E2A401a8ADE2621F39C9E5B' temploid='3DD469F24DB84b41B0A07760D379BA2B' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - number of DTCs by severity</TUV>
+</NAME>
+<QUAL>Read_number_of_DTCs_by_severity</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD57380'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B0009B70' oid='19E4ED07F9254746B4145EE0D773A792' temploid='D3ED67468BCA40b4AC54089DE7CAE783' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - severity information</TUV>
+</NAME>
+<QUAL>Read_severity_information</QUAL>
+<PROXYCOMPREF idref='_000001B1ADDC6B30'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000A170' oid='F1B1655A28B94dd79279A2875BC4E560' temploid='45B74D6855F44f388A8D722AB82B8577' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - most recent confirmed DTC</TUV>
+</NAME>
+<QUAL>Read_most_recent_confirmed_DTC</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE63AD0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000B470' oid='1DB734453A9941cdB583AD94F11EA870' temploid='16BE415BADAC41aaBD7276F8F2056DB4' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - first confirmed DTC</TUV>
+</NAME>
+<QUAL>Read_first_confirmed_DTC</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE63E60'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000A370' oid='5A77F5FB3490486dB0539B15110C07BE' temploid='80D9C79C74E0494dACADE9421F6E22F0' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - fault detection counter</TUV>
+</NAME>
+<QUAL>Read_fault_detection_counter</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEAE450'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000A470' oid='22967C45E49C418a83D02B820F520F0E' temploid='E4E09D212DC8415aA1766866C0F3CA2A' dest='dtc'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Table</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD55E20'/>
+<PROXYCOMPREF idref='_000001B1ADDCA560'/>
+<PROXYCOMPREF idref='_000001B1ADD56670'/>
+<PROXYCOMPREF idref='_000001B1ADDC6670'/>
+<PROXYCOMPREF idref='_000001B1ADDC7120'/>
+<PROXYCOMPREF idref='_000001B1ADE65D40'/>
+<PROXYCOMPREF idref='_000001B1ADE65160'/>
+<PROXYCOMPREF idref='_000001B1ADEAD150'/>
+<PROXYCOMPREF idref='_000001B1ADE601D0'/>
+<PROXYCOMPREF idref='_000001B1ADEB0200'/>
+<PROXYCOMPREF idref='_000001B1ADEB2F20'/>
+<PROXYCOMPREF idref='_000001B1ADE65C10'/>
+<PROXYCOMPREF idref='_000001B1AFE274D0'/>
+<PROXYCOMPREF idref='_000001B1AFF14B60'/>
+<PROXYCOMPREF idref='_000001B1AFF128F0'/>
+<PROXYCOMPREF idref='_000001B1AFF12EE0'/>
+<PROXYCOMPREF idref='_000001B1AFF11AB0'/>
+<PROXYCOMPREF idref='_000001B1AFF17C10'/>
+<PROXYCOMPREF idref='_000001B1AFF19500'/>
+<PROXYCOMPREF idref='_000001B1AFF11850'/>
+<PROXYCOMPREF idref='_000001B1AFF11E40'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000C170' oid='CE668CD484674f95A07806AE5BF0F727' temploid='3F9DDDDB99FA4375AB1900967E4B6B9A' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - snapshot ID</TUV>
+</NAME>
+<QUAL>Read_snapshot_ID</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE5E7B0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000C070' oid='4E53BC5B11644dbe8B51979AE4C32AB9' temploid='5258AD0347914475B101651E57E01C86' dest='dtcStatus'>
+<NAME>
+<TUV xml:lang='en-US'>DtcStatusMask</TUV>
+</NAME>
+<QUAL>DtcStatusMask</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD56B30'/>
+<PROXYCOMPREF idref='_000001B1ADD555D0'/>
+<PROXYCOMPREF idref='_000001B1ADD548C0'/>
+<PROXYCOMPREF idref='_000001B1ADD57F60'/>
+<PROXYCOMPREF idref='_000001B1AFE24680'/>
+<PROXYCOMPREF idref='_000001B1AFF11130'/>
+<PROXYCOMPREF idref='_000001B1AFF13140'/>
+<PROXYCOMPREF idref='_000001B1AFF10C70'/>
+<PROXYCOMPREF idref='_000001B1AFF13860'/>
+<PROXYCOMPREF idref='_000001B1AFF16A40'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000A570' oid='42C62063DE3E4b96BF3E38062425647F' temploid='694E4AA616B84a81827EC15CEEFC32F4' dest='dtcStatus'>
+<NAME>
+<TUV xml:lang='en-US'>DtcStatusAvailabilityMask</TUV>
+</NAME>
+<QUAL>DtcStatusAvailabilityMask_1</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD58A10'/>
+<PROXYCOMPREF idref='_000001B1ADD582F0'/>
+<PROXYCOMPREF idref='_000001B1ADDC6FF0'/>
+<PROXYCOMPREF idref='_000001B1ADDCA690'/>
+<PROXYCOMPREF idref='_000001B1ADD54070'/>
+<PROXYCOMPREF idref='_000001B1ADD56FF0'/>
+<PROXYCOMPREF idref='_000001B1ADE62C90'/>
+<PROXYCOMPREF idref='_000001B1ADE639A0'/>
+<PROXYCOMPREF idref='_000001B1ADEB0F10'/>
+<PROXYCOMPREF idref='_000001B1ADEB0330'/>
+<PROXYCOMPREF idref='_000001B1AFE280B0'/>
+<PROXYCOMPREF idref='_000001B1AFF15610'/>
+<PROXYCOMPREF idref='_000001B1AFF121D0'/>
+<PROXYCOMPREF idref='_000001B1AFF14A30'/>
+<PROXYCOMPREF idref='_000001B1AFF10DA0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000A770' oid='013CD0944C3A476bB500CB16CDBF4EB2' temploid='6F7257F9086741579111B13DECB98346' dest='dtcStatus'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDtc</TUV>
+</NAME>
+<QUAL>StatusOfDtc_2</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD55F50'/>
+<PROXYCOMPREF idref='_000001B1ADD58550'/>
+<PROXYCOMPREF idref='_000001B1ADDC8090'/>
+<PROXYCOMPREF idref='_000001B1ADDC9850'/>
+<PROXYCOMPREF idref='_000001B1ADE633B0'/>
+<PROXYCOMPREF idref='_000001B1ADE646B0'/>
+<PROXYCOMPREF idref='_000001B1ADEAFE70'/>
+<PROXYCOMPREF idref='_000001B1ADEB3510'/>
+<PROXYCOMPREF idref='_000001B1ADE64CA0'/>
+<PROXYCOMPREF idref='_000001B1AFF13D20'/>
+<PROXYCOMPREF idref='_000001B1AFE27D20'/>
+<PROXYCOMPREF idref='_000001B1AFF15280'/>
+<PROXYCOMPREF idref='_000001B1AFF115F0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000B070' oid='7A6E00FE7BA145e8AC20BB360C1D23A4' temploid='FB101EFA10B344cd9909E8D4A42D7D65' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - first test failed DTC</TUV>
+</NAME>
+<QUAL>Read_first_test_failed_DTC</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB2B90'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000A970' oid='676EFED8B72C421aB516BC81F8B1EAE3' temploid='03A92A830CC340abBA8C7ECABCBDE02B' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - most recent test failed DTC</TUV>
+</NAME>
+<QUAL>Read_most_recent_test_failed_DTC</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB32B0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000AA70' oid='0155EBA3A4FD4a178D49ACCD6607F33A' temploid='20F0FCA85EAF4f13AF3163B9C032C03D' dest='envData'>
+<NAME>
+<TUV xml:lang='en-US'>ExtendedDataRecord</TUV>
+</NAME>
+<QUAL>ExtendedDataRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF114C0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000AB70' oid='757969847E004a12BA221A590FB4AFFE' temploid='2A86E407D80941bc8F25EB2EE082058F' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>DTCFunctionalUnit</TUV>
+</NAME>
+<QUAL>DTCFunctionalUnit</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD54B20'/>
+<PROXYCOMPREF idref='_000001B1ADDC82F0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000B270' oid='080946C7A86F463c84F94EFBAFDF066C' temploid='A9E1F098641A4fb59FD7643378A65579' dest='envData'>
+<NAME>
+<TUV xml:lang='en-US'>SnapshotRecordData</TUV>
+</NAME>
+<QUAL>SnapshotRecordData</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE63150'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B000C370' oid='1D4FDD88B2C44387B0B713DDDFE8511E' temploid='285D637CDFE0430283AD3D95BF74E30B' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - snapshot by record number</TUV>
+</NAME>
+<QUAL>Read_snapshot_by_record_number</QUAL>
+<PROXYCOMPREF idref='_000001B1ADE63D30'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005EF70' oid='1F047B1455B34d60982A96E5E3DF9DC5' temploid='FABC1FFA5D954a21BA5530DF48BB4303' dest='envData'>
+<NAME>
+<TUV xml:lang='en-US'>AvailableExtendedDataRecordNumbers</TUV>
+</NAME>
+<QUAL>AvailableExtendedDataRecordNumbers</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF14EF0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005E170' oid='4B5479B91A6C48a9A8E1D98C666CD3C8' temploid='9FF37184075C4a74BFB83066AB3F0719' dest='data' xdtauth='1'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSeverityMask</TUV>
+</NAME>
+<QUAL>DtcSeverityMask</QUAL>
+<PROXYCOMPREF idref='_000001B1ADD541A0'/>
+<PROXYCOMPREF idref='_000001B1ADD57D00'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005F270' oid='DF6D13713F8F4392A41C95E8BFEFBC21' temploid='EF19E0B47E0F48528C312E677C72AF23' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - permanent DTCs</TUV>
+</NAME>
+<QUAL>Read_permanent_DTCs</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE241C0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005D470' oid='C37CF3B2B45A4b04B28216C842BE8C4B' temploid='8BE6E82A394044868DEB57007CC0FAF5' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - identified emission DTCs</TUV>
+</NAME>
+<QUAL>Read_identified_emission_DTCs</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF13010'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005EB70' oid='58107EB13A7B437d8E20A42559750396' temploid='EE73C41FB5B5410eB21D271549798C06' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - number emission DTCs</TUV>
+</NAME>
+<QUAL>Read_number_emission_DTCs</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF14440'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005C870' oid='327F2CF598B2465aA508E4E2889A2F0E' temploid='6AB849661EF4440198A13C54ED3F43B6' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read -Mirror memory DTCs by status mask</TUV>
+</NAME>
+<QUAL>Read_Mirror_memory_DTCs_by_status_mask</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF13730'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005E070' oid='934E25BDDE214665B59C2306AA588CDA' temploid='26F03737ACE04fe994BA724DB03BEB46' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - Mirror memory extended record</TUV>
+</NAME>
+<QUAL>Read_Mirror_memory_extended_record</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF15020'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005E270' oid='F27263B869B2416c967AC06B8B3492AD' temploid='60E6326EBF024e4eAE5B976AF5CC28F0' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - number of mirror memory DTCs</TUV>
+</NAME>
+<QUAL>Read_number_of_mirror_memory_DTCs</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF154E0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005B470' oid='8463D4031D0241a1925307C3322AF2F5' temploid='5DE46EA5AB954a08B8AE99C1455D13D3' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - snapshot record</TUV>
+</NAME>
+<QUAL>Read_snapshot_record</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF15F90'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005DA70' oid='15D0DF8FD3734ea2BE904F2DBF7FB7E2' temploid='673DE0BF290A4aceBE49D292A71923CC' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read - extended data record</TUV>
+</NAME>
+<QUAL>Read_extended_data_record</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF19760'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B005C970' oid='D2F458F65A1B4d13A7EA820A2CA71400' temploid='8FA2A9E3A3FB4d5685A5BD6BB77DFFB4' cls='ftm' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>User Defined Fault Memories</TUV>
+</NAME>
+<QUAL>User_Defined_Fault_Memories</QUAL>
+<DCLSRVTMPL id='_000001B1B005A300' oid='00A5F0C06984434eA0DE72AE39F51465' temploid='852AF057B7B04eb994D44F85810787D6' tmplref='_000001B1AFF3EDF0' dtref='_000001B1ADBDDFD0' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Read by Status Mask</TUV>
+</NAME>
+<QUAL>Read_by_Status_Mask</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0058EC0' oid='71C82060F846417791AEDA0352E61220' temploid='86CFDA17A50741a1994AEB3BDA857918' tmplref='_000001B1AFF3FFF0' dtref='_000001B1ADBDDFD0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read Snapshots</TUV>
+</NAME>
+<QUAL>Read_Snapshots</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0058380' oid='DD4E174EE2AF4b339D77761E33A14A5C' temploid='36940CBAE66D4f91BB5F0AA20F21DDD1' tmplref='_000001B1AFF3E4F0' dtref='_000001B1ADBDDFD0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read Extended Data Records</TUV>
+</NAME>
+<QUAL>Read_Extended_Data_Records</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE6AE0' oid='EABB7646ADF7477c852F1B65301ED6AB' temploid='AA28FD9B491B46d296AF6F5286265C24' spec='id'>
+<NAME>
+<TUV xml:lang='en-US'>Memory Selection</TUV>
+</NAME>
+<QUAL>Memory_Selection</QUAL>
+<STATICCOMPREF idref='_000001B1ADE2CF60'/>
+<STATICCOMPREF idref='_000001B1ADE2D5C0'/>
+<STATICCOMPREF idref='_000001B1ADE2D070'/>
+<STATICCOMPREF idref='_000001B1ADE2F7C0'/>
+<STATICCOMPREF idref='_000001B1ADE2E060'/>
+<STATICCOMPREF idref='_000001B1ADE2D290'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1B005C270' oid='5EF3DE2AAC614ee1831A7188E1BDD64D' temploid='ABA41B99836D439692D67F01969CDC8D' dest='dtcStatus'>
+<NAME>
+<TUV xml:lang='en-US'>DTC Status Mask</TUV>
+</NAME>
+<QUAL>DTC_Status_Mask</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF161F0'/>
+<PROXYCOMPREF idref='_000001B1AFF17E70'/>
+<PROXYCOMPREF idref='_000001B1AFF16F00'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005B870' oid='CCCFB907DA5147778CEF273F9F5B8BFB' temploid='B80008C3A7D04e348FC7043DFA576F4D' dest='dtc'>
+<NAME>
+<TUV xml:lang='en-US'>DTCRecord</TUV>
+</NAME>
+<QUAL>DTCRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF199C0'/>
+<PROXYCOMPREF idref='_000001B1AFF16B70'/>
+<PROXYCOMPREF idref='_000001B1AFF193D0'/>
+<PROXYCOMPREF idref='_000001B1AFF16DD0'/>
+<PROXYCOMPREF idref='_000001B1AFF15E60'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005C370' oid='254334F407E7466386D4815BA8BDA55A' temploid='FB4DFBC1B414451fB55EC257EEE877D7' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read by Status Mask</TUV>
+</NAME>
+<QUAL>Read_by_Status_Mask</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF19AF0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005E970' oid='37F9F2676357413fBFF8EFEE30B94845' temploid='7A6F581CC26E420c9AA5BBA8F41BD227' dest='envData' spec='didReferences'>
+<NAME>
+<TUV xml:lang='en-US'>DTCSnapshotRecord</TUV>
+</NAME>
+<QUAL>DTCSnapshotRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF16CA0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005B570' oid='F825FF7F73004700A75B89B67D0BB831' temploid='C64E8EB170D847e0BE78B745F2489542' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read Snapshots</TUV>
+</NAME>
+<QUAL>Read_Snapshots</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF159A0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005BA70' oid='392DA87DECCF4ac3AEF87E8CEFA6BF35' temploid='6D587559DF18498f87330B344E4BD88C' dest='envData'>
+<NAME>
+<TUV xml:lang='en-US'>DTCExtendedDataRecordNumber</TUV>
+</NAME>
+<QUAL>DTCExtendedDataRecordNumber</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF179B0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005C470' oid='41F91A66D590483fA44FED34E4FCD2A9' temploid='049D857A58764fa19AB4A9A5CADC93BD' dest='envData'>
+<NAME>
+<TUV xml:lang='en-US'>DTCExtendedDataRecord</TUV>
+</NAME>
+<QUAL>DTCExtendedDataRecord</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF16320'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005E570' oid='4621EB08D1DE4f3c9537869200B995C7' temploid='F0D99F9D372544b7AAC8D217908B9BE6' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read Extended Data Records</TUV>
+</NAME>
+<QUAL>Read_Extended_Data_Records</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF16450'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005C570' oid='7C682E8B8FA3439b93C47301C5FFDFBC' temploid='D333A6224D5647ad8A5205EE53017538' dest='dtcStatus'>
+<NAME>
+<TUV xml:lang='en-US'>DTCAvailabilityMask</TUV>
+</NAME>
+<QUAL>DTCAvailabilityMask</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF19E80'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005ED70' oid='A6D7BC84934B42bc8123BD372BE07415' temploid='DEB264E3C6694537AE1C1527DC5903C3' dest='dtcStatus'>
+<NAME>
+<TUV xml:lang='en-US'>StatusOfDTC</TUV>
+</NAME>
+<QUAL>StatusOfDTC</QUAL>
+<PROXYCOMPREF idref='_000001B1AFF17750'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B005BE70' oid='D70E0A77902B4089AFD14F40B156A4FA' temploid='399F8E5F4B0A4b5bBF6FBD22F5453345' cls='dwn' single='1'>
+<NAME>
+<TUV xml:lang='en-US'>Upload/Download</TUV>
+</NAME>
+<QUAL>Upload_Download</QUAL>
+<DCLSRVTMPL id='_000001B1B00573C0' oid='B64D3DF7900D41cdB1214283974C3A24' temploid='ED688D296CA9433dBC54B54AD5B3F0A2' tmplref='_000001B1ADF14BE0' conv='req' mayBeExec='(2,4,5,6,7,8,9,10,12,13,14,15,16,17,18,19,20,21,22,23,24,25)'>
+<NAME>
+<TUV xml:lang='en-US'>RequestDownload</TUV>
+</NAME>
+<QUAL>RequestDownload</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B005A9C0' oid='452D92D692B943879446ACA6FA0F10DD' temploid='0105CB2664754227AE138C3C32942F9C' tmplref='_000001B1ADF14E20' conv='optyes' mayBeExec='(2,4,5,6,7,8,9,10,12,13,14,15,16,17,18,19,20,21,22,23,24,25)'>
+<NAME>
+<TUV xml:lang='en-US'>RequestUpload</TUV>
+</NAME>
+<QUAL>RequestUpload</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B005AAE0' oid='B14ED91787C94e5aA9E1A73BE80159A7' temploid='C673A476297248d3B52F12B116D7AB6F' tmplref='_000001B1ADF164A0' conv='req' mayBeExec='(2,4,5,6,7,8,9,10,12,13,14,15,16,17,18,19,20,21,22,23,24,25)'>
+<NAME>
+<TUV xml:lang='en-US'>Transmit</TUV>
+</NAME>
+<QUAL>Transmit</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0057CC0' oid='FB13A218D5FE4b108463E3E5C9195982' temploid='A942D5C534DF482fBCD55A22C6CD97BB' tmplref='_000001B1ADF152A0' conv='req' mayBeExec='(2,4,5,6,7,8,9,10,12,13,14,15,16,17,18,19,20,21,22,23,24,25)'>
+<NAME>
+<TUV xml:lang='en-US'>Stop</TUV>
+</NAME>
+<QUAL>Stop</QUAL>
+</DCLSRVTMPL>
+<SHPROXY id='_000001B1B005F070' oid='B51BE971E2C84d718FBD830AF3E0C4F9' temploid='E40D235338954578B61B9A51B0DC8DC2' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>DataFormatIdentifier</TUV>
+</NAME>
+<QUAL>DFI_</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB39D0'/>
+<PROXYCOMPREF idref='_000001B1ADEB4350'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005BB70' oid='14D3B22143F245fe85E980D5FB5E92F5' temploid='A020E2A8C8EA472fB0438A3E1AA47410' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>LengthFormatIdentifier</TUV>
+</NAME>
+<QUAL>LFID</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB4220'/>
+<PROXYCOMPREF idref='_000001B1ADEAF9B0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005C670' oid='9A89858A7A304a86BB9D7A2FB4BC6C39' temploid='7A6E8BC2FD974dd1AFD2709E7298FF49' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>MaxNumberOfBlockLength</TUV>
+</NAME>
+<QUAL>MNROB_</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB3B00'/>
+<PROXYCOMPREF idref='_000001B1ADEAFAE0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005EC70' oid='28479C22E9E14891B3259C8BBAAF9514' temploid='5D14D9B2519546f8BDC4D478B1F6645F' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>RequestDownload</TUV>
+</NAME>
+<QUAL>RequestDownload</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB1D50'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005D170' oid='23EBB6001CFE45a7BDC0AFA94475C770' temploid='300DB7F575534edb8DA64CB35D35DCEC' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>RequestParameter</TUV>
+</NAME>
+<QUAL>TRPR_</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB4BA0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005CE70' oid='F3B0A939CBCE4b6089CFF67ED307BC8E' temploid='0BA0CB48123C4e06A57407F137BB370F' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>ResponseParameter</TUV>
+</NAME>
+<QUAL>TREPR_</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB5B10'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005DD70' oid='74DAAC6662014552971459541E7EFB52' temploid='1FCC1DC5CA4742b6B2A8F3AA64F5B620' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Stop</TUV>
+</NAME>
+<QUAL>Stop</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB45B0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005CF70' oid='C37E02951B4E483d9904D0AA324F3C5B' temploid='4CA3A68086A34f7e8B6CFD598CF1CF4F' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>RequestUpload</TUV>
+</NAME>
+<QUAL>RequestUpload</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB1E80'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005C770' oid='0F14AD9A873844248CC9DF9FE672D3D5' temploid='191C9D3392C14c1890861830599574E0' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Transmit</TUV>
+</NAME>
+<QUAL>Transmit</QUAL>
+<PROXYCOMPREF idref='_000001B1ADEB4F30'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B005BD70' oid='26A0EF256F5D4d9e8025DE953FEEE970' temploid='93F35B4633EF4cbeBC2F204F2ECB98EF' cls='rtn' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Powertrain Diagnostic and Freeze Frame Data</TUV>
+</NAME>
+<QUAL>Powertrain_Diagnostic_and_Freeze_Frame_Data</QUAL>
+<DCLSRVTMPL id='_000001B1B0057180' oid='9B53668AE7F04e84A25B7B85C5274BA2' temploid='43ABB041E2B443669CA8AE45DE58DB4D' tmplref='_000001B1ADF15DE0' dtref='_000001B1ADBDCBA0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read Supported PID (OBD)</TUV>
+</NAME>
+<QUAL>Read_Supported_PID_OBD</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B00572A0' oid='52310DA0D2F14ff3A0F01473130BB100' temploid='B9A65BCDA83D463b814E6DD29B6C6831' tmplref='_000001B1ADF178E0' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read PID (OBD)</TUV>
+</NAME>
+<QUAL>Read_PID_OBD</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0057BA0' oid='11BC09F030B54e06884DB8CD0CE407B0' temploid='B377FE5FB0E94357B8F562D5A02132E4' tmplref='_000001B1AFE7B930' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read Supported Freeze Frame PID</TUV>
+</NAME>
+<QUAL>Read_Supported_Freeze_Frame_PID</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B00574E0' oid='6E10913561464f09A5D0219388E90C20' temploid='946D86687FB24e09BF1F40C0D0FB2664' tmplref='_000001B1AFE7A2B0' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read Freeze Frame PID Data</TUV>
+</NAME>
+<QUAL>Read_Freeze_Frame_PID_Data</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0058C80' oid='442F2A3FE28E404cAB8B3811192E2775' temploid='ADAA043B82E246a2972581DF7E2D4BD5' tmplref='_000001B1AFE7BDB0' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read Supported PID (UDS)</TUV>
+</NAME>
+<QUAL>Read_Supported_PID_UDS</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0057600' oid='F273A1AC4EF9489dB79848C366CAC0C9' temploid='C8351E1DD758422f8CD36E228DB07FE9' tmplref='_000001B1AFE7A970' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read PID (UDS)</TUV>
+</NAME>
+<QUAL>Read_PID_UDS</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE67E0' oid='2A1B6B418B0D4273B0410FBED1C4C4B2' temploid='DC00459280EA4e54BF53C4C51F21DA94' spec='pid'>
+<NAME>
+<TUV xml:lang='en-US'>PID</TUV>
+</NAME>
+<QUAL>PID</QUAL>
+<STATICCOMPREF idref='_000001B1ADE33230'/>
+<STATICCOMPREF idref='_000001B1ADE32240'/>
+<STATICCOMPREF idref='_000001B1ADE33450'/>
+<STATICCOMPREF idref='_000001B1ADE30E10'/>
+<STATICCOMPREF idref='_000001B1ADE32F00'/>
+<STATICCOMPREF idref='_000001B1ADE32350'/>
+<STATICCOMPREF idref='_000001B1ADE33CD0'/>
+<STATICCOMPREF idref='_000001B1ADE32790'/>
+<STATICCOMPREF idref='_000001B1ADE2E4A0'/>
+<STATICCOMPREF idref='_000001B1ADE2E5B0'/>
+<STATICCOMPREF idref='_000001B1ADE2D6D0'/>
+<STATICCOMPREF idref='_000001B1ADE2D7E0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1B005CA70' oid='CFD8A15AC92642589487316C6D4D46CA' temploid='AB36989A705D4fa69EAE5B3A0494967C' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Supported OBD PIDs</TUV>
+</NAME>
+<QUAL>Supported_PIDs_or_PID_Data</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE32360'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005D970' oid='FA888218BD4644939910497D1DC1776C' temploid='BEBE470FA32F48398F7846DC04B60A64' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>PID Data</TUV>
+</NAME>
+<QUAL>Supported_PIDs_or_PID_Data_1</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE30A70'/>
+<PROXYCOMPREF idref='_000001B1AFE2ECC0'/>
+<PROXYCOMPREF idref='_000001B1AFE28900'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005B970' oid='A3513F9AAC53460aB31A8DE528DF95EB' temploid='B6DAEC3D8AB542f7828332C00F097686' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Supported OBD FreezeFrame PIDs</TUV>
+</NAME>
+<QUAL>Supported_PIDs_or_PID_Data_2</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE318B0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005E770' oid='CD6ED3D0A87444dc814827440E1CE0BF' temploid='4F6F9FAEB2624973BE368199FCE681C6' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Supported UDS PIDs</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE26690'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005CB70' oid='1FC521140A804bf7BD95C6291844A39F' temploid='9633336B48E2433dADEF4886C9384A92' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read Supported PID (UDS)</TUV>
+</NAME>
+<QUAL>Read_Supported_PID_UDS</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE25720'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005C070' oid='9DAA1A91A0B94464BE0DD0BDB886BAC6' temploid='E0FC4C428D0D40bfB9373CD2B5E5B397' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read PID (UDS)</TUV>
+</NAME>
+<QUAL>Read_PID_UDS</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE27E50'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B005D570' oid='689BB62D32004f7490FC90D4FBF0252C' temploid='1A6A8809144C49fbBF1D10BC13C2FB97' cls='ftm' single='1'>
+<NAME>
+<TUV xml:lang='en-US'>Emission-related Trouble Codes</TUV>
+</NAME>
+<QUAL>Emission_related_Trouble_Codes</QUAL>
+<DCLSRVTMPL id='_000001B1B0057A80' oid='DF6A8FF979A64f28932D03392A39905F' temploid='311829B3F461431e9170A4793D6E7B32' tmplref='_000001B1AFE7ADF0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read (Powertrain)</TUV>
+</NAME>
+<QUAL>Read_Powertrain</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0058A40' oid='1E9D39957F6A4c44B1B8FFA194BBE120' temploid='A4866AE37B104ec2A160A77D09318639' tmplref='_000001B1AFE7A070' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read (detection time dependent)</TUV>
+</NAME>
+<QUAL>Read_detection_time_dependent</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0058DA0' oid='9EBC70820171499e8A5A77EA88F0AAD2' temploid='A0DB10BB28E642bc8720AB8166AE7B44' tmplref='_000001B1AFE7B6F0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read (Permanent Status)</TUV>
+</NAME>
+<QUAL>Read_Permanent_Status</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0062C30' oid='27D65B6183284cd89578F81D991DB8F8' temploid='C3DD79B6D4DA4d5d8DE5C5EFBE52698C' tmplref='_000001B1AFE7C470' conv='req'>
+<NAME>
+<TUV xml:lang='en-US'>Clear/Reset</TUV>
+</NAME>
+<QUAL>Clear_Reset</QUAL>
+</DCLSRVTMPL>
+<SHPROXY id='_000001B1B005D870' oid='3DEC4D9078604b72ACE94015AC01C966' temploid='F8E26D5145454930B92096B6A21958A5' dest='obdDtc'>
+<NAME>
+<TUV xml:lang='en-US'>OBD DTC Table</TUV>
+</NAME>
+<QUAL>DTC</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE319E0'/>
+<PROXYCOMPREF idref='_000001B1AFE30940'/>
+<PROXYCOMPREF idref='_000001B1AFE33400'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005BC70' oid='8E09D9D3F51A4854920D0F1C30952725' temploid='33DF9DCE599B4384AE440BFA891BC612' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read (Permanent Status)</TUV>
+</NAME>
+<QUAL>Read_Permanent_Status</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE33D80'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005DE70' oid='98EEBA4149874434B874E630CBB90362' temploid='6EF23F8D412F41eaB500A39369603C8F' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Clear/Reset</TUV>
+</NAME>
+<QUAL>Clear_Reset</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2FB00'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B005B670' oid='ED14476A80CE4d72A58985CBF1E866FE' temploid='F638123EE4A9403dA4730784D081F512' cls='rtn' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Onboard Monitoring Test Results for Specific Monitored Systems</TUV>
+</NAME>
+<QUAL>Onboard_Monitoring_Test_Results_for_Specific_Monitored_Systems</QUAL>
+<DCLSRVTMPL id='_000001B1B0065030' oid='A092A78D2FF140d3B7FC8FF892881D28' temploid='D6FA722A18CA422eBA583C1EB9D2A160' tmplref='_000001B1AFE7A730' dtref='_000001B1ADBDCBA0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read Supported OBDMID (OBD)</TUV>
+</NAME>
+<QUAL>Read_Supported_OBDMID_OBD</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B00628D0' oid='6E4EF0B19D5C47dfA0ED6540979ECF27' temploid='81AE3367D13E4d4b95635B6299C83E33' tmplref='_000001B1AFE7CD70' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read OBDMID Data (OBD)</TUV>
+</NAME>
+<QUAL>Read_OBDMID_Data_OBD</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0064730' oid='DEBB762B227D431786176B255D1AF3E6' temploid='4F2A2627A6C3482aB8777F5131DB8305' tmplref='_000001B1AFE7B270' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read Supported OBDMID (UDS)</TUV>
+</NAME>
+<QUAL>Read_Supported_OBDMID_UDS</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0063D10' oid='5B10B58D55154f4eBA9DA9E9B1533132' temploid='D0E83550057B4011977E07D8177E6D99' tmplref='_000001B1AFE7B030' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read OBDMID Data (UDS)</TUV>
+</NAME>
+<QUAL>Read_OBDMID_Data_UDS</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE6360' oid='F250BD18DDD941d8AC025C67159E18D4' temploid='C644980C472747099DAF195F8C10D50C' spec='id'>
+<NAME>
+<TUV xml:lang='en-US'>OBDMID</TUV>
+</NAME>
+<QUAL>OBDMID</QUAL>
+<STATICCOMPREF idref='_000001B1ADE33560'/>
+<STATICCOMPREF idref='_000001B1ADE33670'/>
+<STATICCOMPREF idref='_000001B1ADE33120'/>
+<STATICCOMPREF idref='_000001B1ADE33890'/>
+<STATICCOMPREF idref='_000001B1ADE2F490'/>
+<STATICCOMPREF idref='_000001B1ADE2F5A0'/>
+<STATICCOMPREF idref='_000001B1ADE2F160'/>
+<STATICCOMPREF idref='_000001B1ADE2C3B0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1B005CC70' oid='2244CA7BB9DC43118E3A9DECA8D537C0' temploid='7A6C8BA49F1E4f77BABDC6DEF59DB661' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Supported OBD IDs</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2E0E0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005CD70' oid='64BA49FE98AB4cb19C1F45E05A891DA3' temploid='CD5F1CAFB4484aa3A1EB026953073B1F' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>OBD ID Data</TUV>
+</NAME>
+<QUAL>Data_1</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2E6D0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005E370' oid='D60ACC3BB8714afeAA1CC26EBDF4A795' temploid='24D734559ED54a2f94A407FE9BFA98DF' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Supported UDS IDs</TUV>
+</NAME>
+<QUAL>OBDMID_Data</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE248E0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005D070' oid='762CA441F5334d0dB1B9CF0DA286BFA3' temploid='C1A5920076D74c74BC62B4AECA00600C' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read Supported OBDMID (UDS)</TUV>
+</NAME>
+<QUAL>Read_Supported_OBDMID_UDS</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE25BE0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005E470' oid='2E7202E859FE4f62BF9BBFE2BF052EC7' temploid='3C847995EF80457397EE11AB76BE225E' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>UDS ID Data</TUV>
+</NAME>
+<QUAL>OBDMID_Data_1</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE33EB0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005BF70' oid='7D4CCDD0538F4ac093DB142313B87B92' temploid='C901BBE2335C4db7888AD31023E63C22' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read OBDMID Data (UDS)</TUV>
+</NAME>
+<QUAL>Read_OBDMID_Data_UDS</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE325C0'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B005C170' oid='CFEAF6EF518145f0AFC8F07A797DBEE6' temploid='8C1AC22CE13749c8B95EB8074D48AEA2' cls='rtn' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Control of Onboard Systems, Test or Control</TUV>
+</NAME>
+<QUAL>Control_of_Onboard_Systems_Test_or_Control</QUAL>
+<DCLSRVTMPL id='_000001B1B0062210' oid='EC4A55DD360D43ba972B9D1D12516ED3' temploid='38331C82CD244ed1AE6068302DEDEB61' tmplref='_000001B1AFE7CB30' dtref='_000001B1ADBDCBA0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read supported TIDs (OBD)</TUV>
+</NAME>
+<QUAL>Read_supported_TIDs_OBD</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0064F10' oid='0E727DF406814fd1A8940320C49A8C3C' temploid='871CBB0AA2B94c789E0297925EA8F7B4' tmplref='_000001B1AFE7ABB0' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Control TID (OBD)</TUV>
+</NAME>
+<QUAL>Control_TID_OBD</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0062330' oid='645B73F8072641578D2D99EBFD4B36AC' temploid='72F7B7879FE84cf183D57CBFCD2F4057' tmplref='_000001B1AFE7B4B0' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read supported TIDs (UDS)</TUV>
+</NAME>
+<QUAL>Read_supported_TIDs_UDS</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0061FD0' oid='72D2681D8A794159995ACB9FE2FA63F1' temploid='94D266E9FE7A436a8293591F97BAF5FC' tmplref='_000001B1AFE7D8B0' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Control TID (UDS)</TUV>
+</NAME>
+<QUAL>Control_TID_UDS</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE6BA0' oid='BB7FDDF55A244a568807C97F6FB72D42' temploid='82949826431E4b70B0A2CF19CD272AA6' spec='lid'>
+<NAME>
+<TUV xml:lang='en-US'>TID</TUV>
+</NAME>
+<QUAL>TID</QUAL>
+<STATICCOMPREF idref='_000001B1ADE33EF0'/>
+<STATICCOMPREF idref='_000001B1ADE30BF0'/>
+<STATICCOMPREF idref='_000001B1ADE339A0'/>
+<STATICCOMPREF idref='_000001B1ADE33AB0'/>
+<STATICCOMPREF idref='_000001B1ADE2DE40'/>
+<STATICCOMPREF idref='_000001B1ADE30370'/>
+<STATICCOMPREF idref='_000001B1ADE30040'/>
+<STATICCOMPREF idref='_000001B1ADE2C5D0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1B005EA70' oid='A53AA0FD7C754d21BB2A04B02CC6B391' temploid='830F0523A58941e7A9D1E695016321A8' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Supported TIDs</TUV>
+</NAME>
+<QUAL>Supported_TIDs</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE300F0'/>
+<PROXYCOMPREF idref='_000001B1AFE27730'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005D270' oid='530A74F46B7C47c58D5ADB5F83D52B6E' temploid='21CA306EBFCC40b0B0244B27E51DFC73' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read supported TIDs (OBD)</TUV>
+</NAME>
+<QUAL>Read_supported_TIDs_OBD</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE30220'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005EE70' oid='1D3C35F31EC9437b900C864A4F4E8E6F' temploid='9AF8EA524B714f0484A629DE7A046332' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Control TID (OBD)</TUV>
+</NAME>
+<QUAL>Control_TID_OBD</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE30E00'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005F170' oid='8C3292FE9DBB4f869742C22F4C9CB55B' temploid='05907C4D55F4492181529147A3A0F2EF' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read supported TIDs (UDS)</TUV>
+</NAME>
+<QUAL>Read_supported_TIDs_UDS</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE24DA0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005D370' oid='36FC89DB46DE43738B728BCD781A939B' temploid='E951F100C95445ff83653523A6281B9A' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Control TID (UDS)</TUV>
+</NAME>
+<QUAL>Control_TID_UDS</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE24C70'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B005E670' oid='9DC21CF059FC433eB2946A74EFD24C27' temploid='20D26A2B2C8445948A81426C9D3F6C6A' cls='act' single='0'>
+<NAME>
+<TUV xml:lang='en-US'>Vehicle Information</TUV>
+</NAME>
+<QUAL>Vehicle_Information</QUAL>
+<DCLSRVTMPL id='_000001B1B0062E70' oid='F1A18ED16DE64072836D232F8A988E98' temploid='159E4C5163AA4c4c929CCAD486C46D5E' tmplref='_000001B1AFE7DD30' dtref='_000001B1ADBDCBA0' conv='optyes'>
+<NAME>
+<TUV xml:lang='en-US'>Read supported InfoTypes (OBD)</TUV>
+</NAME>
+<QUAL>Read_supported_InfoTypes_OBD</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B00630B0' oid='31C0420BA9934097B63FB4C1F6C39FF2' temploid='510278D4DF544eef97C32171BB816B52' tmplref='_000001B1AFE7CFB0' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read InfoType Data (OBD)</TUV>
+</NAME>
+<QUAL>Read_InfoType_Data_OBD</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B00627B0' oid='18E1E075D8104c1d865E2D7DD8C4253A' temploid='02BCD6DFC09E48db938FB2CDECF0B898' tmplref='_000001B1AFE7BB70' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read supported InfoTypes (UDS)</TUV>
+</NAME>
+<QUAL>Read_supported_InfoTypes_UDS</QUAL>
+</DCLSRVTMPL>
+<DCLSRVTMPL id='_000001B1B0063890' oid='006EAA37A6984c408BAEC708C690D6BA' temploid='F330E4AD27844e0a8CC4F615BB800ABA' tmplref='_000001B1AFE7D430' dtref='_000001B1ADBDCBA0' conv='optno'>
+<NAME>
+<TUV xml:lang='en-US'>Read InfoType Data (UDS)</TUV>
+</NAME>
+<QUAL>Read_InfoType_Data_UDS</QUAL>
+</DCLSRVTMPL>
+<SHSTATIC id='_000001B1AFFE6D20' oid='374EC79DEC1446ae9343E536156E5D95' temploid='06ACE97740154e3599BD070FBD9670FF' spec='info'>
+<NAME>
+<TUV xml:lang='en-US'>InfoType</TUV>
+</NAME>
+<QUAL>InfoType</QUAL>
+<STATICCOMPREF idref='_000001B1ADE2F380'/>
+<STATICCOMPREF idref='_000001B1ADE2E170'/>
+<STATICCOMPREF idref='_000001B1ADE30F20'/>
+<STATICCOMPREF idref='_000001B1ADE2C7F0'/>
+<STATICCOMPREF idref='_000001B1ADE2FC00'/>
+<STATICCOMPREF idref='_000001B1ADE2E280'/>
+<STATICCOMPREF idref='_000001B1ADE2CA10'/>
+<STATICCOMPREF idref='_000001B1ADE2C4C0'/>
+</SHSTATIC>
+<SHPROXY id='_000001B1B005DB70' oid='C6BF8900E3574770A56D0A1F7FC7AFBF' temploid='18A019EDB36242caA68BA5FAE79AA7DB' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Supported OBD IDs</TUV>
+</NAME>
+<QUAL>InfoTypeData</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE30810'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005DF70' oid='F96862FF95A54d27840AE72A5A1A3924' temploid='E93BE79E6069417eA75537E27780B369' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>InfoTypeData</TUV>
+</NAME>
+<QUAL>InfoTypeData_1</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE2DD50'/>
+<PROXYCOMPREF idref='_000001B1AFE32CE0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005DC70' oid='FB27267BDB484813BDC713BB91878FE2' temploid='0E84BCD61E71449dA2345859A2FF7054' dest='data'>
+<NAME>
+<TUV xml:lang='en-US'>Supported UDS IDs</TUV>
+</NAME>
+<QUAL>Data</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE281E0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005D670' oid='1391A216F78F4e53A9AADD9091B91A37' temploid='6A8C43D082894f3b8916D116A95C0649' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read supported InfoTypes (UDS)</TUV>
+</NAME>
+<QUAL>Read_supported_InfoTypes_UDS</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE25AB0'/>
+</SHPROXY>
+<SHPROXY id='_000001B1B005E870' oid='8D9A5BC3E7F142b097CE189B68511E74' temploid='C404EACA7239420f918CDDB4C412399A' dest='resCode'>
+<NAME>
+<TUV xml:lang='en-US'>Read InfoType Data (UDS)</TUV>
+</NAME>
+<QUAL>Read_InfoType_Data_UDS</QUAL>
+<PROXYCOMPREF idref='_000001B1AFE338C0'/>
+</SHPROXY>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B005B770' oid='E96F985CB3034b219DF60F99369E4294' temploid='45790AF8382F4292962517066DDFBB9D' cls='flashjob' single='1'>
+<NAME>
+<TUV xml:lang='en-US'>Flash Jobs</TUV>
+</NAME>
+<QUAL>Flash_Jobs</QUAL>
+</DCLTMPL>
+<DCLTMPL id='_000001B1B005D770' oid='948606CD44764947A1282BA5D02666F1' temploid='945EC05883164a8cB84A8689760A7D01' cls='job' single='1'>
+<NAME>
+<TUV xml:lang='en-US'>Generic Jobs</TUV>
+</NAME>
+<QUAL>Generic_Jobs</QUAL>
+</DCLTMPL>
+</DCLTMPLS>
+<RECORDDTPOOL>
+<RECORDDT id='_000001B1ADC18E30' oid='2AAAD593560F4a239E76A09B2C5ACD72' temploid='6F30D391D9564678B33BF5646B1386BE' bm='4294967295' rtSpec='faultMemory'>
+<NAME>
+<TUV xml:lang='en-US'>RecordDataType</TUV>
+</NAME>
+<QUAL>RecordDataType</QUAL>
+<CVALUETYPE bl='24' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='0' maxsz='255'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+</RECORDDT>
+<RECORDDT id='_000001B1ADC19BF0' oid='CBCFC834905F40c3826941DA5B01A25E' temploid='D9ECBBF66E524a2aA935467C69211CAC' bm='4294967295' rtSpec='obdFaultMemory'>
+<NAME>
+<TUV xml:lang='en-US'>OBDRecordDataType</TUV>
+</NAME>
+<QUAL>OBDRecordDataType</QUAL>
+<CVALUETYPE bl='16' bo='21' enc='uns' sig='0' df='hex' qty='atom' sz='no' minsz='0' maxsz='255'/>
+<PVALUETYPE bl='16' bo='21' enc='utf' sig='0' df='text' qty='field' sz='no' minsz='0' maxsz='65535'/>
+</RECORDDT>
+</RECORDDTPOOL>
+<ECU id='_000001B1AD93A5E0' oid='FE136D38FDA548698D72E65625021765' temploid='{A120ED60-20AB-4660-97EA-CD85CDFA5B23}' maxCombinedServiceIds='5' maxEcuSchedulerIds='5'>
+<NAME>
+<TUV xml:lang='en-US'>SBS Test</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US' struct='1'><PARA><FC b='1'>Notes for CANdesc Code Generation</FC>
+</PARA>
+<PARA><FC></FC>
+</PARA>
+<PARA><FC>The following diagnostic instance options can be configured in GENy (CANdesc) only:</FC>
+</PARA>
+<PARA list='bul'><FC>MaxAttemptsToDelay</FC>
+</PARA>
+<PARA list='bul'><FC>MaxAttemptsToLock</FC>
+</PARA>
+<PARA list='bul'><FC>DelayTimeMs</FC>
+</PARA>
+<PARA list='bul'><FC>DelayTimeOnPowerOnMs</FC>
+</PARA>
+<PARA><FC>The options are available as attributes in this file, but with category "UDS", therefore they do not take effect in GENy.</FC>
+</PARA>
+<PARA><FC>To configure the options for GENy already in the CANdela file, use the older Vector_UDS_1.5.cddt instead.</FC>
+</PARA>
+<PARA><FC></FC>
+</PARA>
+<PARA><FC>User Defined Fault Memory:</FC>
+</PARA>
+<PARA list='bul'><FC>CANdesc </FC>
+<FC>with Vector DEM checks the Memory Selection parameter, accepts only the first one defined in the CDD and rejects all other requests. It does not forward the Memory Selection to the Vector DEM but just asks for "SecondaryMemory". </FC>
+</PARA>
+<PARA list='bul'><FC>CANdesc without Vector DEM: it is the task of the main handler (application) to distinguish the User Defined Fault Memories. The main handler gets all parameters of the request.</FC>
+</PARA>
+</TUV>
+</DESC>
+<QUAL>SBS_Test</QUAL>
+<UNS oid='2A1AAE643A39463eB2461E903B5AC661' temploid='9E27186D6C924819ABE15D0CCD9EE894' attrref='_000001B1ABDB84A0' v='1000'/>
+<UNS oid='0AE040EDEB0D4e59AE2F9B1C0772EA3D' temploid='9694A3E3965043359318BE785E9CA59E' attrref='_000001B1ABDB8690' v='100'/>
+<UNS oid='62C75545563643f2A428D77D413C2988' temploid='D0EF81724469438a8E25686B6FDF5176' attrref='_000001B1ADA98170' v='20'/>
+<ENUM oid='D9A79220C543465cBD398593A7D03EEB' temploid='8635A956B17F4505981115C2D6D2B53D' attrref='_000001B1ADA809B0' v='1'/>
+<CSTR oid='EBD43083F1CB46e1BD7C4374246B4FBD' temploid='741DE4A877B74bfaB2B45D63830BA213' attrref='_000001B1ADA9E460'>
+<COMMONSTRING>SYNCHELEMENT</COMMONSTRING>
+</CSTR>
+<FAULTMEMORY mayBeAddDelSr='1' supportDtcSpecificData='1' forceSameSnapshotData='1' forceDidSnapshotData='1' mayBeAddDelEdr='1' supportEdrForDtc='1' dnDtRef='_000001B1AD958EA0'>
+<COMMONSNAPSHOTDATAPOOL>
+<DIDCOMMONSNAPSHOTDATA id='_000001B1AFFE6DE0' oid='BDA398367BEA44129B904B4D0EB6F374' temploid='AC202A95C8F549338BD9BF47AC6411E8' supportDtcSpecificData='1'>
+<NAME>
+<TUV xml:lang='en-US'>Snapshot Data</TUV>
+</NAME>
+<QUAL>Snapshot_Data</QUAL>
+</DIDCOMMONSNAPSHOTDATA>
+</COMMONSNAPSHOTDATAPOOL>
+<SNAPSHOTRECORDS>
+<SPECIFICSNAPSHOTRECORD rn='16' mayBeDel='1' oid='CC7D17D864104b898C112654BF1C0BB7' temploid='37B2C08C15794194810FF720266BB63C' mayBeMod='1' mayBeModData='1' csdRef='_000001B1AFFE6DE0'>
+<NAME>
+<TUV xml:lang='en-US'>Snapshot Record 0x10</TUV>
+</NAME>
+<QUAL>Snapshot_Record_0x10</QUAL>
+</SPECIFICSNAPSHOTRECORD>
+</SNAPSHOTRECORDS>
+<EXTENDEDDATARECORDS>
+<EXTENDEDDATARECORD oid='C7909539802D4c3cA4B5CC8DA57550FF' temploid='57AE6C9BB06E48cc85D6CD41BAEFDCB5' rn='1' mayBeMod='1' mayBeDel='1' mayBeModData='1' supportEdrForDtc='1'>
+<NAME>
+<TUV xml:lang='en-US'>Extended Data Record 0x01</TUV>
+</NAME>
+<QUAL>Extended_Data_Record_0x01</QUAL>
+<STRUCTURE>
+</STRUCTURE>
+</EXTENDEDDATARECORD>
+</EXTENDEDDATARECORDS>
+</FAULTMEMORY>
+<VAR id='_000001B1AD923900' oid='65E0A5882CD142cfA63A6C8BDAD7AAAE' temploid='{8E93F445-4173-4bff-9D7C-852EFDF68146}' base='1'>
+<NAME>
+<TUV xml:lang='en-US'>Base Variant</TUV>
+</NAME>
+<QUAL>Base_Variant</QUAL>
+<DIDREFS>
+<DIDREF didRef='_000001B1ADAAE070'/>
+<DIDREF didRef='_000001B1ADAB0070'/>
+<DIDREF didRef='_000001B1ADAB0A70'/>
+<DIDREF didRef='_000001B1ADAB0B70'/>
+<DIDREF didRef='_000001B1ADAAD870'/>
+<DIDREF didRef='_000001B1ADAAE170'/>
+<DIDREF didRef='_000001B1ADAADD70'/>
+<DIDREF didRef='_000001B1ADAAE370'/>
+<DIDREF didRef='_000001B1ADAADC70'/>
+<DIDREF didRef='_000001B1ADAB0170'/>
+<DIDREF didRef='_000001B1ADAB0370'/>
+<DIDREF didRef='_000001B1ADAAE870'/>
+<DIDREF didRef='_000001B1ADAAFE70'/>
+<DIDREF didRef='_000001B1ADAADE70'/>
+<DIDREF didRef='_000001B1ADAB1170'/>
+</DIDREFS>
+<DIAGCLASS id='_000001B1AFEF8220' oid='7E7B14A29DBE4243999FFA46CD304DFC' temploid='{EF519DA9-7F26-447d-895E-2A56D79C0554}' tmplref='_000001B1ADAAD770'>
+<NAME>
+<TUV xml:lang='en-US'>Sessions</TUV>
+</NAME>
+<DESC>
+<TUV xml:lang='en-US' struct='1'><PARA><FC>This Diagnostic Class describes the use case of the Session Management.</FC>
+</PARA>
+</TUV>
+</DESC>
+<QUAL>Sessions</QUAL>
+<DIAGINST id='_000001B1ADAE02C0' oid='95F116EFA92B423cA531405A31321C38' temploid='{192FE97A-5CB2-4c27-9A7C-670CD61A843B}' tmplref='_000001B1ADAAD770' req='req' xauth='a'>
+<NAME>
+<TUV xml:lang='en-US'>Default Session</TUV>
+</NAME>
+<QUAL>DefaultSession</QUAL>
+<SERVICE id='_000001B1ADB14AB0' oid='15A2863B59D346b78A0FD5FF53214D22' temploid='{F40C0DEC-B6F0-420a-8EC8-287EC7EAC344}' tmplref='_000001B1ADCB8E20' func='1' phys='1' respOnPhys='1' respOnFunc='1' req='0' mayBeExec='(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25)' trans='(1,1,2,1,3,1,12,11)'>
+<NAME>
+<TUV xml:lang='en-US'>Start</TUV>
+</NAME>
+<QUAL>Start</QUAL>
+<ENUM oid='9A096E0509F84606B3DADCF83466179F' temploid='{F26925EA-4EF0-452e-AF4F-745361B1E974}' attrref='_000001B1ADADCD80' v='1'/>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Default Session Start</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>DefaultSession_Start</SHORTCUTQUAL>
+</SERVICE>
+<STATICVALUE oid='A1F47D6BFC624014AFAF705221D3A48C' temploid='{03FFA54B-5B3B-457d-B1EA-08687BF7892D}' shstaticref='_000001B1ADA6D580' v='1'/>
+<SIMPLECOMPCONT oid='9AB2D40BD8494d43841ED2FBAAC59958' temploid='65A736D7CFBC41d29E7887066C3FBB78' shproxyref='_000001B1ADAAF770'>
+<DATAOBJ oid='E8F38EBEA1F74478AA671FD5F11989BA' temploid='98D3AFC1A2F54d51BDE3CDE882E6CE8E' spec='no' dtref='_000001B1ADCB8640'>
+<NAME>
+<TUV xml:lang='en-US'>P2</TUV>
+</NAME>
+<QUAL>P2</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='39FAC64B1F214de09C4E50F006E80E8E' temploid='90FF00B3EDA94915B8089EB59FB826BB' spec='no' dtref='_000001B1ADC19E70'>
+<NAME>
+<TUV xml:lang='en-US'>P2Ex</TUV>
+</NAME>
+<QUAL>P2Ex</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='647557B26A57440eBA053C7C35CBF4DC' temploid='{694E208C-1D74-4e6a-948C-FC251F1A848B}' shproxyref='_000001B1ADAAF570'>
+<SPECDATAOBJ oid='14F14ED01EFB438a881225BE4988C17F' temploid='{D0F85234-2639-42e7-A910-2F52BFB7729D}'>
+<NAME>
+<TUV xml:lang='en-US'>Start NR</TUV>
+</NAME>
+<QUAL>Start_NR</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+</DIAGINST>
+<DIAGINST id='_000001B1ADAE0D40' oid='6260499264074a5285B84501489D10C9' temploid='{996DB146-069D-48fa-94D5-16DEF5139A05}' tmplref='_000001B1ADAAD770' req='req'>
+<NAME>
+<TUV xml:lang='en-US'>Programming Session</TUV>
+</NAME>
+<QUAL>ProgrammingSession</QUAL>
+<SERVICE id='_000001B1ADB14C90' oid='2C29373846A34762A9F8C3FE494506C8' temploid='{65676A76-8FD4-432b-BFA9-E4B5D85EE274}' tmplref='_000001B1ADCB8E20' func='1' phys='1' respOnPhys='1' respOnFunc='1' req='0' mayBeExec='(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25)' trans='(1,2,2,2,3,2,12,11)'>
+<NAME>
+<TUV xml:lang='en-US'>Start</TUV>
+</NAME>
+<QUAL>Start</QUAL>
+<ENUM oid='E1E4A0D2F7F64c7dBFAB65CB7DA51BA2' temploid='{C5FFF374-0C8D-4f9e-B486-CAC1D4FFDD62}' attrref='_000001B1ADADCD80' v='1'/>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Programming Session Start</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>ProgrammingSession_Start</SHORTCUTQUAL>
+</SERVICE>
+<STATICVALUE oid='A2E2E37E0DE34babB9AC48BB5D19C1F7' temploid='{0A86220D-1FD0-4779-8BEA-A89F391D0E92}' shstaticref='_000001B1ADA6D580' v='2'/>
+<SIMPLECOMPCONT oid='07DDAD2A9F79447dAA49BB426BA27FAE' temploid='B54F5168848549b7955F2F82A0083A2E' shproxyref='_000001B1ADAAF770'>
+<DATAOBJ oid='779021EC8DEB460aA2EEBB65667C5ED1' temploid='1C7C0B0472AC441c9BF5D298F1FD210E' spec='no' dtref='_000001B1ADCB8640'>
+<NAME>
+<TUV xml:lang='en-US'>P2</TUV>
+</NAME>
+<QUAL>P2</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='05D51B7A0A7B48059F610E8E9C973B36' temploid='026BBDD2BA944b1dB465F39A931C0CFC' spec='no' dtref='_000001B1ADC19E70'>
+<NAME>
+<TUV xml:lang='en-US'>P2Ex</TUV>
+</NAME>
+<QUAL>P2Ex</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='08D19C09EFD24441912AED4CCF677B1A' temploid='{B903EB3F-53C4-46bf-A386-8101CFF67577}' shproxyref='_000001B1ADAAF570'>
+<SPECDATAOBJ oid='0348304B3CCB460d8CAF0E3038531D4B' temploid='{E79BDE97-40F9-458e-A254-6F74922A62DD}'>
+<NAME>
+<TUV xml:lang='en-US'>Start NR</TUV>
+</NAME>
+<QUAL>Start_NR</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB322F0'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+</DIAGINST>
+<DIAGINST id='_000001B1ADADFCC0' oid='3433E0FD64B445d5B85695B36CA20798' temploid='{A7E046A3-3EBD-4dee-9E66-977165E32881}' tmplref='_000001B1ADAAD770' req='req'>
+<NAME>
+<TUV xml:lang='en-US'>Extended Diagnostic Session</TUV>
+</NAME>
+<QUAL>ExtendedDiagnosticSession</QUAL>
+<SERVICE id='_000001B1ADB139D0' oid='2C600C3646AD4188B4A6DC9A03055E0E' temploid='{95B98A15-824A-4204-ACE7-CA93065582B3}' tmplref='_000001B1ADCB8E20' func='1' phys='1' respOnPhys='1' respOnFunc='1' req='0' mayBeExec='(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25)' trans='(1,3,2,3,3,3,12,11)'>
+<NAME>
+<TUV xml:lang='en-US'>Start</TUV>
+</NAME>
+<QUAL>Start</QUAL>
+<ENUM oid='842FCD9654FA45edACB000E5FE59C93F' temploid='{5DA423DE-6977-4f55-8404-5FBCBA624E80}' attrref='_000001B1ADADCD80' v='1'/>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Extended Diagnostic Session Start</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>ExtendedDiagnosticSession_Start</SHORTCUTQUAL>
+</SERVICE>
+<STATICVALUE oid='EBCDF24A01C745b7B19FF06B8FA95155' temploid='{C033E615-26F9-42d4-A8A5-6D58DC644289}' shstaticref='_000001B1ADA6D580' v='3'/>
+<SIMPLECOMPCONT oid='4078A3EBEE894acdAA7E1040022D010C' temploid='9C69EC0862544e0987A05E2109381DE5' shproxyref='_000001B1ADAAF770'>
+<DATAOBJ oid='7AB81918F6DE454792B367E4B2957AAF' temploid='5B1B35A040B54eab94565B3C63BE95EF' spec='no' dtref='_000001B1ADCB8640'>
+<NAME>
+<TUV xml:lang='en-US'>P2</TUV>
+</NAME>
+<QUAL>P2</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='99866AB817A74f7aA8F4A3D4D29EF2A0' temploid='3DF72B08D8E04b1cB37A9C2E1BCB9A54' spec='no' dtref='_000001B1ADC19E70'>
+<NAME>
+<TUV xml:lang='en-US'>P2Ex</TUV>
+</NAME>
+<QUAL>P2Ex</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='85BB6C277B9A4c25BB687A0E0DF02761' temploid='{6F58EBF2-EFF1-4a79-BEE2-745174892510}' shproxyref='_000001B1ADAAF570'>
+<SPECDATAOBJ oid='46E0ACDFA683447c9F554D6C74E6FD7E' temploid='{13C2DC8D-1B5F-4448-9852-845C1985E1C1}'>
+<NAME>
+<TUV xml:lang='en-US'>Start NR</TUV>
+</NAME>
+<QUAL>Start_NR</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+</DIAGINST>
+</DIAGCLASS>
+<DIAGINST id='_000001B18CF758E0' oid='181FFC16E21E422fAA70B6C181A25963' temploid='{EA8A4755-A147-4e30-AA93-18D4BC8D9AFF}' tmplref='_000001B1AFFAA670' req='req'>
+<NAME>
+<TUV xml:lang='en-US'>Tester Present</TUV>
+</NAME>
+<QUAL>TesterPresent</QUAL>
+<SERVICE id='_000001B1B00F08C0' oid='9D75C60FB36D4eb6A46E500C2E33D7A8' temploid='{7FCD7FF9-50AB-4a7f-AE10-DB310227E826}' tmplref='_000001B1AFFAE860' func='1' phys='1' respOnPhys='1' respOnFunc='1' req='0'>
+<NAME>
+<TUV xml:lang='en-US'>Send</TUV>
+</NAME>
+<QUAL>Send</QUAL>
+<ENUM oid='B32908530A5C4affAAC90A7E65BEB946' temploid='{2F6910D8-1BD9-49df-B902-3942597AD7E5}' attrref='_000001B1ADADCD80' v='2'/>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Tester Present Send</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>TesterPresent_Send</SHORTCUTQUAL>
+</SERVICE>
+<SIMPLECOMPCONT oid='DFAA7CD1F1F64e0d8FAF4E726488C4E1' temploid='{2C5FE0BC-B90B-45a3-8FDB-5180FEBA646B}' shproxyref='_000001B1AFFAA770'>
+<SPECDATAOBJ oid='2CB8B7061EDB4dc4B0B8E80D9DD3AAFE' temploid='{9359924F-230E-4b47-847A-0140D1B9BBFC}'>
+<NAME>
+<TUV xml:lang='en-US'>Send</TUV>
+</NAME>
+<QUAL>Send</QUAL>
+<NEGRESCODEPROXIES>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+</DIAGINST>
+<DIAGCLASS id='_000001B1B012CD70' oid='F1C3BE92D67243849C836903BC2152B5' temploid='351A4D8B0AEE4bc7BA9958481AD328CF' tmplref='_000001B1B000C470'>
+<NAME>
+<TUV xml:lang='en-US'>IO Control</TUV>
+</NAME>
+<QUAL>IOControl</QUAL>
+<DIAGINST id='_000001B1B0127AF0' oid='6DAF8941CA1E4c1aB806E41803276337' temploid='6625E9EC0EB2440bBF0C6B2F8C8C3398' tmplref='_000001B1B000C470' req='notReq'>
+<NAME>
+<TUV xml:lang='en-US'>Control Digital IO</TUV>
+</NAME>
+<QUAL>Control_Digital_IO</QUAL>
+<SERVICE id='_000001B1B0153430' oid='9FC825269264459cBCEF6CDD895BD744' temploid='29C65C549C6D43eaB70200D5A4F38CFF' tmplref='_000001B1ADF7C050' func='1' phys='1' respOnPhys='1' respOnFunc='1' req='0'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Control Digital IO Read</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>Control_Digital_IO_Read</SHORTCUTQUAL>
+</SERVICE>
+<SERVICE id='_000001B1B0153070' oid='5D0C0094F5A044f98E9D479EAD0BC283' temploid='3AB6E6645CD149139CE9252AD0011761' tmplref='_000001B1ADF7A8B0' func='1' phys='1' respOnPhys='1' respOnFunc='1' req='0' mayBeExec='(3,4,5,6,7,8,9,10)'>
+<NAME>
+<TUV xml:lang='en-US'>Control</TUV>
+</NAME>
+<QUAL>Control</QUAL>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Control Digital IO Control</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>Control_Digital_IO_Control</SHORTCUTQUAL>
+</SERVICE>
+<STATICVALUE oid='51922AE4B18C431cB3E6FE72936F3FBA' temploid='E0A0FF5AA15948e29FD1E46A6579D188' shstaticref='_000001B1AFFE65A0' v='768'/>
+<SIMPLECOMPCONT oid='F5B2D98076A04223889DD51976F9DCA6' temploid='ED68442207934879B20DD0D84562FEB9' shproxyref='_000001B1B000C870'>
+<DIDDATAREF oid='599A789E44604c0e97A80CE75D6D6D23' temploid='534621A1FF394d558273E75C10EF7A13' didRef='_000001B1ADAB0A70'>
+<NAME>
+<TUV xml:lang='en-US'>Common Diagnostics Control States 16</TUV>
+</NAME>
+<QUAL>Common_Diagnostics_Control_States_16</QUAL>
+</DIDDATAREF>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='10D025D4ABB44e0cA37FED66681DB80E' temploid='68E163F1C67B40778056551C389EE035' shproxyref='_000001B1B000C570'>
+<STRUCT oid='675D2604EBB54cd9829EB4E80381E86F' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>New Bit Field</TUV>
+</NAME>
+<QUAL>New_Bit_Field</QUAL>
+<DATAOBJ oid='C0111D22409C4cecA955E02302FFEB9C' spec='no' def='0' dtref='_000001B1ADCA4EF0'>
+<NAME>
+<TUV xml:lang='en-US'>IO State</TUV>
+</NAME>
+<QUAL>IO_State</QUAL>
+</DATAOBJ>
+<DATAOBJ oid='FDF9BF237E6E4b328CB1E688A666BDE7' spec='no' def='0' dtref='_000001B1ADCA4EF0'>
+<NAME>
+<TUV xml:lang='en-US'>Pin ID</TUV>
+</NAME>
+<QUAL>Pin_ID</QUAL>
+</DATAOBJ>
+</STRUCT>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='097E9759FF9342a7B93E25587EA194EC' temploid='A4394937F3B94f87A9561FBD6826CAB5' shproxyref='_000001B1B000B670'>
+<SPECDATAOBJ oid='2C2216795CD64e3b82B95BE8BDD10B39' temploid='278E4DDE597D4e9aA0742F96551DB0B3'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='27E79C2A40644459B655FA5C771D0C4A' temploid='4017630861174ef3AC44DABA49025911' shproxyref='_000001B1B000CA70'>
+<SPECDATAOBJ oid='9307E688F06E4e90A4300C1002319F6D' temploid='7B8A6B5470154852B0254F6DB1280DD7'>
+<NAME>
+<TUV xml:lang='en-US'>Control</TUV>
+</NAME>
+<QUAL>Control</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB322F0'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+</DIAGINST>
+</DIAGCLASS>
+<DIAGINST id='_000001B1B0127C70' oid='4B0C139F99F9456a83151561BD6FFB68' temploid='8871B842EC2A49629E245C7A1D78F51A' tmplref='_000001B1B0009C70' req='notReq'>
+<NAME>
+<TUV xml:lang='en-US'>Memory</TUV>
+</NAME>
+<QUAL>Memory</QUAL>
+<SERVICE id='_000001B1B01E1D90' oid='F51A40AE92E44986978DF2EAA04151D2' temploid='58439C8BC8D145b2B86EF6259C8E9067' tmplref='_000001B1B000DBC0' func='1' phys='1' respOnPhys='1' respOnFunc='1' req='0'>
+<NAME>
+<TUV xml:lang='en-US'>Read</TUV>
+</NAME>
+<QUAL>Read</QUAL>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Memory Read</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>Memory_Read</SHORTCUTQUAL>
+</SERVICE>
+<SERVICE id='_000001B1B01E2C90' oid='5F5743CB01CD4fe1B458E0BF4C325A26' temploid='6C4917944554460cBC64646E80EB5908' tmplref='_000001B1B0010680' func='1' phys='1' respOnPhys='1' respOnFunc='1' req='0'>
+<NAME>
+<TUV xml:lang='en-US'>Write</TUV>
+</NAME>
+<QUAL>Write</QUAL>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Memory Write</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>Memory_Write</SHORTCUTQUAL>
+</SERVICE>
+<SIMPLECOMPCONT oid='2FC2616CEDA041849F722BBBC2CB35BC' temploid='7D9E3CC421D44c978623E59995F5A0C1' shproxyref='_000001B1B0009D70'>
+<DATAOBJ oid='36931D30B231481d892326A808C1EBAE' temploid='3825B5675DC5493cB942C909C4944E04' spec='no' dtref='_000001B1ADCB9BA0'>
+<NAME>
+<TUV xml:lang='en-US'>DataRecord</TUV>
+</NAME>
+<QUAL>DataRecord</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='F180953DDC2747128C7E8CEBD83DBF5C' temploid='3262AE2DA20849b8ACAB37CDA01934D6' shproxyref='_000001B1B0009070'>
+<SPECDATAOBJ oid='32C675081BCD4ead89C8D983E1553C12' temploid='FAE48398E0904965812549C46BB1720E'>
+<NAME>
+<TUV xml:lang='en-US'>New Service 2</TUV>
+</NAME>
+<QUAL>New_Service_2</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='626C7043E8174744B2E9DE31DAF9C5A2' temploid='165CC0A7B4DC43d293D0BEC30B3CE0B7' shproxyref='_000001B1B0009F70'>
+<SPECDATAOBJ oid='BA0D346524B24b2588A6CF96AAACF454' temploid='BE837D2D824345acBFD48C2057662869'>
+<NAME>
+<TUV xml:lang='en-US'>New Service 3</TUV>
+</NAME>
+<QUAL>New_Service_3</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB319F0'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+</DIAGINST>
+<DIAGCLASS id='_000001B1B012EE70' oid='119559F3E778400cB435A83D3399568F' temploid='0E517BAEEFD54875AC062D2D457F3AF4' tmplref='_000001B1B005C970'>
+<NAME>
+<TUV xml:lang='en-US'>User Defined Fault Memories</TUV>
+</NAME>
+<QUAL>User_Defined_Fault_Memories</QUAL>
+</DIAGCLASS>
+<DIAGINST id='_000001B1B01280F0' oid='02E84B45F4404b56AABDE0ABC9D47DA1' temploid='38D23A2836324d71B8055E1E63EB7045' tmplref='_000001B1B005BE70' req='notReq'>
+<NAME>
+<TUV xml:lang='en-US'>Upload/Download</TUV>
+</NAME>
+<QUAL>Upload_Download</QUAL>
+<SERVICE id='_000001B1B01E1610' oid='35D3D4FBB7FA44b785BABFAA38847DA2' temploid='48C8B27E2DB74ab191E2CF8C1E205774' tmplref='_000001B1B00573C0' func='1' phys='1' respOnPhys='1' respOnFunc='1' req='0' mayBeExec='(2,4,5,6,7,8,9,10,12,13,14,15,16,17,18,19,20,21,22,23,24,25)'>
+<NAME>
+<TUV xml:lang='en-US'>RequestDownload</TUV>
+</NAME>
+<QUAL>RequestDownload</QUAL>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Upload/Download RequestDownload</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>Upload_Download_RequestDownload</SHORTCUTQUAL>
+</SERVICE>
+<SERVICE id='_000001B1B01E1070' oid='93A17E036D014471B250FC76E03984B5' temploid='C90645A2B58243feA8170D05CA75CCF3' tmplref='_000001B1B005A9C0' func='1' phys='1' respOnPhys='1' respOnFunc='1' req='0' mayBeExec='(2,4,5,6,7,8,9,10,12,13,14,15,16,17,18,19,20,21,22,23,24,25)'>
+<NAME>
+<TUV xml:lang='en-US'>RequestUpload</TUV>
+</NAME>
+<QUAL>RequestUpload</QUAL>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Upload/Download RequestUpload</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>Upload_Download_RequestUpload</SHORTCUTQUAL>
+</SERVICE>
+<SERVICE id='_000001B1B01E26F0' oid='F81D9BFEDD6543af9F184D51BAACF06B' temploid='DCC4452C03714c01B8789E307889147B' tmplref='_000001B1B005AAE0' func='0' phys='1' respOnPhys='1' respOnFunc='0' req='0' mayBeExec='(2,4,5,6,7,8,9,10,12,13,14,15,16,17,18,19,20,21,22,23,24,25)'>
+<NAME>
+<TUV xml:lang='en-US'>Transmit</TUV>
+</NAME>
+<QUAL>Transmit</QUAL>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Upload/Download Transmit</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>Upload_Download_Transmit</SHORTCUTQUAL>
+</SERVICE>
+<SERVICE id='_000001B1B01E1F70' oid='3D87CD79950247edB1AB8EF0403A1C13' temploid='377F5D7D31B24d579AACA3632678C1D9' tmplref='_000001B1B0057CC0' func='1' phys='1' respOnPhys='1' respOnFunc='1' req='0' mayBeExec='(2,4,5,6,7,8,9,10,12,13,14,15,16,17,18,19,20,21,22,23,24,25)'>
+<NAME>
+<TUV xml:lang='en-US'>Stop</TUV>
+</NAME>
+<QUAL>Stop</QUAL>
+<SHORTCUTNAME>
+<TUV xml:lang='en-US'>Upload/Download Stop</TUV>
+</SHORTCUTNAME>
+<SHORTCUTQUAL>Upload_Download_Stop</SHORTCUTQUAL>
+</SERVICE>
+<SIMPLECOMPCONT oid='6899A027BF0C47ffA8655822B44C53B2' temploid='6D1604EFD2B04f13B319DE83A64B16E4' shproxyref='_000001B1B005F070'>
+<DATAOBJ oid='C8A86DC7CBCB46ba8C97C4B69AC9D60E' temploid='480975D51645420c8C0982BB4E42C927' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>DataFormatIdentifier</TUV>
+</NAME>
+<QUAL>DFI_</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='F9873D9D9FD64a1cBCFAC5CDAE4F891F' temploid='3E3087AD3C8C4e408E796C16B9EC0312' shproxyref='_000001B1B005BB70'>
+<DATAOBJ oid='8DEA66BCEF6643a7864ABD77CC2EB632' temploid='B7040406C2C741f99B19057023513CED' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>LengthFormatIdentifier</TUV>
+</NAME>
+<QUAL>LFID</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='DCAAB3CEDB6749eb91D8E336E6C2FC1E' temploid='FC4671B06A044a7aA35879A01726EED9' shproxyref='_000001B1B005C670'>
+<DATAOBJ oid='D9C79C4BE8344b37BE7B2B204C96B5CE' temploid='A142C7DBE90040feAA0844D1F72141F4' spec='no' dtref='_000001B1AD958480'>
+<NAME>
+<TUV xml:lang='en-US'>MaxNumberOfBlockLength</TUV>
+</NAME>
+<QUAL>MNROB_</QUAL>
+</DATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='722FC4DEAF8B409dAEFDAF13FE7D76DE' temploid='3C23DF6C885B44e5894120BDAEB805BA' shproxyref='_000001B1B005D170'>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='43B46107660E475aB730656BBB97BCE0' temploid='8EAAA926A0994dccA1B9933389019697' shproxyref='_000001B1B005CE70'>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='B537C2A869094d66870EC16D9B3BABCE' temploid='98CB72111367462eB941A667B27FDB2A' shproxyref='_000001B1B005EC70'>
+<SPECDATAOBJ oid='BE148F77E1C74f9695F0DFD2574325BF' temploid='1B905CF4C5D149fbB5AE748806823D9F'>
+<NAME>
+<TUV xml:lang='en-US'>Request</TUV>
+</NAME>
+<QUAL>Request</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB31EF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB322F0'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='AEF3E7BD4C984bae82CDFEED6BA1783E' temploid='9461D4D3B4224e4f9A3AE07966A31B59' shproxyref='_000001B1B005CF70'>
+<SPECDATAOBJ oid='D40C8D49974C432590F667607C7D674A' temploid='508B7DBB506444148807726CBBDD6588'>
+<NAME>
+<TUV xml:lang='en-US'>RequestUpload</TUV>
+</NAME>
+<QUAL>RequestUpload</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB31EF0'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='4B174ADD4444446aBC392278B4F1801D' temploid='FBA055696E2340d184F444C796DC6B54' shproxyref='_000001B1B005C770'>
+<SPECDATAOBJ oid='54A4F4BAC7ED4a46ACA3871D0A9F2FED' temploid='D5DD7ED1FDC34bceA79FA91FCF98F221'>
+<NAME>
+<TUV xml:lang='en-US'>Transmit</TUV>
+</NAME>
+<QUAL>Transmit</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB325F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB316F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB31970'/>
+<NEGRESCODEPROXY idref='_000001B1ADB319F0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32A70'/>
+<NEGRESCODEPROXY idref='_000001B1ADB33370'/>
+<NEGRESCODEPROXY idref='_000001B1ADB30470'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+<SIMPLECOMPCONT oid='36F5308F1D814517AC66D56BADDA1E1D' temploid='4D93D186CAD8419f8CA9CBA92A16588E' shproxyref='_000001B1B005DD70'>
+<SPECDATAOBJ oid='09C739CB572B4bddB479C169B52E8FEB' temploid='9C439A22215A40eaBC9C73836ADAEAA6'>
+<NAME>
+<TUV xml:lang='en-US'>Stop</TUV>
+</NAME>
+<QUAL>Stop</QUAL>
+<NEGRESCODEPROXIES>
+<NEGRESCODEPROXY idref='_000001B1ADB02DD0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32870'/>
+<NEGRESCODEPROXY idref='_000001B1ADB32BF0'/>
+<NEGRESCODEPROXY idref='_000001B1ADB322F0'/>
+</NEGRESCODEPROXIES>
+</SPECDATAOBJ>
+</SIMPLECOMPCONT>
+</DIAGINST>
+<JOBCNR id='_000001B1ADC18F70' oid='4026C60AC6754e54A1D839E35C173977' temploid='6BF1968F70424b4aA3A8F89EAA5971D0' tmplref='_000001B1B005B770' req='notReq'>
+<NAME>
+<TUV xml:lang='en-US'>Flash Jobs</TUV>
+</NAME>
+<QUAL>Flash_Jobs</QUAL>
+</JOBCNR>
+<JOBCNR id='_000001B1ADC19330' oid='33C82EF216B64ebe8E40B552D5EC36F6' temploid='ED704015C4DB4496909F952BCE78FB6D' tmplref='_000001B1B005D770' req='notReq'>
+<NAME>
+<TUV xml:lang='en-US'>Generic Jobs</TUV>
+</NAME>
+<QUAL>Generic_Jobs</QUAL>
+</JOBCNR>
+</VAR>
+</ECU>
+</ECUDOC>
+</CANDELA>

--- a/tests/test_diagnostics_database.py
+++ b/tests/test_diagnostics_database.py
@@ -491,6 +491,10 @@ class CanToolsDiagnosticsDatabaseTest(unittest.TestCase):
 
         self.assertEqual(str(pe.exception), "Unknown byte order code: 4321")
 
+    def test_datarefs(self):
+        db = cantools.db.load_file('tests/files/cdd/example-diddatarefs.cdd', encoding = 'iso-8859-1')
+        self.assertEqual(len(db.dids[-1].datas), 2)
+
 
 # This file is not '__main__' when executed via 'python setup.py3
 # test'.


### PR DESCRIPTION
Some data objects are not directly part of the variant specific DID XML elements but are instead referencing to another location, this pr helps with that.
All diagnostics unit tests are still passing and a new test for this functionality has been added.