### PR TITLE
fix: use __repr__() when adding values to plot

### DIFF
--- a/cantools/subparsers/plot.py
+++ b/cantools/subparsers/plot.py
@@ -62,6 +62,7 @@ except ImportError:
     plt = None
 
 from .. import database
+from ..database.can.signal import NamedSignalValue
 from .. import errors
 
 
@@ -441,6 +442,8 @@ class Plotter:
         for signal in decoded_signals:
             x = timestamp
             y = decoded_signals[signal]
+            if isinstance(y, NamedSignalValue):
+                y = str(y)
             signal = message.name + '.' + signal
             self.signals.add_value(signal, x, y)
 


### PR DESCRIPTION
When trying to plot a NamedSignalValue, the following error occurs.
```
error: float() argument must be a string or a real number, not 'NamedSignalValue'
```

Use `__repr__()` when plotting to allow all signal types to be plotted.