### PR TITLE
do no longer use the ncurses module in the dump subparser

### DIFF
--- a/cantools/subparsers/dump/__init__.py
+++ b/cantools/subparsers/dump/__init__.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 from . import formatting
 from ... import database
@@ -105,16 +106,9 @@ def _dump_can_message(message, with_comments=False, name_prefix='', WIDTH=None):
 def _dump_can_database(dbase, with_comments=False):
     WIDTH = 80
     try:
-        import curses
-    except ModuleNotFoundError:  # pragma: no cover
+        WIDTH, _ = os.get_terminal_size()
+    except:
         pass
-    else:
-        try:
-            _stdscr = curses.initscr()
-            _, WIDTH = _stdscr.getmaxyx()  # pragma: no cover
-            curses.endwin()  # pragma: no cover
-        except Exception as e:
-            pass
 
     print('================================= Messages =================================')
     print()


### PR DESCRIPTION
it seems to cause issues when trying to redirect the output of the subparser on windows. Since it is only used to determine the width of the terminal anyway, let's determine that using `os.get_terminal_size()`.

Andreas Lauser &lt;<andreas.lauser@mercedes-benz.com>&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)