### PR TITLE
Fix test_plot to pass it in large time difference zone and fix misspelling 

### DIFF
--- a/cantools/autosar/end_to_end.py
+++ b/cantools/autosar/end_to_end.py
@@ -43,7 +43,7 @@ def compute_profile2_crc(payload : Union[bytes, bytearray],
         protected_len = len(payload)
         data_id = msg_or_data_id
 
-    # create the data to be checksumed
+    # create the data to be checksummed
     crc_data = bytearray(payload[1:protected_len])
 
     # append data id

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -23,7 +23,7 @@
         <ECU-INSTANCE UUID="b22f03b772a649e9bac58cab613d49ab">
           <SHORT-NAME>Dancer</SHORT-NAME>
           <DESC>
-            <L-2 L="FOR-ALL">Rythm is a Dancer!</L-2>
+            <L-2 L="FOR-ALL">Rhythm is a Dancer!</L-2>
           </DESC>
           <ASSOCIATED-COM-I-PDU-GROUP-REFS>
             <ASSOCIATED-COM-I-PDU-GROUP-REF  DEST="I-SIGNAL-I-PDU-GROUP">/PDU_GROUPS/RX/Dancer</ASSOCIATED-COM-I-PDU-GROUP-REF>

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -614,7 +614,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             'BIT_G': 0,
             'BIT_L': 0,
 
-            # BIT_A is only featued by MULTIPLEXOR_24
+            # BIT_A is only featured by MULTIPLEXOR_24
             'BIT_A': 0,
         }
 
@@ -1056,7 +1056,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(decoded, decoded2)
         self.assertEqual(decoded, decoded3)
 
-        # make sure that we won't let ourselfs disturb by trailing
+        # make sure that we won't let ourselves disturb by trailing
         # garbage
         encoded += b'\x00\x00\x00\x00'
         decoded2 = db.decode_message(db_msg.frame_id,
@@ -4817,8 +4817,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         node2 = db.nodes[1]
         self.assertEqual(node2.name, 'Dancer')
-        self.assertEqual(node2.comments, {'FOR-ALL': 'Rythm is a Dancer!'})
-        self.assertEqual(node2.comment, 'Rythm is a Dancer!')
+        self.assertEqual(node2.comments, {'FOR-ALL': 'Rhythm is a Dancer!'})
+        self.assertEqual(node2.comment, 'Rhythm is a Dancer!')
 
         node3 = db.nodes[2]
         self.assertEqual(node3.name, 'Guard')

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -163,7 +163,7 @@ Passenger:
             expected_output = """\
 DJ:
 Dancer:
-  Comment[FOR-ALL]: Rythm is a Dancer!
+  Comment[FOR-ALL]: Rhythm is a Dancer!
 Guard:
 """
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -115,6 +115,7 @@ class CanToolsPlotTest(unittest.TestCase):
     DBC_FILE_CHOICES = os.path.join(os.path.split(__file__)[0], 'files/dbc/choices.dbc')
     REO_TIMESTAMP = re.compile('\(([^)]+)\)')
     FORMAT_ABSOLUTE_TIMESTAMP = "%Y-%m-%d %H:%M:%S.%f"
+    FORMAT_START_TIME = "%d.%m.%Y"
 
     COLOR_INVALID_SYNTAX = '#ff0000'
     COLOR_UNKNOWN_FRAMES = '#ffab00'
@@ -160,7 +161,7 @@ class CanToolsPlotTest(unittest.TestCase):
             mock.call.subplot().plot(xs, ys_whlspeed_fr, '', label='BREMSE_33.whlspeed_FR'),
             mock.call.subplot().plot(xs, ys_whlspeed_rl, '', label='BREMSE_33.whlspeed_RL'),
             mock.call.subplot().plot(xs, ys_whlspeed_rr, '', label='BREMSE_33.whlspeed_RR'),
-            mock.call.subplot().set_xlabel(self.XLABEL_tA % "27.12.2020"),
+            mock.call.subplot().set_xlabel(self.XLABEL_tA % self.parse_start_time(xs[0])),
             mock.call.show(),
         ]
 
