### PR TITLE
fix exception when arxml contains FRESSNESS-VALUE-LENGTH with zero.

### DIFF
--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -1103,7 +1103,7 @@ class SystemLoader(object):
 
         # add "pseudo signals" for the truncated freshness value and
         # the truncated authenticator
-        if fresh_tx_len is not None:
+        if fresh_tx_len is not None and fresh_tx_len > 0:
             signals.append(Signal(name=f'{message_name}_Freshness',
                                   start=payload_length*8 + 7,
                                   length=fresh_tx_len,
@@ -1112,7 +1112,7 @@ class SystemLoader(object):
                                   {'FOR-ALL':
                                    f'Truncated freshness value for '
                                    f"'{message_name}'"}))
-        if auth_tx_len is not None:
+        if auth_tx_len is not None and auth_tx_len > 0:
             n0 = payload_length*8 + (fresh_tx_len//8)*8 + (7-fresh_tx_len%8)
             signals.append(Signal(name=f'{message_name}_Authenticator',
                                   start=n0,


### PR DESCRIPTION
Some ARXML files (which was provided by our clients) contain FRESSNESS-VALUE-LENGTH with a value of zero.  Currently cantools cannot load such arxml files:

```
  File "/usr/local/lib/python3.6/site-packages/cantools-37.1.0-py3.6.egg/cantools/database/can/formats/arxml.py", line 1047, in _load_message
    sort_signals=self._sort_signals)
  File "/usr/local/lib/python3.6/site-packages/cantools-37.1.0-py3.6.egg/cantools/database/can/message.py", line 142, in __init__
    self.refresh()
  File "/usr/local/lib/python3.6/site-packages/cantools-37.1.0-py3.6.egg/cantools/database/can/message.py", line 1272, in refresh
    self._check_signal_lengths()
  File "/usr/local/lib/python3.6/site-packages/cantools-37.1.0-py3.6.egg/cantools/database/can/message.py", line 1260, in _check_signal_lengths
    self.name))
cantools.database.errors.Error: The signal ***_Freshness length 0 is not greater than 0 in message ***.

```

This fixed the exception.