### PR TITLE
Bugfix in handling more than one node mapped attribute per signal

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -1146,7 +1146,7 @@ def _load_attributes_rel(tokens, definitions):
             if node not in attributes_rel[frame_id_dbc]['signal'][signal]['node']:
                 attributes_rel[frame_id_dbc]['signal'][signal]['node'][node] = OrderedDict()
 
-                attributes_rel[frame_id_dbc]['signal'][signal]['node'][node][name] = to_object(attribute, attribute[7])
+            attributes_rel[frame_id_dbc]['signal'][signal]['node'][node][name] = to_object(attribute, attribute[7])
 
         elif rel_type == "BU_BO_REL_":
             frame_id_dbc = int(attribute[4])

--- a/tests/files/dbc/attributes_relation.dbc
+++ b/tests/files/dbc/attributes_relation.dbc
@@ -50,15 +50,18 @@ BA_DEF_ SG_  "GenSigInactiveValue" INT 0 65535;
 BA_DEF_ BO_  "MsgProject" ENUM  "A","B","C";
 BA_DEF_  "BusType" STRING ;
 BA_DEF_ BO_  "GenMsgCycleTime" INT 0 65535;
+BA_DEF_REL_ BU_SG_REL_  "SigFirstTimeoutTime" INT 0 65535;
 BA_DEF_REL_ BU_SG_REL_  "SigTimeoutTime" INT 0 65535;
 BA_DEF_DEF_  "GenSigInactiveValue" 0;
 BA_DEF_DEF_  "MsgProject" "A";
 BA_DEF_DEF_  "BusType" "";
 BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_DEF_DEF_REL_ "SigFirstTimeoutTime" 0;
 BA_DEF_DEF_REL_ "SigTimeoutTime" 0;
 BA_ "BusType" "CAN";
 BA_ "GenMsgCycleTime" BO_ 83 50;
 BA_REL_ "SigTimeoutTime" BU_SG_REL_ ECU2 SG_ 82 signal_1 6000;
+BA_REL_ "SigFirstTimeoutTime" BU_SG_REL_ ECU2 SG_ 82 signal_1 24000;
 
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6146,7 +6146,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
             signal = frame.get("signal")
             if "signal_1" in signal.keys():
                 rel_attributes = signal["signal_1"]["node"]["ECU2"]
+                first_timeout_attr = rel_attributes["SigFirstTimeoutTime"]
                 timeout_attr = rel_attributes["SigTimeoutTime"]
+                self.assertEqual(first_timeout_attr.value, 24000)
                 self.assertEqual(timeout_attr.value, 6000)
                 break
         self.assert_dbc_dump(db, filename)


### PR DESCRIPTION
dbc: corrected indentation error that occurred in [https://github.com/cantools/cantools/pull/477](477)