@@ -198,7 +199,7 @@ class CanToolsPlotTest(unittest.TestCase):
             mock.call.subplot().plot(xs, ys_fr, '', label='BREMSE_33.whlspeed_FR'),
             mock.call.subplot().plot(xs, ys_rl, '', label='BREMSE_33.whlspeed_RL'),
             mock.call.subplot().plot(xs, ys_rr, '', label='BREMSE_33.whlspeed_RR'),
-            mock.call.subplot().set_xlabel(self.XLABEL_ta % "24.12.2020"),
+            mock.call.subplot().set_xlabel(self.XLABEL_ta % self.parse_start_time(xs[0])),
             mock.call.show(),
         ]
 
@@ -314,7 +315,7 @@ class CanToolsPlotTest(unittest.TestCase):
             mock.call.subplot().plot(xs, ys_whlspeed_fr, '', label='BREMSE_33.whlspeed_FR'),
             mock.call.subplot().plot(xs, ys_whlspeed_rl, '', label='BREMSE_33.whlspeed_RL'),
             mock.call.subplot().plot(xs, ys_whlspeed_rr, '', label='BREMSE_33.whlspeed_RR'),
-            mock.call.subplot().set_xlabel(self.XLABEL_l % "31.12.2020"),
+            mock.call.subplot().set_xlabel(self.XLABEL_l % self.parse_start_time(xs[0])),
             mock.call.show(),
         ]
 
@@ -396,7 +397,7 @@ BREMSE_33(
             mock.call.subplot().plot(xs, ys_whlspeed_fr, '', label='BREMSE_33.whlspeed_FR'),
             mock.call.subplot().plot(xs, ys_whlspeed_rl, '', label='BREMSE_33.whlspeed_RL'),
             mock.call.subplot().plot(xs, ys_whlspeed_rr, '', label='BREMSE_33.whlspeed_RR'),
-            mock.call.subplot().set_xlabel(self.XLABEL_tA % "02.01.2021"),
+            mock.call.subplot().set_xlabel(self.XLABEL_tA % self.parse_start_time(xs[0])),
             mock.call.show(),
         ]
 
@@ -445,7 +446,7 @@ BREMSE_33(
             [
                 mock.call.plot(xs2, whlspeed_fl_bremse2, '', label='BREMSE_2.whlspeed_FL_Bremse2'),
                 mock.call.plot(xs33, whlspeed_fl, '', label='BREMSE_33.whlspeed_FL'),
-                mock.call.set_xlabel(self.XLABEL_tA % "28.12.2020"),
+                mock.call.set_xlabel(self.XLABEL_tA % self.parse_start_time(xs2[0])),
             ],
         ]
 
@@ -497,14 +498,14 @@ BREMSE_33(
                 mock.call.plot(xs33, whlspeed_fr, '', label='BREMSE_33.whlspeed_FR'),
                 mock.call.plot(xs33, whlspeed_rl, '', label='BREMSE_33.whlspeed_RL'),
                 mock.call.plot(xs33, whlspeed_rr, '', label='BREMSE_33.whlspeed_RR'),
-                mock.call.set_xlabel(self.XLABEL_tA % "28.12.2020"),
+                mock.call.set_xlabel(self.XLABEL_tA % self.parse_start_time(xs33[0])),
             ],
             [
                 mock.call.plot(xs2, whlspeed_fl_bremse2, '', label='BREMSE_2.whlspeed_FL_Bremse2'),
                 mock.call.plot(xs2, whlspeed_fr_bremse2, '', label='BREMSE_2.whlspeed_FR_Bremse2'),
                 mock.call.plot(xs2, whlspeed_rl_bremse2, '', label='BREMSE_2.whlspeed_RL_Bremse2'),
                 mock.call.plot(xs2, whlspeed_rr_bremse2, '', label='BREMSE_2.whlspeed_RR_Bremse2'),
-                mock.call.set_xlabel(self.XLABEL_tA % "28.12.2020"),
+                mock.call.set_xlabel(self.XLABEL_tA % self.parse_start_time(xs2[0])),
             ],
         ]
 
