### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -41,22 +41,34 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
-    if: ! ${{ matrix.skip_job }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, macos-latest, windows-latest]
-        # we cannot simply define a matrix with python versions 3.6
-        # and 3.10 directly because python 3.6 is not available on
-        # ubuntu-latest anymore. The workaround is to make the job
-        # conditional on the "skip-job" variable specified via matrix
-        # includes and only set it to true for illegal combinations
-        python-version: ["3.6", "3.10"]
         include:
-          - skip-job: false
 
-          - os: ubuntu-latest
-            python-version: 3.6
-            skip-job: true
+          # we cannot simply define a matrix for [ubuntu-latest,
+          # macos-latest, windows-latest] times [python-3.6 ,
+          # python-3.10] directly because python 3.6 is not available on
+          # ubuntu-latest anymore. The workaround is to make a long 1D
+          # matrix and set the matrix variables manually via
+          # includes. This is pretty clunky, but job-conditionals are
+          # not allowed to depend on matrix variables and other
+          # solutions like preparing the matrix using a separate job
+          # seem to be even more cumbersome...
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
+          - os: "ubuntu-latest"
+            python-version: "3.8"
+          - os: "ubuntu-latest"
+            python-version: "3.10"
+          - os: "windows-latest"
+            python-version: "3.6"
+          - os: windows-latest
+            python-version: "3.10"
+          - os: "macos-latest"
+            python-version: "3.6"
+          - os: "macos-latest"
+            python-version: "3.10"
+
       fail-fast: false
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   codegen:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6", "3.10"]
@@ -41,10 +41,22 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
+    if: ! ${{ matrix.skip_job }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-20.04, macos-latest, windows-latest]
+        # we cannot simply define a matrix with python versions 3.6
+        # and 3.10 directly because python 3.6 is not available on
+        # ubuntu-latest anymore. The workaround is to make the job
+        # conditional on the "skip-job" variable specified via matrix
+        # includes and only set it to true for illegal combinations
         python-version: ["3.6", "3.10"]
+        include:
+          - skip-job: false
+
+          - os: ubuntu-latest
+            python-version: 3.6
+            skip-job: true
       fail-fast: false
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,10 +7,10 @@ env:
 
 jobs:
   codegen:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.10"]
+        python-version: ["3.8", "3.10"]
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -43,32 +43,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-
-          # we cannot simply define a matrix for [ubuntu-latest,
-          # macos-latest, windows-latest] times [python-3.6 ,
-          # python-3.10] directly because python 3.6 is not available on
-          # ubuntu-latest anymore. The workaround is to make a long 1D
-          # matrix and set the matrix variables manually via
-          # includes. This is pretty clunky, but job-conditionals are
-          # not allowed to depend on matrix variables and other
-          # solutions like preparing the matrix using a separate job
-          # seem to be even more cumbersome...
-          - os: "ubuntu-20.04"
-            python-version: "3.6"
-          - os: "ubuntu-latest"
-            python-version: "3.8"
-          - os: "ubuntu-latest"
-            python-version: "3.10"
-          - os: "windows-latest"
-            python-version: "3.6"
-          - os: windows-latest
-            python-version: "3.10"
-          - os: "macos-latest"
-            python-version: "3.6"
-          - os: "macos-latest"
-            python-version: "3.10"
-
+        os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
+        python-version: ["3.8", "3.10"]
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -80,6 +56,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
+    - name: Install optional windows dependencies
+      run: |
+        python -m pip install -e ".[windows-all]"
     - name: Test
       run: |
         tox -e gh

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 
 from setuptools import setup
 from setuptools import find_packages
-import sys
 import re
 
 
@@ -11,24 +10,6 @@ def find_version():
                      open('cantools/version.py', 'r').read(),
                      re.MULTILINE).group(1)
 
