### PR TITLE
Typing improvements

### DIFF
--- a/cantools/database/can/database.py
+++ b/cantools/database/can/database.py
@@ -16,7 +16,7 @@ from .formats import sym
 from .formats.arxml import AutosarDatabaseSpecifics
 from .formats.dbc import DbcSpecifics
 from .internal_database import InternalDatabase
-from .message import Message, EncodeInputType, DecodeResultType
+from .message import Message
 from .node import Node
 from ..errors import DecodeError
 from ..utils import (
@@ -27,7 +27,7 @@ from ..utils import (
     SORT_SIGNALS_DEFAULT
 )
 from ...compat import fopen
-from ...typechecking import StringPathLike
+from ...typechecking import StringPathLike, EncodeInputType, DecodeResultType
 
 LOGGER = logging.getLogger(__name__)
 

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -29,6 +29,7 @@ from ..errors import DecodeError
 from ...typechecking import (
     Comments,
     Codec,
+    SignalDictType,
     SignalMappingType,
     ContainerHeaderSpecType,
     ContainerDecodeResultType,
@@ -521,7 +522,7 @@ class Message(object):
     def gather_signals(self,
                        input_data: SignalMappingType,
                        node: Optional[Codec] = None) \
-      -> SignalMappingType:
+      -> SignalDictType:
 
         '''Given a superset of all signals required to encode the message,
         return a dictionary containing exactly the ones required.
@@ -954,7 +955,7 @@ class Message(object):
                 data: bytes,
                 decode_choices: bool,
                 scaling: bool,
-                allow_truncated: bool) -> SignalMappingType:
+                allow_truncated: bool) -> SignalDictType:
         decoded = decode_data(data,
                               self.length,
                               node['signals'],
@@ -1103,7 +1104,7 @@ class Message(object):
                       decode_choices: bool = True,
                       scaling: bool = True,
                       allow_truncated: bool = False) \
-                      -> SignalMappingType:
+                      -> SignalDictType:
         """Decode given data as a container message.
 
         This method is identical to ``decode()`` except that the

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -29,7 +29,7 @@ from ..errors import DecodeError
 from ...typechecking import (
     Comments,
     Codec,
-    SignalDictType,
+    SignalMappingType,
     ContainerHeaderSpecType,
     ContainerDecodeResultType,
     ContainerDecodeResultListType,
@@ -519,9 +519,9 @@ class Message(object):
         return self._signal_tree
 
     def gather_signals(self,
-                       input_data: SignalDictType,
+                       input_data: SignalMappingType,
                        node: Optional[Codec] = None) \
-      -> SignalDictType:
+      -> SignalMappingType:
 
         '''Given a superset of all signals required to encode the message,
         return a dictionary containing exactly the ones required.
@@ -567,7 +567,7 @@ class Message(object):
 
     def gather_container(self,
                          contained_messages: List[ContainerHeaderSpecType],
-                         signal_values: SignalDictType) \
+                         signal_values: SignalMappingType) \
       -> ContainerDecodeResultType:
 
         '''Given a superset of all messages required to encode all messages
@@ -610,7 +610,7 @@ class Message(object):
         return result
 
     def assert_signals_encodable(self,
-                                 input_data: SignalDictType,
+                                 input_data: SignalMappingType,
                                  scaling: bool,
                                  assert_values_valid: bool = True,
                                  assert_all_known: bool = True) \
@@ -719,7 +719,7 @@ class Message(object):
                                                            assert_values_valid,
                                                            assert_all_known)
 
-    def _get_mux_number(self, decoded: SignalDictType, signal_name: str) -> int:
+    def _get_mux_number(self, decoded: SignalMappingType, signal_name: str) -> int:
         mux = decoded[signal_name]
 
         if isinstance(mux, str) or isinstance(mux, NamedSignalValue):
@@ -731,7 +731,7 @@ class Message(object):
         return int(mux)
 
     def _assert_signal_values_valid(self,
-                                    data: SignalDictType,
+                                    data: SignalMappingType,
                                     scaling: bool) -> None:
 
         for signal_name, signal_value in data.items():
@@ -775,7 +775,7 @@ class Message(object):
                         f'equal to {max_effective} in message "{self.name}", '
                         f'but got {signal_value}.')
 
-    def _encode(self, node: Codec, data: SignalDictType, scaling: bool) -> Tuple[int, int, List[Signal]]:
+    def _encode(self, node: Codec, data: SignalMappingType, scaling: bool) -> Tuple[int, int, List[Signal]]:
         encoded = encode_data(data,
                               node['signals'],
                               node['formats'],
@@ -916,7 +916,7 @@ class Message(object):
 
         if self.is_container:
             if strict:
-                if isinstance(data, dict):
+                if not isinstance(data, (list, tuple)):
                     raise EncodeError(f'Container frames can only encode lists of '
                                       f'(message, data) tuples')
 
@@ -940,7 +940,7 @@ class Message(object):
             raise ValueError('Codec is not initialized.')
 
         encoded, padding_mask, all_signals = self._encode(self._codecs,
-                                                          cast(SignalDictType, data),
+                                                          cast(SignalMappingType, data),
                                                           scaling)
 
         if padding:
@@ -954,7 +954,7 @@ class Message(object):
                 data: bytes,
                 decode_choices: bool,
                 scaling: bool,
-                allow_truncated: bool) -> SignalDictType:
+                allow_truncated: bool) -> SignalMappingType:
         decoded = decode_data(data,
                               self.length,
                               node['signals'],
@@ -1103,7 +1103,7 @@ class Message(object):
                       decode_choices: bool = True,
                       scaling: bool = True,
                       allow_truncated: bool = False) \
-                      -> SignalDictType:
+                      -> SignalMappingType:
         """Decode given data as a container message.
 
         This method is identical to ``decode()`` except that the

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -10,6 +10,7 @@ from typing_extensions import Literal, Final
 from cantools.typechecking import (
     Formats,
     Choices,
+    SignalMappingType,
     SignalDictType,
     ByteOrder,
 )
@@ -56,7 +57,7 @@ def start_bit(data: Union["Data", "Signal"]) -> int:
 
 
 def _encode_fields(fields: Sequence[Union["Signal", "Data"]],
-                   data: SignalDictType,
+                   data: SignalMappingType,
                    scaling: bool,
                    ) -> Dict[str, Union[int, float]]:
     unpacked = {}
@@ -82,7 +83,7 @@ def _encode_fields(fields: Sequence[Union["Signal", "Data"]],
     return unpacked
 
 
-def encode_data(data: SignalDictType,
+def encode_data(data: SignalMappingType,
                 fields: Sequence[Union["Signal", "Data"]],
                 formats: Formats,
                 scaling: bool

--- a/cantools/typechecking.py
+++ b/cantools/typechecking.py
@@ -2,6 +2,7 @@ from typing import (
     TYPE_CHECKING,
     NamedTuple,
     Union,
+    Mapping,
     Dict,
     Optional,
     List,
@@ -34,7 +35,7 @@ Codec = TypedDict(
     {
         "signals": List["Signal"],
         "formats": Formats,
-        "multiplexers": Dict[str, Dict[int, Any]],  # "Any" should be "Codec" (cyclic definition is not possible though)
+        "multiplexers": Mapping[str, Mapping[int, Any]],  # "Any" should be "Codec" (cyclic definition is not possible though)
     },
 )
 
@@ -46,19 +47,20 @@ Choices = OrderedDict[int, Union[str, "NamedSignalValue"]]
 # for AUTOSAR container messages.
 SignalValueType = Union[float, str, "NamedSignalValue"]
 SignalDictType = Dict[str, SignalValueType]
+SignalMappingType = Mapping[str, SignalValueType]
 ContainerHeaderSpecType = Union["Message", str, int]
 ContainerUnpackResultType = Sequence[Union[Tuple["Message", bytes], Tuple[int, bytes]]]
 ContainerUnpackListType = List[Union[Tuple["Message", bytes], Tuple[int, bytes]]]
 ContainerDecodeResultType = Sequence[
-    Union[Tuple["Message", SignalDictType], Tuple[int, bytes]]
+    Union[Tuple["Message", SignalMappingType], Tuple[int, bytes]]
 ]
 ContainerDecodeResultListType = List[
-    Union[Tuple["Message", SignalDictType], Tuple[int, bytes]]
+    Union[Tuple["Message", SignalMappingType], Tuple[int, bytes]]
 ]
 ContainerEncodeInputType = Sequence[
-    Tuple[ContainerHeaderSpecType, Union[bytes, SignalDictType]]
+    Tuple[ContainerHeaderSpecType, Union[bytes, SignalMappingType]]
 ]
-DecodeResultType = Union[SignalDictType, ContainerDecodeResultType]
-EncodeInputType = Union[SignalDictType, ContainerEncodeInputType]
+DecodeResultType = Union[SignalMappingType, ContainerDecodeResultType]
+EncodeInputType = Union[SignalMappingType, ContainerEncodeInputType]
 
 SecOCAuthenticatorFn = Callable[["Message", bytearray, int], bytearray]

--- a/cantools/typechecking.py
+++ b/cantools/typechecking.py
@@ -55,12 +55,12 @@ ContainerDecodeResultType = Sequence[
     Union[Tuple["Message", SignalMappingType], Tuple[int, bytes]]
 ]
 ContainerDecodeResultListType = List[
-    Union[Tuple["Message", SignalMappingType], Tuple[int, bytes]]
+    Union[Tuple["Message", SignalDictType], Tuple[int, bytes]]
 ]
 ContainerEncodeInputType = Sequence[
     Tuple[ContainerHeaderSpecType, Union[bytes, SignalMappingType]]
 ]
-DecodeResultType = Union[SignalMappingType, ContainerDecodeResultType]
+DecodeResultType = Union[SignalDictType, ContainerDecodeResultType]
 EncodeInputType = Union[SignalMappingType, ContainerEncodeInputType]
 
 SecOCAuthenticatorFn = Callable[["Message", bytearray, int], bytearray]


### PR DESCRIPTION
- Use `Mapping` instead of `Dict` where possible, see the commit message of commit 7f853c660768d6142a4c027acdeb567e827d42d0
- Return type of `Database.decode_message` is not considered to be `Any` with `mypy --strict`, see the commit message of commit 72e1642b590513001f235e20b5378d4fd29b806d