### PR TITLE
Make dbc format more closely match Vector CANdb++ 3.1.18

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -487,7 +487,7 @@ def _dump_messages(database, sort_signals):
                 length=signal.length,
                 receivers=format_receivers(signal),
                 byte_order=(0 if signal.byte_order == 'big_endian' else 1),
-                sign=('-' if signal.is_signed else '+'),
+                sign=('-' if signal.is_signed or signal.is_float else '+'),
                 scale=signal.scale,
                 offset=signal.offset,
                 minimum=(0 if signal.minimum is None else signal.minimum),
@@ -554,7 +554,7 @@ def _dump_signal_types(database):
     valtype = []
 
     for message in database.messages:
-        for signal in message.signals:
+        for signal in sorted(message.signals, key=lambda x: x.start, reverse=True):
             if not signal.is_float:
                 continue
 


### PR DESCRIPTION
- Indicate a value is signed if it's a float
- Reverse sort signals (`SIG_VALTYPE_`) by start bit

Newest Vector CANdb++ tool indicates a signal is signed (`-`) if it's a floating point value and has a different sorting for signals in .dbc files.