@@ -548,12 +549,12 @@ BREMSE_33(
             [
                 mock.call.plot(xs33, whlspeed_fl, 'b', label='BREMSE_33.whlspeed_FL'),
                 mock.call.set(ylabel='*_33.*fl*'),
-                mock.call.set_xlabel(self.XLABEL_tA % "30.01.2021"),
+                mock.call.set_xlabel(self.XLABEL_tA % self.parse_start_time(xs33[0])),
                 mock.call.twinx(),
             ], [
                 mock.call.plot(xs2, whlspeed_fl_bremse2, 'r', label='BREMSE_2.whlspeed_FL_Bremse2'),
                 mock.call.set(ylabel='*_2.*fl*'),
-                mock.call.set_xlabel(self.XLABEL_tA % "30.01.2021"),
+                mock.call.set_xlabel(self.XLABEL_tA % self.parse_start_time(xs2[0])),
                 mock.call.legend([None, None], ['BREMSE_33.whlspeed_FL', 'BREMSE_2.whlspeed_FL_Bremse2']),
             ],
         ]
@@ -599,7 +600,7 @@ BREMSE_33(
                 mock.call.plot(xs33, whlspeed_fl, '', label='BREMSE_33.whlspeed_FL'),
                 mock.call.plot()._getitem_0.set_color('C0'),
                 mock.call.set(ylabel='Bremse 33'),
-                mock.call.set_xlabel(self.XLABEL_tA % "30.01.2021"),
+                mock.call.set_xlabel(self.XLABEL_tA % self.parse_start_time(xs33[0])),
                 mock.call.yaxis.label.set_color('C0'),
                 mock.call.tick_params(axis='y', which='both', colors='C0'),
                 mock.call.twinx(),
@@ -607,7 +608,7 @@ BREMSE_33(
                 mock.call.plot(xs2, whlspeed_fl_bremse2, '', label='BREMSE_2.whlspeed_FL_Bremse2'),
                 mock.call.plot()._getitem_0.set_color('C1'),
                 mock.call.set(ylabel='Bremse 2'),
-                mock.call.set_xlabel(self.XLABEL_tA % "30.01.2021"),
+                mock.call.set_xlabel(self.XLABEL_tA % self.parse_start_time(xs2[0])),
                 mock.call.yaxis.label.set_color('C1'),
                 mock.call.tick_params(axis='y', which='both', colors='C1'),
             ],
@@ -669,7 +670,7 @@ BREMSE_33(
                 mock.call.plot(xs33, whlspeed_rr, '4', label='BREMSE_33.whlspeed_RR'),
                 mock.call.plot()._getitem_0.set_color('C0'),
                 mock.call.set(ylabel='Bremse 33'),
-                mock.call.set_xlabel(self.XLABEL_tA % "04.01.2021"),
+                mock.call.set_xlabel(self.XLABEL_tA % self.parse_start_time(xs33[0])),
                 mock.call.yaxis.label.set_color('C0'),
                 mock.call.tick_params(axis='y', which='both', colors='C0'),
                 mock.call.twinx(),
@@ -683,7 +684,7 @@ BREMSE_33(
                 mock.call.plot(xs2, whlspeed_rr_bremse2, '4', label='BREMSE_2.whlspeed_RR_Bremse2'),
                 mock.call.plot()._getitem_0.set_color('C1'),
                 mock.call.set(ylabel='Bremse 2'),
-                mock.call.set_xlabel(self.XLABEL_tA % "04.01.2021"),
+                mock.call.set_xlabel(self.XLABEL_tA % self.parse_start_time(xs2[0])),
                 mock.call.yaxis.label.set_color('C1'),
                 mock.call.tick_params(axis='y', which='both', colors='C1'),
             ],
@@ -793,7 +794,7 @@ BREMSE_33(
         expected_subplot_calls = [
             [
                 mock.call.stem(xs, ys, '', label='Foo.Foo'),
-                mock.call.set_xlabel(self.XLABEL_tA % "29.12.2020"),
+                mock.call.set_xlabel(self.XLABEL_tA % self.parse_start_time(xs[0])),
             ],
         ]
 
@@ -836,7 +837,7 @@ BREMSE_33(
         expected_subplot_calls = [
             [
                 mock.call.stem(xs, ys, '', label='Foo.Foo'),
-                mock.call.set_xlabel(self.XLABEL_tA % "29.12.2020"),
+                mock.call.set_xlabel(self.XLABEL_tA % self.parse_start_time(xs[0])),
             ],
         ]
 
@@ -1475,7 +1476,7 @@ Failed to parse line: 'invalid syntax'
             mock.call.subplot().plot(xs, ys_whlspeed_fr, '', label='BREMSE_33.whlspeed_FR'),
             mock.call.subplot().plot(xs, ys_whlspeed_rl, '', label='BREMSE_33.whlspeed_RL'),
             mock.call.subplot().plot(xs, ys_whlspeed_rr, '', label='BREMSE_33.whlspeed_RR'),
-            mock.call.subplot().set_xlabel(self.XLABEL_tA % "27.12.2020"),
+            mock.call.subplot().set_xlabel(self.XLABEL_tA % self.parse_start_time(xs[0])),
             mock.call.savefig(fn),
         ]
 
@@ -1515,7 +1516,7 @@ Failed to parse line: 'invalid syntax'
             mock.call.subplot(1,1,1, sharex=None),
             mock.call.subplot().plot(xs, ys_whlspeed_fl, '', label='BREMSE_33.whlspeed_FL'),
             mock.call.subplot().set(ylabel='*FL'),
-            mock.call.subplot().set_xlabel(self.XLABEL_tA % "27.12.2020"),
+            mock.call.subplot().set_xlabel(self.XLABEL_tA % self.parse_start_time(xs[0])),
             mock.call.show(),
         ]
 
@@ -1632,7 +1633,7 @@ Failed to parse line: 'invalid syntax'
             mock.call.subplot(1,1,1, sharex=None),
             mock.call.subplot().plot(xs, ys_whlspeed_fl, '', label='BREMSE_33.whlspeed_FL'),
             mock.call.subplot().set(ylabel='*FL'),
-            mock.call.subplot().set_xlabel(self.XLABEL_tA % "06.02.2021"),
+            mock.call.subplot().set_xlabel(self.XLABEL_tA % self.parse_start_time(xs[0])),
             mock.call.show(),
         ]
 
@@ -1709,7 +1710,7 @@ Failed to parse line: 'invalid syntax'
             mock.call.subplot(1,1,1, sharex=None),
             mock.call.subplot().plot(xs, ys_whlspeed_fl, '', label='BREMSE_33.whlspeed_FL'),
             mock.call.subplot().set(title='Test', ylabel='*fl'),
-            mock.call.subplot().set_xlabel(self.XLABEL_tA % "27.12.2020"),
+            mock.call.subplot().set_xlabel(self.XLABEL_tA % self.parse_start_time(xs[0])),
             mock.call.show(),
         ]
 
