### PR TITLE
Run ruff linter in CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install mypy
+        pip install mypy ruff
         pip install -e .[plot]
     - name: Static type checking with mypy
       run: |
@@ -97,6 +97,9 @@ jobs:
         mypy --python-version 3.9 .
         mypy --python-version 3.10 .
         mypy --python-version 3.11 .
+    - name: Run linters
+      run: |
+        ruff check ./cantools
 
   docs:
     runs-on: ubuntu-latest

--- a/cantools/compat.py
+++ b/cantools/compat.py
@@ -1,4 +1,4 @@
-class fopen(object):
+class fopen:
 
     def __init__(self, filename, mode, encoding, newline=None):
         self._filename = filename

--- a/cantools/database/__init__.py
+++ b/cantools/database/__init__.py
@@ -29,23 +29,23 @@ class UnsupportedDatabaseFormatError(Error):
         message = []
 
         if e_arxml is not None:
-            message.append('ARXML: "{}"'.format(e_arxml))
+            message.append(f'ARXML: "{e_arxml}"')
 
         if e_dbc is not None:
-            message.append('DBC: "{}"'.format(e_dbc))
+            message.append(f'DBC: "{e_dbc}"')
 
         if e_kcd is not None:
-            message.append('KCD: "{}"'.format(e_kcd))
+            message.append(f'KCD: "{e_kcd}"')
 
         if e_sym is not None:
-            message.append('SYM: "{}"'.format(e_sym))
+            message.append(f'SYM: "{e_sym}"')
 
         if e_cdd is not None:
-            message.append('CDD: "{}"'.format(e_cdd))
+            message.append(f'CDD: "{e_cdd}"')
 
         message = ', '.join(message)
 
-        super(UnsupportedDatabaseFormatError, self).__init__(message)
+        super().__init__(message)
 
         self.e_arxml = e_arxml
         self.e_dbc = e_dbc
@@ -252,7 +252,7 @@ def dump_file(database,
         output = database.as_sym_string(sort_signals=sort_signals)
     else:
         raise Error(
-            "Unsupported output database format '{}'.".format(database_format))
+            f"Unsupported output database format '{database_format}'.")
 
     with fopen(filename, 'w', encoding=encoding, newline=newline) as fout:
         fout.write(output)

--- a/cantools/database/can/attribute.py
+++ b/cantools/database/can/attribute.py
@@ -1,4 +1,4 @@
-class Attribute(object):
+class Attribute:
     """An attribute that can be associated with nodes/messages/signals.
 
     """

--- a/cantools/database/can/attribute_definition.py
+++ b/cantools/database/can/attribute_definition.py
@@ -1,4 +1,4 @@
-class AttributeDefinition(object):
+class AttributeDefinition:
     """A definition of an attribute that can be associated with attributes
     in nodes/messages/signals.
 

--- a/cantools/database/can/bus.py
+++ b/cantools/database/can/bus.py
@@ -1,6 +1,6 @@
 # A CAN bus.
 
-class Bus(object):
+class Bus:
     """A CAN bus.
 
     """

--- a/cantools/database/can/database.py
+++ b/cantools/database/can/database.py
@@ -32,7 +32,7 @@ from ...typechecking import StringPathLike, EncodeInputType, DecodeResultType
 LOGGER = logging.getLogger(__name__)
 
 
-class Database(object):
+class Database:
     """This class contains all messages, signals and definitions of a CAN
     network.
 
@@ -522,7 +522,7 @@ class Database(object):
             self._add_message(message)
 
     def __repr__(self) -> str:
-        lines = ["version('{}')".format(self._version), '']
+        lines = [f"version('{self._version}')", '']
 
         if self._nodes:
             for node in self._nodes:

--- a/cantools/database/can/environment_variable.py
+++ b/cantools/database/can/environment_variable.py
@@ -1,4 +1,4 @@
-class EnvironmentVariable(object):
+class EnvironmentVariable:
     """A CAN environment variable.
 
     """

