### PR TITLE
Add missing Bus import in can/__init__.py

### DIFF
--- a/cantools/database/can/__init__.py
+++ b/cantools/database/can/__init__.py
@@ -4,3 +4,4 @@ from .message import EncodeError
 from .message import DecodeError
 from .signal import Signal
 from .node import Node
+from .bus import Bus


### PR DESCRIPTION
Allows users to directly create Bus objects