### PR TITLE
Add group_comment_signals flag to DBC output

### DIFF
--- a/cantools/database/can/database.py
+++ b/cantools/database/can/database.py
@@ -323,11 +323,15 @@ class Database:
                       sort_attribute_signals:type_sort_signals=SORT_SIGNALS_DEFAULT,
                       sort_attributes:type_sort_attributes=None,
                       sort_choices:type_sort_choices=None,
-                      shorten_long_names:bool=True) -> str:
+                      shorten_long_names:bool=True,
+                      group_comment_signals:bool=False) -> str:
         """Return the database as a string formatted as a DBC file.
            sort_signals defines how to sort signals in message definitions
            sort_attribute_signals defines how to sort signals in metadata -
               comments, value table definitions and attributes
+           If group_comment_signals==True, `CM_ SG_` lines appear after all
+              `CM_ BO_` lines, instead of immediately after their containing
+              message
 
         """
         if not self._sort_signals and sort_signals == SORT_SIGNALS_DEFAULT:
@@ -342,7 +346,8 @@ class Database:
                                sort_attribute_signals=sort_attribute_signals,
                                sort_attributes=sort_attributes,
                                sort_choices=sort_choices,
-                               shorten_long_names=shorten_long_names)
+                               shorten_long_names=shorten_long_names,
+                               group_comment_signals=group_comment_signals)
 
     def as_kcd_string(self, *, sort_signals:type_sort_signals=SORT_SIGNALS_DEFAULT) -> str:
         """Return the database as a string formatted as a KCD file.


### PR DESCRIPTION
Some more DBC output knobs to twiddle :)

Currently, comments are serialised as
- Node comment 1
- Node 1 message comment 1
- Node 1 message comment n
- Node comment 2
- Node 2 message comment 1

This changes things to be
- Node comment 1
- Node comment 2
- Node 1 message comment 1
- Node 1 message comment n
- Node 2 message comment 1