### PR TITLE
Handle Multiple Section Headers in SYM File

### DIFF
--- a/cantools/database/can/formats/sym.py
+++ b/cantools/database/can/formats/sym.py
@@ -259,11 +259,12 @@ class Parser60(textparser.Parser):
 
 
 def _get_section_tokens(tokens, name):
+    rows = []
     for section in tokens[3]:
         if section[0] == name:
-            return [row for row in section[1] if isinstance(row, list)]
+            rows.extend([row for row in section[1] if isinstance(row, list)])
 
-    return []
+    return rows
 
 
 def _load_comment(tokens):

--- a/tests/files/sym/jopp-6.0.sym
+++ b/tests/files/sym/jopp-6.0.sym
@@ -57,3 +57,10 @@ Sig=Signal2 6
 Len=8
 Mux=Multiplexer3 0,3 2
 Sig=Signal3 9
+
+{SENDRECEIVE}
+
+[Message3]
+ID=00Ah
+Len=8
+Sig=Signal3 0

--- a/tests/files/sym/jopp-6.0.sym
+++ b/tests/files/sym/jopp-6.0.sym
@@ -37,6 +37,13 @@ MinInterval=10
 Sig=Signal2 32
 Sig=Signal1 0
 
+{SENDRECEIVE}
+
+[Message3]
+ID=00Ah
+Len=8
+Sig=Signal3 0
+
 [Symbol2]
 ID=099h
 Len=8
@@ -57,10 +64,3 @@ Sig=Signal2 6
 Len=8
 Mux=Multiplexer3 0,3 2
 Sig=Signal3 9
-
-{SENDRECEIVE}
-
-[Message3]
-ID=00Ah
-Len=8
-Sig=Signal3 0

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1827,7 +1827,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_3.spn, None)
 
         # Symbol2.
-        signal_4 = db.messages[4].signals[0]
+        signal_4 = db.messages[5].signals[0]
         self.assertEqual(signal_4.name, 'Signal4')
         self.assertEqual(signal_4.start, 0)
         self.assertEqual(signal_4.length, 64)
@@ -1851,7 +1851,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_4.spn, None)
 
         # Symbol3.
-        symbol_3 = db.messages[5]
+        symbol_3 = db.messages[6]
         self.assertEqual(symbol_3.frame_id, 0x33)
         self.assertEqual(symbol_3.length, 8)
         self.assertEqual(symbol_3.is_multiplexed(), True)
@@ -1886,7 +1886,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_3.multiplexer_ids, [2])
         
         # Message3.
-        message_3 = db.messages[6]
+        message_3 = db.messages[4]
         self.assertEqual(message_3.frame_id, 0xA)
         self.assertEqual(message_3.length, 8)
         signal_3 = message_3.signals[0]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1725,7 +1725,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         if test_sym_string:
             db = cantools.db.load_string(db.as_sym_string())
 
-        self.assertEqual(len(db.messages), 6)
+        self.assertEqual(len(db.messages), 7)
         self.assertEqual(len(db.messages[0].signals), 0)
 
         # Message1.
@@ -1884,6 +1884,17 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_3.length, 11)
         self.assertEqual(signal_3.is_multiplexer, False)
         self.assertEqual(signal_3.multiplexer_ids, [2])
+        
+        # Message3.
+        message_3 = db.messages[6]
+        self.assertEqual(message_3.frame_id, 0xA)
+        self.assertEqual(message_3.length, 8)
+        signal_3 = message_3.signals[0]
+        self.assertEqual(signal_3.name, 'Signal3')
+        self.assertEqual(signal_3.start, 7)
+        self.assertEqual(signal_3.length, 11)
+        self.assertEqual(signal_3.is_multiplexer, False)
+        self.assertEqual(signal_3.multiplexer_ids, None)
 
         # Encode and decode.
         frame_id = 0x009


### PR DESCRIPTION
- When searching for SEND, RECEIVE, etc sections,
  don't stop when we find the first one. Keep iterating
  in case there are multiple

Closes #454 