### PR TITLE
Fix handling of initial values and allow the use of none-strict mode in Tester

### DIFF
--- a/cantools/tester.py
+++ b/cantools/tester.py
@@ -274,7 +274,13 @@ class Message(UserDict):
             maximum = 0 if not signal.maximum else signal.maximum
             if signal.initial:
                 # use initial signal value (if set)
-                initial_sig_values[signal.name] = (signal.initial * signal.decimal.scale) + signal.decimal.offset
+                if self.scaling:
+                    initial_sig_values[signal.name] = \
+                                                    (signal.initial *
+                                                     signal.decimal.scale) + \
+                                                    signal.decimal.offset
+                else:
+                    initial_sig_values[signal.name] = signal.initial
             elif signal.is_multiplexer:
                 initial_sig_values[signal.name] = mplex_settings.get(signal.name, 0)
             elif minimum <= 0 <= maximum:

--- a/cantools/tester.py
+++ b/cantools/tester.py
@@ -120,7 +120,8 @@ class Message(UserDict):
                  input_queue,
                  decode_choices,
                  scaling,
-                 padding):
+                 padding,
+                 strict):
         super().__init__()
         self.database = database
         self._mplex_map = invert_signal_tree(database.signal_tree)
@@ -129,6 +130,7 @@ class Message(UserDict):
         self.decode_choices = decode_choices
         self.scaling = scaling
         self.padding = padding
+        self.strict = strict
         self._input_list = input_list
         self.enabled = True
         self._can_message = None
@@ -249,7 +251,8 @@ class Message(UserDict):
         pruned_data = self.database.gather_signals(self.data)
         data = self.database.encode(pruned_data,
                                     self.scaling,
-                                    self.padding)
+                                    self.padding,
+                                    self.strict)
         self._can_message = can.Message(arbitration_id=arbitration_id,
                                         is_extended_id=extended_id,
                                         data=data)
@@ -315,7 +318,8 @@ class Tester:
                  on_message=None,
                  decode_choices=True,
                  scaling=True,
-                 padding=False):
+                 padding=False,
+                 strict=True):
         self._dut_name = dut_name
         self._bus_name = bus_name
         self._database = database
@@ -354,7 +358,8 @@ class Tester:
                                                        self._input_queue,
                                                        decode_choices,
                                                        scaling,
-                                                       padding)
+                                                       padding,
+                                                       strict)
 
         listener = Listener(self._database,
                             self._messages,


### PR DESCRIPTION
When parsing a DBC file with initial values, scaling is always applied. The following line from _prepare_initial_signal_values uses signal.decimal
```
initial_sig_values[signal.name] = (signal.initial * signal.decimal.scale) + signal.decimal.offset
```
This means that all initial values are given the type decimal.Decimal. Consequently the function _encode_fields always call choice_string_to_number since the type check only looks for int and float:
```
if isinstance(value, (float, int)):
```

This PR adds
 - a check for decimal.Decimal type in  _encode_fields,
 - a check for non-scaling mode for initial values,
 - the option to run Tester in non-strict mode. 

The above changes hopefully solve the case where initial values are present but out of range. In addition, decimal type will be handled as such and not as string.