### PR TITLE
Decode Formula updated

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "ros.distro": "melodic"
+}

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -145,7 +145,7 @@ def decode_data(data: bytes,
                     pass
 
             if scaling:
-                decoded[field.name] = field.scale * value + field.offset
+                decoded[field.name] = (value + field.offset) * field.scale 
                 continue
             else:
                 decoded[field.name] = value


### PR DESCRIPTION
If both attributes are present, the data are scaled before the offset is added. When scaled data are written, the application should first subtract the offset and then divide by the scale factor.
For example, if x is to be sent and the field has an offset of 400 and scaling factor of 10, the final data becomes:
y = [(Scaling factor) * (x)] + offset

Now when this message is decoded, the scaling factor being 0.1 and offset being -400,
x = (y + offset) / scaling factor

Below is the link for the standard convention:
https://www.eyascopublic.com/mehelp/index.html#!Documents/scalefactorandoffset.htm

https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch08.html#:~:text=8.1.,-Packed%20Data&text=If%20both%20attributes%20are%20present,divide%20by%20the%20scale%20factor.