### PR TITLE
Relaxed an PDU assert for ARXML format.

### DIFF
--- a/cantools/database/can/formats/arxml/system_loader.py
+++ b/cantools/database/can/formats/arxml/system_loader.py
@@ -758,7 +758,24 @@ class SystemLoader(object):
         # things like multiplexed and container messages, this is not
         # the case...
         pdu = self._get_pdu(can_frame)
-        assert pdu is not None
+        if pdu is None:
+            return Message(bus_name=bus_name,
+                           frame_id=frame_id,
+                           is_extended_frame=is_extended_frame,
+                           is_fd=is_fd,
+                           name=name,
+                           length=length,
+                           senders=[],
+                           send_type=None,
+                           cycle_time=None,
+                           signals=[],
+                           contained_messages=None,
+                           unused_bit_pattern=0xff,
+                           comment=None,
+                           autosar_specifics=autosar_specifics,
+                           strict=self._strict,
+                           sort_signals=self._sort_signals)
+
         pdu_path = self._get_pdu_path(can_frame)
         autosar_specifics._pdu_paths.append(pdu_path)
 

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -220,6 +220,12 @@
                       <CAN-ADDRESSING-MODE>STANDARD</CAN-ADDRESSING-MODE>
                       <IDENTIFIER>1001</IDENTIFIER>
                     </CAN-FRAME-TRIGGERING>
+                    <CAN-FRAME-TRIGGERING>
+                      <SHORT-NAME>MessageWithoutPDU</SHORT-NAME>
+                      <FRAME-REF DEST="CAN-FRAME">/CanFrame/MessageWithoutPDU</FRAME-REF>
+                      <CAN-ADDRESSING-MODE>STANDARD</CAN-ADDRESSING-MODE>
+                      <IDENTIFIER>1002</IDENTIFIER>
+                    </CAN-FRAME-TRIGGERING>
                   </FRAME-TRIGGERINGS>
                   <PDU-TRIGGERINGS>
                     <!-- /Cluster/Cluster0/Pch0/message1_triggering -->
@@ -349,6 +355,11 @@
               <PDU-REF DEST="NM-PDU">/NMPdu/alarm_status</PDU-REF>
             </PDU-TO-FRAME-MAPPING>
           </PDU-TO-FRAME-MAPPINGS>
+        </CAN-FRAME>
+        <!-- /CanFrame/MessageWithoutPDU -->
+        <CAN-FRAME>
+          <SHORT-NAME>MessageWithoutPDU</SHORT-NAME>
+          <FRAME-LENGTH>8</FRAME-LENGTH>
         </CAN-FRAME>
       </ELEMENTS>
     </AR-PACKAGE>

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4817,7 +4817,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(bus.fd_baudrate, 2000000)
 
         self.assertEqual(len(db.nodes), 3)
-        self.assertEqual(len(db.messages), 7)
+        self.assertEqual(len(db.messages), 8)
         self.assertTrue(db.autosar is not None)
         self.assertTrue(db.dbc is None)
         self.assertEqual(db.autosar.arxml_version, "4.0.0")
@@ -5375,6 +5375,20 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(nm_message.bus_name, 'Cluster0')
         self.assertTrue(nm_message.dbc is None)
         self.assertTrue(nm_message.autosar is not None)
+
+        msg_without_pdu = db.messages[7]
+        self.assertEqual(msg_without_pdu.frame_id, 1002)
+        self.assertEqual(msg_without_pdu.is_extended_frame, False)
+        self.assertEqual(msg_without_pdu.name, 'MessageWithoutPDU')
+        self.assertEqual(msg_without_pdu.length, 8)
+        self.assertEqual(msg_without_pdu.senders, [])
+        self.assertEqual(msg_without_pdu.send_type, None)
+        self.assertEqual(msg_without_pdu.cycle_time, None)
+        self.assertEqual(len(msg_without_pdu.signals), 0)
+        self.assertEqual(msg_without_pdu.comment, None)
+        self.assertEqual(msg_without_pdu.bus_name, 'Cluster0')
+        self.assertTrue(msg_without_pdu.dbc is None)
+        self.assertTrue(msg_without_pdu.autosar is not None)
 
     def test_system_arxml_traversal(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -300,6 +300,7 @@ AlarmStatus
 Message1
 Message3
 Message4
+MessageWithoutPDU
 MultiplexedMessage
 OneToContainThemAll
 """


### PR DESCRIPTION
Instead of breaking the parser if PDU is none, just return an empty message. The same result occurs if a PDU does not contain any signals.