### PR TITLE
remove obsolete checks for Python 2

### DIFF
--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1304,12 +1304,10 @@ BATTERY_VT(
             with patch('sys.argv', argv):
                 cantools._main()
 
-            if sys.version_info[0] > 2:
-                self.assert_files_equal(database_h,
-                                        'tests/files/c_source/' + database_h)
-                self.assert_files_equal(database_c,
-                                        'tests/files/c_source/' + database_c)
-
+            self.assert_files_equal(database_h,
+                                    'tests/files/c_source/' + database_h)
+            self.assert_files_equal(database_c,
+                                    'tests/files/c_source/' + database_c)
             self.assertFalse(os.path.exists(fuzzer_c))
             self.assertFalse(os.path.exists(fuzzer_mk))
 
@@ -1341,13 +1339,12 @@ BATTERY_VT(
             with patch('sys.argv', argv):
                 cantools._main()
 
-            if sys.version_info[0] > 2:
-                self.assert_files_equal(
-                    database_h,
-                    'tests/files/c_source/' + expected_database_h)
-                self.assert_files_equal(
-                    database_c,
-                    'tests/files/c_source/' + expected_database_c)
+            self.assert_files_equal(
+                database_h,
+                'tests/files/c_source/' + expected_database_h)
+            self.assert_files_equal(
+                database_c,
+                'tests/files/c_source/' + expected_database_c)
 
     def test_generate_c_source_sender_node_no_signal_encode_decode(self):
         databases = [
@@ -1382,11 +1379,10 @@ BATTERY_VT(
             with patch('sys.argv', argv):
                 cantools._main()
 
-            if sys.version_info[0] > 2:
-                self.assert_files_equal(database_h,
-                                        'tests/files/c_source/' + expected_database_h)
-                self.assert_files_equal(database_c,
-                                        'tests/files/c_source/' + expected_database_c)
+            self.assert_files_equal(database_h,
+                                    'tests/files/c_source/' + expected_database_h)
+            self.assert_files_equal(database_c,
+                                    'tests/files/c_source/' + expected_database_c)
 
     def test_generate_c_source_database_name(self):
         databases = [
@@ -1413,11 +1409,10 @@ BATTERY_VT(
             with patch('sys.argv', argv):
                 cantools._main()
 
-            if sys.version_info[0] > 2:
-                self.assert_files_equal(database_h,
-                                        'tests/files/c_source/' + database_h)
-                self.assert_files_equal(database_c,
-                                        'tests/files/c_source/' + database_c)
+            self.assert_files_equal(database_h,
+                                    'tests/files/c_source/' + database_h)
+            self.assert_files_equal(database_c,
+                                    'tests/files/c_source/' + database_c)
 
     def test_generate_c_source_output_directory(self):
         database = 'motohawk'
@@ -1472,11 +1467,10 @@ BATTERY_VT(
             with patch('sys.argv', argv):
                 cantools._main()
 
-            if sys.version_info[0] > 2:
-                self.assert_files_equal(database_h,
-                                        'tests/files/c_source/' + database_h)
-                self.assert_files_equal(database_c,
-                                        'tests/files/c_source/' + database_c)
+            self.assert_files_equal(database_h,
+                                    'tests/files/c_source/' + database_h)
+            self.assert_files_equal(database_c,
+                                    'tests/files/c_source/' + database_c)
 
     def test_generate_c_source_sender_node(self):
         databases = [
@@ -1510,11 +1504,10 @@ BATTERY_VT(
             with patch('sys.argv', argv):
                 cantools._main()
 
-            if sys.version_info[0] > 2:
-                self.assert_files_equal(database_h,
-                                        'tests/files/c_source/' + expected_database_h)
-                self.assert_files_equal(database_c,
-                                        'tests/files/c_source/' + expected_database_c)
+            self.assert_files_equal(database_h,
+                                    'tests/files/c_source/' + expected_database_h)
+            self.assert_files_equal(database_c,
+                                    'tests/files/c_source/' + expected_database_c)
 
     def test_generate_c_source_generate_fuzzer(self):
         argv = [
@@ -1544,15 +1537,14 @@ BATTERY_VT(
         with patch('sys.argv', argv):
             cantools._main()
 
-        if sys.version_info[0] > 2:
-            self.assert_files_equal(database_h,
-                                    'tests/files/c_source/' + database_h)
-            self.assert_files_equal(database_c,
-                                    'tests/files/c_source/' + database_c)
-            self.assert_files_equal(fuzzer_c,
-                                    'tests/files/c_source/' + fuzzer_c)
-            self.assert_files_equal(fuzzer_mk,
-                                    'tests/files/c_source/' + fuzzer_mk)
+        self.assert_files_equal(database_h,
+                                'tests/files/c_source/' + database_h)
+        self.assert_files_equal(database_c,
+                                'tests/files/c_source/' + database_c)
+        self.assert_files_equal(fuzzer_c,
+                                'tests/files/c_source/' + fuzzer_c)
+        self.assert_files_equal(fuzzer_mk,
+                                'tests/files/c_source/' + fuzzer_mk)
 
     def test_generate_c_source_sym(self):
         databases = [
@@ -1592,12 +1584,10 @@ BATTERY_VT(
             with patch('sys.argv', argv):
                 cantools._main()
 
-            if sys.version_info[0] > 2:
-                self.assert_files_equal(database_h,
-                                        'tests/files/c_source/' + database_h)
-                self.assert_files_equal(database_c,
-                                        'tests/files/c_source/' + database_c)
-
+            self.assert_files_equal(database_h,
+                                    'tests/files/c_source/' + database_h)
+            self.assert_files_equal(database_c,
+                                    'tests/files/c_source/' + database_c)
             self.assertFalse(os.path.exists(fuzzer_c))
             self.assertFalse(os.path.exists(fuzzer_mk))
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4047,9 +4047,6 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        if sys.version_info < (3, 8):
-            return
-
         filename = 'tests/files/kcd/dump.kcd'
         db = cantools.database.load_file(filename)
 


### PR DESCRIPTION
the minimum required python version has been 3.8 for a while now...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)