### PR TITLE
Add missing crccheck dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(name='cantools',
           'diskcache',
           'argparse_addons',
           'typing_extensions>=3.10.0.0',
+          'crccheck',
       ],
       extras_require=dict(
           plot=['matplotlib'],


### PR DESCRIPTION
crccheck is actually used in the cantools package, so it should be in install_requires.

https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/