-
-def dependencies():
-    deps = [
-        'bitstruct>=8.15.1',
-        'python-can>=3.3.4',
-        'textparser>=0.21.1',
-        'diskcache',
-        'argparse_addons',
-        'typing_extensions>=3.10.0.0',
-        'crccheck',
-    ]
-
-    if sys.platform == 'win32':
-        deps += [
-            'windows-curses'
-        ]
-
-    return deps
 
 setup(name='cantools',
       version=find_version(),
@@ -45,11 +26,20 @@ setup(name='cantools',
       url='https://github.com/eerimoq/cantools',
       packages=find_packages(exclude=['tests']),
       package_data={"cantools": ["py.typed"]},
-      python_requires='>=3.6',
-      install_requires=dependencies(),
-      extras_require=dict(
-          plot=['matplotlib'],
-      ),
+      python_requires='>=3.8',
+      install_requires=[
+          'bitstruct>=8.15.1',
+          'python-can>=3.3.4',
+          'textparser>=0.21.1',
+          'diskcache',
+          'argparse_addons',
+          'typing_extensions>=3.10.0.0',
+          'crccheck',
+      ],
+      extras_require={
+          'plot': ['matplotlib'],
+          'windows-all': ["windows-curses;platform_system=='Windows'"],
+      },
       test_suite="tests",
       entry_points={
           'console_scripts': ['cantools=cantools.__init__:_main']

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 from setuptools import setup
 from setuptools import find_packages
+import sys
 import re
 
 
@@ -10,6 +11,24 @@ def find_version():
                      open('cantools/version.py', 'r').read(),
                      re.MULTILINE).group(1)
 
+
+def dependencies():
+    deps = [
+        'bitstruct>=8.15.1',
+        'python-can>=3.3.4',
+        'textparser>=0.21.1',
+        'diskcache',
+        'argparse_addons',
+        'typing_extensions>=3.10.0.0',
+        'crccheck',
+    ]
+
+    if sys.platform == 'win32':
+        deps += [
+            'windows-curses'
+        ]
+
+    return deps
 
 setup(name='cantools',
       version=find_version(),
@@ -27,15 +46,7 @@ setup(name='cantools',
       packages=find_packages(exclude=['tests']),
       package_data={"cantools": ["py.typed"]},
       python_requires='>=3.6',
-      install_requires=[
-          'bitstruct>=8.15.1',
-          'python-can>=3.3.4',
-          'textparser>=0.21.1',
-          'diskcache',
-          'argparse_addons',
-          'typing_extensions>=3.10.0.0',
-          'crccheck',
-      ],
+      install_requires=dependencies(),
       extras_require=dict(
           plot=['matplotlib'],
       ),

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,6 +1,14 @@
 import unittest
-import curses
 import traceback
+
+try:
+    import curses
+    have_curses = True
+except (ImportError, ModuleNotFoundError) as e:
+    # on windows, the batteries for the curses package are not
+    # included by default (there is a "windows-curses" package
+    # available, though)
+    have_curses = False
 
 try:
     from unittest.mock import Mock
@@ -12,7 +20,8 @@ except ImportError:
     from mock import call
 
 import can
-from cantools.subparsers.monitor import Monitor
+if have_curses:
+    from cantools.subparsers.monitor import Monitor
 
 
 class Args(object):
@@ -51,7 +60,8 @@ class StdScr(object):
         self.getkey = Mock(side_effect=user_input)
         self.move = Mock()
 
-
+@unittest.skipIf(not have_curses,
+                 "The curses module is not available on your system")
 class CanToolsMonitorTest(unittest.TestCase):
 
     maxDiff = None


### PR DESCRIPTION
this PR tries to fix the github actions which recently started failing:

- The first issue is that on windows, cantools depends on the `windows-curses` package which was an implicit dependency of previous versions `python-can`. (Note that I'm not sure if the fix is correct: we check if we are running on windows in `setup.py` and if we are, add `windows-curses` to the requirements. This approach will fail if dependencies get "hard baked" into PyPi packages and one tries to install a package prepared on a non-Windows system on Windows or vice-versa.)
- the second issue is that python-3.6 does not seem to be available on the latest ubuntu plattform anymore. This is fixed by disabling the python 3.6 tests on ubuntu-latest (to compensate, we now also test on ubuntu 20.04)

I guess it is time to think about dropping support for python 3.6. do you have a stance here @juleq?

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)