--- a/cantools/database/can/formats/arxml/bus_specifics.py
+++ b/cantools/database/can/formats/arxml/bus_specifics.py
@@ -1,4 +1,4 @@
-class AutosarBusSpecifics(object):
+class AutosarBusSpecifics:
     """This class collects the AUTOSAR specific information of a CAN bus
 
     """

--- a/cantools/database/can/formats/arxml/database_specifics.py
+++ b/cantools/database/can/formats/arxml/database_specifics.py
@@ -1,4 +1,4 @@
-class AutosarDatabaseSpecifics(object):
+class AutosarDatabaseSpecifics:
     """This class collects the AUTOSAR specific information of a system
 
     """

--- a/cantools/database/can/formats/arxml/ecu_extract_loader.py
+++ b/cantools/database/can/formats/arxml/ecu_extract_loader.py
@@ -49,7 +49,7 @@ REFERENCE_VALUES_XPATH = make_xpath([
     'REFERENCE-VALUES'
 ])
 
-class EcuExtractLoader(object):
+class EcuExtractLoader:
 
     def __init__(self,
                  root:Any,
@@ -77,7 +77,7 @@ class EcuExtractLoader(object):
 
         if len(com_xpaths) != 1:
             raise ValueError(
-                'Expected 1 /Com, but got {}.'.format(len(com_xpaths)))
+                f'Expected 1 /Com, but got {len(com_xpaths)}.')
 
         com_config = self.find_com_config(com_xpaths[0] + '/ComConfig')
 
@@ -131,7 +131,7 @@ class EcuExtractLoader(object):
                 com_pdu_id_ref)
         else:
             raise NotImplementedError(
-                'Direction {} not supported.'.format(direction))
+                f'Direction {direction} not supported.')
 
         if frame_id is None:
             LOGGER.warning('No frame id found for message %s.', name)

--- a/cantools/database/can/formats/arxml/message_specifics.py
+++ b/cantools/database/can/formats/arxml/message_specifics.py
@@ -3,7 +3,7 @@ from typing import Optional, List
 from .secoc_properties import AutosarSecOCProperties
 from .end_to_end_properties import AutosarEnd2EndProperties
 
-class AutosarMessageSpecifics(object):
+class AutosarMessageSpecifics:
     """This class collects all AUTOSAR specific information of a CAN message
 
     This means useful information about CAN messages which is provided

--- a/cantools/database/can/formats/arxml/node_specifics.py
+++ b/cantools/database/can/formats/arxml/node_specifics.py
@@ -1,4 +1,4 @@
-class AutosarNodeSpecifics(object):
+class AutosarNodeSpecifics:
     """This class collects the AUTOSAR specific information of node that
     is attached to a CAN bus
 

--- a/cantools/database/can/formats/arxml/system_loader.py
+++ b/cantools/database/can/formats/arxml/system_loader.py
@@ -27,7 +27,7 @@ from ....utils import type_sort_signals, sort_signals_by_start_bit
 
 LOGGER = logging.getLogger(__name__)
 
-class SystemLoader(object):
+class SystemLoader:
     def __init__(self,
                  root:Any,
                  strict:bool,

--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -361,7 +361,7 @@ class Parser(textparser.Parser):
                 bs,
                 version))
 
-class LongNamesConverter(object):
+class LongNamesConverter:
 
     def __init__(self, database):
         self._database = database
@@ -380,7 +380,7 @@ class LongNamesConverter(object):
             if short_name in self._short_names:
                 index = self._next_index_per_cut_name[cut_name]
                 self._next_index_per_cut_name[cut_name] += 1
-                short_name = '{}_{:04d}'.format(name[:27], index)
+                short_name = f'{name[:27]}_{index:04d}'
             else:
                 self._next_index_per_cut_name[cut_name] = 0
                 self._short_names.add(short_name)
@@ -432,7 +432,7 @@ def _dump_value_tables(database):
 
     for name, choices in database.dbc.value_tables.items():
         choices = [
-            '{} "{}"'.format(number, text)
+            f'{number} "{text}"'
             for number, text in reversed(sorted(choices.items()))
         ]
         val_table.append('VAL_TABLE_ {} {} ;'.format(name, ' '.join(choices)))