@@ -1797,7 +1798,7 @@ Failed to parse line: 'invalid syntax'
             mock.call.subplot().plot(xs, ys_whlspeed_fr, '', label='BREMSE_33.whlspeed_FR'),
             mock.call.subplot().plot(xs, ys_whlspeed_rl, '', label='BREMSE_33.whlspeed_RL'),
             mock.call.subplot().plot(xs, ys_whlspeed_rr, '', label='BREMSE_33.whlspeed_RR'),
-            mock.call.subplot().set_xlabel(self.XLABEL_ta % "09.01.2021"),
+            mock.call.subplot().set_xlabel(self.XLABEL_ta % self.parse_start_time(xs[0])),
             mock.call.subplot().axes.set_ylim(0.0, None),
             mock.call.show(),
         ]
@@ -1835,7 +1836,7 @@ Failed to parse line: 'invalid syntax'
             mock.call.subplot().plot(xs, ys_whlspeed_fr, '', label='BREMSE_33.whlspeed_FR'),
             mock.call.subplot().plot(xs, ys_whlspeed_rl, '', label='BREMSE_33.whlspeed_RL'),
             mock.call.subplot().plot(xs, ys_whlspeed_rr, '', label='BREMSE_33.whlspeed_RR'),
-            mock.call.subplot().set_xlabel(self.XLABEL_ta % "09.01.2021"),
+            mock.call.subplot().set_xlabel(self.XLABEL_ta % self.parse_start_time(xs[0])),
             mock.call.subplot().axes.set_ylim(20.0, 40.0),
             mock.call.show(),
         ]
