### PR TITLE
minor bug fixes and improvements

### DIFF
--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -965,7 +965,7 @@ class Message(object):
 
     def unpack_container(self,
                          data: bytes,
-                         allow_truncated: bool) \
+                         allow_truncated: bool = False) \
                          -> ContainerUnpackResultType:
         """Unwrap the contents of a container message.
 
@@ -1030,7 +1030,7 @@ class Message(object):
                           data: bytes,
                           decode_choices: bool,
                           scaling: bool,
-                          allow_truncated: bool = False) \
+                          allow_truncated: bool) \
                           -> ContainerDecodeResultType:
 
         unpacked = self.unpack_container(data, allow_truncated)

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -943,6 +943,9 @@ class Message(object):
         multiplexers = node['multiplexers']
 
         for signal in multiplexers:
+            if allow_truncated and signal not in decoded:
+                continue
+
             mux = self._get_mux_number(decoded, signal)
 
             try:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -673,6 +673,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
                              'BIT_E': 1
                          })
 
+        # partial message with omitted multiplexor signal
+        self.assertEqual(msg.decode(b'', allow_truncated=True), {})
+
     def test_big_endian_no_decode_choices(self):
         """Decode a big endian signal with `decode_choices` set to False.
 


### PR DESCRIPTION
the most significant change is to fix decoding of truncated multiplexer messages if the multiplexor signal itself is missing. (mea culpa! if just "content" signals were missing, it worked fine...)

besides this, I added an officially sanctioned way to calculate the authenticator value for a message to the AUTOSAR SecOC code and extended the decode subparser to print the raw data of the individual chunks of container messages...

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)