@@ -447,7 +447,7 @@ def _dump_messages(database, sort_signals):
         if signal.is_multiplexer:
             return ' M'
         elif signal.multiplexer_ids is not None:
-            return ' m{}'.format(signal.multiplexer_ids[0])
+            return f' m{signal.multiplexer_ids[0]}'
         else:
             return ''
 
@@ -592,7 +592,7 @@ def _dump_attribute_definitions(database):
         if definition.minimum is None:
             value = ''
         else:
-            value = ' {}'.format(value)
+            value = f' {value}'
 
         return value
 
@@ -607,7 +607,7 @@ def _dump_attribute_definitions(database):
 
     for definition in definitions.values():
         if definition.type_name == 'ENUM':
-            choices = ','.join(['"{}"'.format(choice)
+            choices = ','.join([f'"{choice}"'
                                 for choice in definition.choices])
             ba_def.append(
                 'BA_DEF_ {kind} "{name}" {type_name}  {choices};'.format(
@@ -645,7 +645,7 @@ def _dump_attribute_definitions_rel(database):
         if definition.minimum is None:
             value = ''
         else:
-            value = ' {}'.format(value)
+            value = f' {value}'
 
         return value
 
@@ -657,7 +657,7 @@ def _dump_attribute_definitions_rel(database):
 
     for definition in definitions.values():
         if definition.type_name == 'ENUM':
-            choices = ','.join(['"{}"'.format(choice)
+            choices = ','.join([f'"{choice}"'
                                 for choice in definition.choices])
             ba_def_rel.append(
                 'BA_DEF_REL_ {kind}  "{name}" {type_name}  {choices};'.format(
@@ -962,7 +962,7 @@ def _dump_signal_mux_values(database):
                 continue
 
             ranges = ', '.join([
-                '{}-{}'.format(minimum, maximum)
+                f'{minimum}-{maximum}'
                 for minimum, maximum in _create_mux_ranges(signal.multiplexer_ids)
             ])
 

--- a/cantools/database/can/formats/dbc_specifics.py
+++ b/cantools/database/can/formats/dbc_specifics.py
@@ -2,7 +2,7 @@
 
 from collections import OrderedDict
 
-class DbcSpecifics(object):
+class DbcSpecifics:
 
     def __init__(self,
                  attributes=None,

--- a/cantools/database/can/formats/kcd.py
+++ b/cantools/database/can/formats/kcd.py
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESPACE = 'http://kayak.2codeornot2code.org/1.0'
 NAMESPACES = {'ns': NAMESPACE}
 
-ROOT_TAG = '{{{}}}NetworkDefinition'.format(NAMESPACE)
+ROOT_TAG = f'{{{NAMESPACE}}}NetworkDefinition'
 
 
 def _start_bit(offset, byte_order):
@@ -74,7 +74,7 @@ def _load_signal_element(signal, nodes):
         elif key == 'length':
             length = int(value)
         elif key == 'endianess':
-            byte_order = '{}_endian'.format(value)
+            byte_order = f'{value}_endian'
         else:
             LOGGER.debug("Ignoring unsupported signal attribute '%s'.", key)
 
@@ -371,7 +371,7 @@ def _dump_mux_groups(multiplexer_name, signals, node_refs, parent):
 
 
 def _dump_message(message, bus, node_refs, sort_signals):
-    frame_id = '0x{:03X}'.format(message.frame_id)
+    frame_id = f'0x{message.frame_id:03X}'
     message_element = SubElement(bus,
                                  'Message',
                                  id=frame_id,

--- a/cantools/database/can/formats/sym.py
+++ b/cantools/database/can/formats/sym.py
@@ -105,7 +105,7 @@ class Parser60(textparser.Parser):
             ('HEXNUMBER',          r'-?\d+\.?[0-9A-F]*([eE][+-]?\d+)?(h)'),
             ('NUMBER',             r'-?\d+\.?[0-9A-F]*([eE][+-]?\d+)?'),
             ('STRING',             re_string),
-            ('U',                  r'/u:({}|\S+)'.format(re_string)),
+            ('U',                  fr'/u:({re_string}|\S+)'),
             ('F',                  r'/f:'),
             ('O',                  r'/o:'),
             ('MIN',                r'/min:'),
@@ -275,7 +275,7 @@ def _get_enum(enums, name):
     try:
         return enums[name]
     except KeyError:
-        raise ParseError("Enum '{}' is not defined.".format(name))
+        raise ParseError(f"Enum '{name}' is not defined.")
 
 
 def _load_enums(tokens):
@@ -374,7 +374,7 @@ def _load_signal_attributes(tokens, enum, enums, minimum, maximum, decimal, spn)
         elif item.startswith('/u:'):
             unit = item[3:]
         else:
-            raise ParseError('Iternal error {}.'.format(item))
+            raise ParseError(f'Iternal error {item}.')
 
     return unit, factor, offset, enum, minimum, maximum, decimal, spn
 

--- a/cantools/database/can/internal_database.py
+++ b/cantools/database/can/internal_database.py
@@ -8,7 +8,7 @@ from .bus import Bus
 from .formats.dbc_specifics import DbcSpecifics
 from .formats.arxml.database_specifics import AutosarDatabaseSpecifics
 
-class InternalDatabase(object):
+class InternalDatabase:
     """Internal CAN database.
 
     """

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-class Message(object):
+class Message:
     """A CAN message with frame id, comment, signals and other
     information.
 
@@ -810,7 +810,7 @@ class Message(object):
                           scaling: bool,
                           padding: bool) -> bytes:
 
-        result = bytes()
+        result = b""
 
         for header, value in data:
             if isinstance(header, str):

--- a/cantools/database/can/node.py
+++ b/cantools/database/can/node.py
@@ -9,7 +9,7 @@ if typing.TYPE_CHECKING:
     from ...database.can.formats.dbc import DbcSpecifics
 
 
-class Node(object):
+class Node:
     """An NODE on the CAN bus.
 
     """

--- a/cantools/database/can/signal.py
+++ b/cantools/database/can/signal.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from ...database.can.formats.dbc import DbcSpecifics
 
 
-class Decimal(object):
+class Decimal:
     """Holds the same values as
     :attr:`~cantools.database.can.Signal.scale`,
     :attr:`~cantools.database.can.Signal.offset`,
@@ -80,7 +80,7 @@ class Decimal(object):
         self._maximum = value
 
 
-class NamedSignalValue(object):
+class NamedSignalValue:
     """Represents a named value of a signal.
 
     Named values map an integer number to a human-readable
@@ -149,7 +149,7 @@ class NamedSignalValue(object):
         return False
 
 
-class Signal(object):
+class Signal:
     """A CAN signal with position, size, unit and other information. A
     signal is part of a message.
 
@@ -344,7 +344,7 @@ class Signal(object):
             choices = None
         else:
             choices = '{{{}}}'.format(', '.join(
-                ["{}: '{}'".format(value, text)
+                [f"{value}: '{text}'"
                  for value, text in self.choices.items()]))
 
         return \

--- a/cantools/database/can/signal_group.py
+++ b/cantools/database/can/signal_group.py
@@ -1,7 +1,7 @@
 # A signal group.
 
 
-class SignalGroup(object):
+class SignalGroup:
     """A CAN signal group. Signal groups are used to define a group of
     signals within a message, e.g. to define that the signals of a
     group have to be updated in common.

--- a/cantools/database/diagnostics/data.py
+++ b/cantools/database/diagnostics/data.py
@@ -4,7 +4,7 @@ from typing import Optional
 from ...typechecking import ByteOrder, Choices
 
 
-class Data(object):
+class Data:
     """A data data with position, size, unit and other information. A data
     is part of a DID.
 
@@ -72,7 +72,7 @@ class Data(object):
             choices = None
         else:
             choices = '{{{}}}'.format(', '.join(
-                ["{}: '{}'".format(value, text)
+                [f"{value}: '{text}'"
                  for value, text in self.choices.items()]))
 
         return "data('{}', {}, {}, '{}', {}, {}, {}, {}, '{}', {})".format(

--- a/cantools/database/diagnostics/database.py
+++ b/cantools/database/diagnostics/database.py
@@ -7,7 +7,7 @@ from ...compat import fopen
 LOGGER = logging.getLogger(__name__)
 
 
-class Database(object):
+class Database:
     """This class contains all DIDs.
 
     The factory functions :func:`load()<cantools.database.load()>`,

--- a/cantools/database/diagnostics/did.py
+++ b/cantools/database/diagnostics/did.py
@@ -7,7 +7,7 @@ from ..utils import decode_data
 from ..utils import create_encode_decode_formats
 
 
-class Did(object):
+class Did:
     """A DID with identifier and other information.
 
     """

--- a/cantools/database/diagnostics/formats/cdd.py
+++ b/cantools/database/diagnostics/formats/cdd.py
@@ -13,7 +13,7 @@ from ...utils import cdd_offset_to_dbc_start_bit
 LOGGER = logging.getLogger(__name__)
 
 
-class DataType(object):
+class DataType:
 
     def __init__(self,
                  name,

--- a/cantools/database/diagnostics/internal_database.py
+++ b/cantools/database/diagnostics/internal_database.py
@@ -1,6 +1,6 @@
 # Internal diagnostics database.
 
-class InternalDatabase(object):
+class InternalDatabase:
     """Internal diagnostics database.
 
     """

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -3,9 +3,18 @@
 from collections import OrderedDict
 import os.path
 import re
-from typing import Union, List, Callable, Tuple, Optional, Dict, Sequence, TYPE_CHECKING
-
-from typing_extensions import Literal, Final
+from typing import (
+    Union,
+    List,
+    Callable,
+    Tuple,
+    Optional,
+    Dict,
+    Sequence,
+    Literal,
+    Final,
+    TYPE_CHECKING,
+)
 
 from ..typechecking import (
     Formats,
@@ -169,7 +178,7 @@ def create_encode_decode_formats(datas: Sequence[Union["Data", "Signal"]], numbe
             return 'u'
 
     def padding_item(length: int) -> Tuple[str, str, None]:
-        fmt = 'p{}'.format(length)
+        fmt = f'p{length}'
         padding_mask = '1' * length
 
         return fmt, padding_mask, None
@@ -242,7 +251,7 @@ def create_encode_decode_formats(datas: Sequence[Union["Data", "Signal"]], numbe
 
         if format_length > 0:
             length = len(''.join([item[1] for item in items]))
-            _packed = bitstruct.pack('u{}'.format(length), value)
+            _packed = bitstruct.pack(f'u{length}', value)
             value = int.from_bytes(_packed, "little")
 
         return fmt(items), value, names(items)

--- a/cantools/j1939.py
+++ b/cantools/j1939.py
@@ -48,11 +48,11 @@ def frame_id_pack(priority,
                                 source_address)
     except bitstruct.Error:
         if priority > 7:
-            raise Error('Expected priority 0..7, but got {}.'.format(priority))
+            raise Error(f'Expected priority 0..7, but got {priority}.')
         elif reserved > 1:
-            raise Error('Expected reserved 0..1, but got {}.'.format(reserved))
+            raise Error(f'Expected reserved 0..1, but got {reserved}.')
         elif data_page > 1:
-            raise Error('Expected data page 0..1, but got {}.'.format(data_page))
+            raise Error(f'Expected data page 0..1, but got {data_page}.')
         elif pdu_format > 255:
             raise Error('Expected PDU format 0..255, but got {}.'.format(
                 pdu_format))
@@ -103,7 +103,7 @@ def pgn_pack(reserved, data_page, pdu_format, pdu_specific=0):
                                 pdu_specific)
     except bitstruct.Error:
         if reserved > 1:
-            raise Error('Expected reserved 0..1, but got {}.'.format(reserved))
+            raise Error(f'Expected reserved 0..1, but got {reserved}.')
         elif data_page > 1:
             raise Error('Expected data page 0..1, but got {}.'.format(
                 data_page))

--- a/cantools/subparsers/dump/__init__.py
+++ b/cantools/subparsers/dump/__init__.py
@@ -14,12 +14,12 @@ from ...j1939 import pgn_pack
 def _print_j1939_frame_id(message):
     unpacked = frame_id_unpack(message.frame_id)
 
-    print('      Priority:       {}'.format(unpacked.priority))
+    print(f'      Priority:       {unpacked.priority}')
 
     if is_pdu_format_1(unpacked.pdu_format):
         pdu_format = 'PDU 1'
         pdu_specific = 0
-        destination = '0x{:02x}'.format(unpacked.pdu_specific)
+        destination = f'0x{unpacked.pdu_specific:02x}'
     else:
         pdu_format = 'PDU 2'
         pdu_specific = unpacked.pdu_specific
@@ -30,9 +30,9 @@ def _print_j1939_frame_id(message):
                  unpacked.data_page,
                  unpacked.pdu_format,
                  pdu_specific)))
-    print('      Source:         0x{:02x}'.format(unpacked.source_address))
-    print('      Destination:    {}'.format(destination))
-    print('      Format:         {}'.format(pdu_format))
+    print(f'      Source:         0x{unpacked.source_address:02x}')
+    print(f'      Destination:    {destination}')
+    print(f'      Format:         {pdu_format}')
 
 def _dump_can_message(message, with_comments=False, name_prefix='', WIDTH=None):
     cycle_time = message.cycle_time
@@ -57,12 +57,12 @@ def _dump_can_message(message, with_comments=False, name_prefix='', WIDTH=None):
         _print_j1939_frame_id(message)
 
     if message.is_container:
-        print('  Maximum length: {} bytes'.format(message.length))
+        print(f'  Maximum length: {message.length} bytes')
     else:
-        print('  Length:         {} bytes'.format(message.length))
+        print(f'  Length:         {message.length} bytes')
 
-    print('  Cycle time:     {} ms'.format(cycle_time))
-    print('  Senders:        {}'.format(format_and(message.senders)))
+    print(f'  Cycle time:     {cycle_time} ms')
+    print(f'  Senders:        {format_and(message.senders)}')
     if message.is_container:
         print('  Possibly contained children:')
         print()
@@ -128,15 +128,15 @@ def _dump_diagnostics_database(dbase):
 
     for did in dbase.dids:
         print()
-        print('  Name:       {}'.format(did.name))
-        print('  Length:     {} bytes'.format(did.length))
+        print(f'  Name:       {did.name}')
+        print(f'  Length:     {did.length} bytes')
         print('  Layout:')
         print()
 
         for data in did.datas:
-            print('    Name:      {}'.format(data.name))
-            print('    Start bit: {}'.format(data.start))
-            print('    Length:    {}'.format(data.length))
+            print(f'    Name:      {data.name}')
+            print(f'    Start bit: {data.start}')
+            print(f'    Length:    {data.length}')
             print()
 
         print()

--- a/cantools/subparsers/dump/formatting.py
+++ b/cantools/subparsers/dump/formatting.py
@@ -243,7 +243,7 @@ def layout_string(message, signal_names=True):
 
         # Add byte numbering.
         number_width = len(str(len(lines))) + 4
-        number_fmt = '{{:{}d}} {{}}'.format(number_width - 1)
+        number_fmt = f'{{:{number_width - 1}d}} {{}}'
         a = []
 
         for number, line in enumerate(lines):
@@ -376,6 +376,6 @@ def signal_choices_string(message):
             lines.append(signal.name)
 
             for value, text in sorted(signal.choices.items()):
-                lines.append('    {} {}'.format(value, text))
+                lines.append(f'    {value} {text}')
 
     return '\n'.join(lines)

--- a/cantools/subparsers/generate_c_source.py
+++ b/cantools/subparsers/generate_c_source.py
@@ -48,7 +48,7 @@ def _do_generate_c_source(args):
     with open(path_c, 'w') as fout:
         fout.write(source)
 
-    print('Successfully generated {} and {}.'.format(path_h, path_c))
+    print(f'Successfully generated {path_h} and {path_c}.')
 
     if args.generate_fuzzer:
         fuzzer_path_c = os.path.join(args.output_directory, fuzzer_filename_c)

--- a/cantools/subparsers/monitor.py
+++ b/cantools/subparsers/monitor.py
@@ -401,7 +401,7 @@ class Monitor(can.Listener):
         else:
             formatted = format_message(message, data, True, False)
             lines = formatted.splitlines()
-            formatted = ['{:12.3f}  {}'.format(timestamp, lines[1])]
+            formatted = [f'{timestamp:12.3f}  {lines[1]}']
             formatted += [14 * ' ' + line for line in lines[2:]]
 
         self._update_formatted_message(name, formatted)

--- a/cantools/subparsers/plot.py
+++ b/cantools/subparsers/plot.py
@@ -671,7 +671,7 @@ class Signals:
                 plotted = True
 
             if not plotted:
-                print("WARNING: signal %r with format %r was not plotted." % (sgo.reo.pattern, sgo.fmt))
+                print(f"WARNING: signal {sgo.reo.pattern!r} with format {sgo.fmt!r} was not plotted.")
 
         self.plot_error(splot, x_invalid_syntax, 'invalid syntax', self.COLOR_INVALID_SYNTAX)
         self.plot_error(splot, x_unknown_frames, 'unknown frames', self.COLOR_UNKNOWN_FRAMES)

--- a/cantools/tester.py
+++ b/cantools/tester.py
@@ -10,7 +10,7 @@ from typing import Optional, Dict, List
 from .errors import Error
 
 
-class DecodedMessage(object):
+class DecodedMessage:
     """A decoded message.
 
     """
@@ -28,7 +28,7 @@ class Messages(UserDict):
         self.data[message_name] = value
 
     def __missing__(self, key):
-        raise Error("invalid message name '{}'".format(key))
+        raise Error(f"invalid message name '{key}'")
 
 
 def _invert_signal_tree(
@@ -111,7 +111,7 @@ class Listener(can.Listener):
         self._input_queue.put(decoded)
 
 
-class Message(UserDict, object):
+class Message(UserDict):
 
     def __init__(self,
                  database,
@@ -121,7 +121,7 @@ class Message(UserDict, object):
                  decode_choices,
                  scaling,
                  padding):
-        super(Message, self).__init__()
+        super().__init__()
         self.database = database
         self._mplex_map = invert_signal_tree(database.signal_tree)
         self._can_bus = can_bus
@@ -283,7 +283,7 @@ class Message(UserDict, object):
         return initial_sig_values
 
 
-class Tester(object):
+class Tester:
     """Test given node `dut_name` on given CAN bus `bus_name`.
 
     `database` is a :class:`~cantools.database.can.Database` instance.

--- a/cantools/typechecking.py
+++ b/cantools/typechecking.py
@@ -10,9 +10,11 @@ from typing import (
     Sequence,
     Tuple,
     Callable,
+    Literal,
+    OrderedDict,
 )
 
-from typing_extensions import TypedDict, Literal, OrderedDict
+from typing_extensions import TypedDict
 from bitstruct import CompiledFormatDict
 
 if TYPE_CHECKING:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,17 @@ module = [
 ]
 ignore_missing_imports = true
 
+[tool.ruff]
+select = [
+#    "E",  # pycodestyle Error
+#    "F",  # pyflakes
+#    "B",  # pyflakes-bugbear
+    "UP",  # pyupgrade
+#    "C4",  # flake8-comprehensions
+]
+
+# Assume Python 3.8.
+target-version = "py38"
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]


### PR DESCRIPTION
In this PR i only activated the pyupgrade checks. The other checks can be activated in follow-up PRs, otherwise it will be impossible to review.

So this PR mostly removes `object` as parent class and uses f-strings where possible.