@@ -1913,7 +1914,7 @@ Failed to parse line: 'invalid syntax'
             mock.call.subplot(1,1,1, sharex=None),
             mock.call.subplot().plot(xs, ys_whlspeed_fl, '', label='BREMSE_33.whlspeed_FL'),
             mock.call.subplot().set(title='Test', ylabel='*fl'),
-            mock.call.subplot().set_xlabel(self.XLABEL_tA % "27.12.2020"),
+            mock.call.subplot().set_xlabel(self.XLABEL_tA % self.parse_start_time(xs[0])),
             mock.call.show(),
         ]
 
@@ -2001,7 +2002,7 @@ Failed to parse line: 'invalid syntax'
             mock.call.subplot().plot(xs, ys_whlspeed_fr, '', label='BREMSE_33.whlspeed_FR'),
             mock.call.subplot().plot(xs, ys_whlspeed_rl, '', label='BREMSE_33.whlspeed_RL'),
             mock.call.subplot().plot(xs, ys_whlspeed_rr, '', label='BREMSE_33.whlspeed_RR'),
-            mock.call.subplot().set_xlabel(self.XLABEL_ta % "09.01.2021"),
+            mock.call.subplot().set_xlabel(self.XLABEL_ta % self.parse_start_time(xs[0])),
             mock.call.subplot().axes.set_ylim(0.0, None),
             mock.call.show(),
         ]
@@ -2039,7 +2040,7 @@ Failed to parse line: 'invalid syntax'
             mock.call.subplot().plot(xs, ys_whlspeed_fr, '', label='BREMSE_33.whlspeed_FR'),
             mock.call.subplot().plot(xs, ys_whlspeed_rl, '', label='BREMSE_33.whlspeed_RL'),
             mock.call.subplot().plot(xs, ys_whlspeed_rr, '', label='BREMSE_33.whlspeed_RR'),
-            mock.call.subplot().set_xlabel(self.XLABEL_ta % "09.01.2021"),
+            mock.call.subplot().set_xlabel(self.XLABEL_ta % self.parse_start_time(xs[0])),
             mock.call.subplot().axes.set_ylim(20.0, 40.0),
             mock.call.show(),
         ]
@@ -2206,6 +2207,9 @@ Failed to parse line: 'invalid syntax'
 
     def parse_seconds(self, timestamp):
         return float(timestamp)
+
+    def parse_start_time(self, date_time):
+        return date_time.strftime(self.FORMAT_START_TIME)
 
     ELLIPSIS = "..."
     LEN_ELLIPSIS = len(ELLIPSIS)


### PR DESCRIPTION
I fixed test to pass it in master branch in large time difference zones and fix misspelling.

1.
Master branch doesn't pass make test in Japan or other large time difference zones from GMT.
This is caused by hard coding dates in test_plot.py. 
2.
There are some misspellings and codespelling outputs error.