### PR TITLE
rename `field` to `signal`

### DIFF
--- a/cantools/autosar/end_to_end.py
+++ b/cantools/autosar/end_to_end.py
@@ -1,14 +1,14 @@
 # Utilities for calculating the CRC of the AUTOSAR end-to-end
 # protection specification
 
-from typing import Optional, Union
+from typing import ByteString, Optional, Union
 
 import crccheck  # type: ignore
 
 from ..database.can.message import Message
 
 
-def compute_profile2_crc(payload : Union[bytes, bytearray],
+def compute_profile2_crc(payload: ByteString,
                          msg_or_data_id: Union[int, Message]) -> Optional[int]:
     """Compute the CRC checksum for profile 2 of the AUTOSAR end-to-end
     protection specification.
@@ -53,7 +53,7 @@ def compute_profile2_crc(payload : Union[bytes, bytearray],
     # do the actual work
     return int(crccheck.crc.Crc8Autosar().calc(crc_data))
 
-def apply_profile2_crc(payload : Union[bytes, bytearray],
+def apply_profile2_crc(payload: ByteString,
                        msg_or_data_id: Union[int, Message]) \
   -> Optional[bytearray]:
     """Compute the CRC checksum for profile 2 of the AUTOSAR end-to-end
@@ -74,7 +74,7 @@ def apply_profile2_crc(payload : Union[bytes, bytearray],
     return result
 
 
-def check_profile2_crc(payload : Union[bytes, bytearray],
+def check_profile2_crc(payload: ByteString,
                        msg_or_data_id: Union[int, Message]) -> Optional[bool]:
     """Check if the AUTOSAR E2E checksum for profile 2 of the AUTOSAR
     end-to-end protection specification is correct.
@@ -92,7 +92,7 @@ def check_profile2_crc(payload : Union[bytes, bytearray],
 
     return crc == crc2
 
-def compute_profile5_crc(payload : Union[bytes, bytearray],
+def compute_profile5_crc(payload: ByteString,
                          msg_or_data_id: Union[int, Message]) -> Optional[int]:
     """Compute the CRC checksum for profile 5 of the AUTOSAR end-to-end
     protection specification.
@@ -140,7 +140,7 @@ def compute_profile5_crc(payload : Union[bytes, bytearray],
 
     return int(result)
 
-def apply_profile5_crc(payload : Union[bytes, bytearray],
+def apply_profile5_crc(payload: ByteString,
                        msg_or_data_id: Union[int, Message]) \
   -> Optional[bytearray]:
     """Compute the AUTOSAR E2E checksum for profile 5 of the AUTOSAR
@@ -164,7 +164,7 @@ def apply_profile5_crc(payload : Union[bytes, bytearray],
 
     return result
 
-def check_profile5_crc(payload : Union[bytes, bytearray],
+def check_profile5_crc(payload: ByteString,
                        msg_or_data_id: Union[int, Message]) -> Optional[bool]:
     """Check if the AUTOSAR E2E checksum for profile 5 of the AUTOSAR
     end-to-end protection specification is correct.

--- a/cantools/autosar/end_to_end.py
+++ b/cantools/autosar/end_to_end.py
@@ -1,14 +1,14 @@
 # Utilities for calculating the CRC of the AUTOSAR end-to-end
 # protection specification
 
-from typing import ByteString, Optional, Union
+from typing import Optional, Union
 
 import crccheck  # type: ignore
 
 from ..database.can.message import Message
 
 
-def compute_profile2_crc(payload: ByteString,
+def compute_profile2_crc(payload: bytes,
                          msg_or_data_id: Union[int, Message]) -> Optional[int]:
     """Compute the CRC checksum for profile 2 of the AUTOSAR end-to-end
     protection specification.
@@ -53,7 +53,7 @@ def compute_profile2_crc(payload: ByteString,
     # do the actual work
     return int(crccheck.crc.Crc8Autosar().calc(crc_data))
 
-def apply_profile2_crc(payload: ByteString,
+def apply_profile2_crc(payload: bytes,
                        msg_or_data_id: Union[int, Message]) \
   -> Optional[bytearray]:
     """Compute the CRC checksum for profile 2 of the AUTOSAR end-to-end
@@ -74,7 +74,7 @@ def apply_profile2_crc(payload: ByteString,
     return result
 
 
-def check_profile2_crc(payload: ByteString,
+def check_profile2_crc(payload: bytes,
                        msg_or_data_id: Union[int, Message]) -> Optional[bool]:
     """Check if the AUTOSAR E2E checksum for profile 2 of the AUTOSAR
     end-to-end protection specification is correct.
@@ -92,7 +92,7 @@ def check_profile2_crc(payload: ByteString,
 
     return crc == crc2
 
-def compute_profile5_crc(payload: ByteString,
+def compute_profile5_crc(payload: bytes,
                          msg_or_data_id: Union[int, Message]) -> Optional[int]:
     """Compute the CRC checksum for profile 5 of the AUTOSAR end-to-end
     protection specification.
@@ -140,7 +140,7 @@ def compute_profile5_crc(payload: ByteString,
 
     return int(result)
 
-def apply_profile5_crc(payload: ByteString,
+def apply_profile5_crc(payload: bytes,
                        msg_or_data_id: Union[int, Message]) \
   -> Optional[bytearray]:
     """Compute the AUTOSAR E2E checksum for profile 5 of the AUTOSAR
@@ -164,7 +164,7 @@ def apply_profile5_crc(payload: ByteString,
 
     return result
 
-def check_profile5_crc(payload: ByteString,
+def check_profile5_crc(payload: bytes,
                        msg_or_data_id: Union[int, Message]) -> Optional[bool]:
     """Check if the AUTOSAR E2E checksum for profile 5 of the AUTOSAR
     end-to-end protection specification is correct.

--- a/cantools/autosar/secoc.py
+++ b/cantools/autosar/secoc.py
@@ -3,6 +3,7 @@
 # messages.)
 
 import bitstruct
+from typing import ByteString
 
 from ..database.can.message import Message
 from ..errors import Error
@@ -17,11 +18,11 @@ class SecOCError(Error):
     """
     pass
 
-def compute_authenticator(raw_payload: bytes,
+def compute_authenticator(raw_payload: ByteString,
                           dbmsg: Message,
                           authenticator_fn: SecOCAuthenticatorFn,
                           freshness_value: int) \
-                          -> bytearray:
+                          -> ByteString:
     """Given a byte-like object that contains the encoded signals to be
     send, compute the full authenticator SecOC value.
     """
@@ -44,7 +45,7 @@ def compute_authenticator(raw_payload: bytes,
     # compute authenticator value
     return authenticator_fn(dbmsg, auth_data, freshness_value)
 
-def apply_authenticator(raw_payload: bytes,
+def apply_authenticator(raw_payload: ByteString,
                         dbmsg: Message,
                         authenticator_fn: SecOCAuthenticatorFn,
                         freshness_value: int) \
@@ -87,7 +88,7 @@ def apply_authenticator(raw_payload: bytes,
 
     return result
 
-def verify_authenticator(raw_payload: bytes,
+def verify_authenticator(raw_payload: ByteString,
                          dbmsg: Message,
                          authenticator_fn: SecOCAuthenticatorFn,
                          freshness_value: int) \

--- a/cantools/autosar/secoc.py
+++ b/cantools/autosar/secoc.py
@@ -2,8 +2,9 @@
 # (SecOC, i.e., verification of the authenticity of the sender of
 # messages.)
 
-import bitstruct
 from typing import ByteString
+
+import bitstruct
 
 from ..database.can.message import Message
 from ..errors import Error

--- a/cantools/autosar/secoc.py
+++ b/cantools/autosar/secoc.py
@@ -2,8 +2,6 @@
 # (SecOC, i.e., verification of the authenticity of the sender of
 # messages.)
 
-from typing import ByteString
-
 import bitstruct
 
 from ..database.can.message import Message
@@ -19,11 +17,11 @@ class SecOCError(Error):
     """
     pass
 
-def compute_authenticator(raw_payload: ByteString,
+def compute_authenticator(raw_payload: bytes,
                           dbmsg: Message,
                           authenticator_fn: SecOCAuthenticatorFn,
                           freshness_value: int) \
-                          -> ByteString:
+                          -> bytes:
     """Given a byte-like object that contains the encoded signals to be
     send, compute the full authenticator SecOC value.
     """
@@ -46,7 +44,7 @@ def compute_authenticator(raw_payload: ByteString,
     # compute authenticator value
     return authenticator_fn(dbmsg, auth_data, freshness_value)
 
-def apply_authenticator(raw_payload: ByteString,
+def apply_authenticator(raw_payload: bytes,
                         dbmsg: Message,
                         authenticator_fn: SecOCAuthenticatorFn,
                         freshness_value: int) \
@@ -89,7 +87,7 @@ def apply_authenticator(raw_payload: ByteString,
 
     return result
 
-def verify_authenticator(raw_payload: ByteString,
+def verify_authenticator(raw_payload: bytes,
                          dbmsg: Message,
                          authenticator_fn: SecOCAuthenticatorFn,
                          freshness_value: int) \

--- a/cantools/autosar/snakeauth.py
+++ b/cantools/autosar/snakeauth.py
@@ -1,7 +1,7 @@
 # An example cipher suite for secure on-board communication. This is
 # in no way cryptographically secure. DO NOT USE IN THE REAL WORLD!
 
-from typing import Union
+from typing import ByteString, Union
 
 from ..database import Message
 
@@ -14,7 +14,7 @@ class SnakeOilAuthenticator:
     cryptographically secure! DO NOT USE THEM IN THE REAL WORLD!
     """
     def __init__(self,
-                 secret: Union[str, bytes, bytearray]):
+                 secret: ByteString):
         if isinstance(secret, str):
             self._secret = secret.encode()
         else:

--- a/cantools/autosar/snakeauth.py
+++ b/cantools/autosar/snakeauth.py
@@ -1,7 +1,7 @@
 # An example cipher suite for secure on-board communication. This is
 # in no way cryptographically secure. DO NOT USE IN THE REAL WORLD!
 
-from typing import ByteString
+from typing import Union
 
 from ..database import Message
 
@@ -14,7 +14,7 @@ class SnakeOilAuthenticator:
     cryptographically secure! DO NOT USE THEM IN THE REAL WORLD!
     """
     def __init__(self,
-                 secret: ByteString):
+                 secret: Union[bytes, str]) -> None:
         if isinstance(secret, str):
             self._secret = secret.encode()
         else:

--- a/cantools/autosar/snakeauth.py
+++ b/cantools/autosar/snakeauth.py
@@ -1,7 +1,7 @@
 # An example cipher suite for secure on-board communication. This is
 # in no way cryptographically secure. DO NOT USE IN THE REAL WORLD!
 
-from typing import ByteString, Union
+from typing import ByteString
 
 from ..database import Message
 

--- a/cantools/database/can/database.py
+++ b/cantools/database/can/database.py
@@ -1,6 +1,5 @@
 import logging
 from typing import (
-    ByteString,
     Dict,
     List,
     Optional,
@@ -447,7 +446,7 @@ class Database:
 
     def decode_message(self,
                        frame_id_or_name: Union[int, str],
-                       data: ByteString,
+                       data: bytes,
                        decode_choices: bool = True,
                        scaling: bool = True,
                        decode_containers: bool = False,

--- a/cantools/database/can/database.py
+++ b/cantools/database/can/database.py
@@ -1,5 +1,6 @@
 import logging
 from typing import (
+    ByteString,
     Dict,
     List,
     Optional,
@@ -446,7 +447,7 @@ class Database:
 
     def decode_message(self,
                        frame_id_or_name: Union[int, str],
-                       data: bytes,
+                       data: ByteString,
                        decode_choices: bool = True,
                        scaling: bool = True,
                        decode_containers: bool = False,

--- a/cantools/database/can/formats/arxml/system_loader.py
+++ b/cantools/database/can/formats/arxml/system_loader.py
@@ -1223,7 +1223,9 @@ class SystemLoader:
             assert dselsig.length == selector_len
 
             if dynalt_selector_signals[0].choices is not None:
-                selector_signal.choices.update(dynalt_selector_signals[0].choices)
+                tmp = selector_signal.choices
+                tmp.update(dynalt_selector_signals[0].choices)
+                selector_signal.set_choices(tmp)
 
             if dynalt_selector_signals[0].invalid is not None:
                 # TODO: this may lead to undefined behaviour if

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -746,7 +746,7 @@ class Message:
                 # undo the scaling of the signal's minimum value if we
                 # are not supposed to scale the input value
                 if not scaling:
-                    min_effective = (signal.minimum - signal.offset)/signal.scale
+                    min_effective = signal.scaled_to_raw(signal.minimum)
 
                 if signal_value < min_effective - signal.scale*1e-6:
                     raise EncodeError(
@@ -764,8 +764,8 @@ class Message:
 
                 if signal_value > max_effective + signal.scale*1e-6:
                     raise EncodeError(
-                        f'Expected signal "{signal.name}" value less than or '
-                        f'equal to {max_effective} in message "{self.name}", '
+                        f'Expected signal "{signal.name}" value smaller than '
+                        f'or equal to {max_effective} in message "{self.name}", '
                         f'but got {signal_value}.')
 
     def _encode(self, node: Codec, data: SignalMappingType, scaling: bool) -> Tuple[int, int, List[Signal]]:

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -718,7 +718,7 @@ class Message:
         if isinstance(mux, str) or isinstance(mux, NamedSignalValue):
             signal = self.get_signal_by_name(signal_name)
             try:
-                mux = signal.choice_string_to_number(str(mux))
+                mux = signal.choice_to_number(str(mux))
             except KeyError:
                 raise EncodeError() from None
         return int(mux)
@@ -732,7 +732,7 @@ class Message:
 
             if isinstance(signal_value, (str, NamedSignalValue)):
                 # Check choices
-                signal_value_num = signal.choice_string_to_number(str(signal_value))
+                signal_value_num = signal.choice_to_number(str(signal_value))
 
                 if signal_value_num is None:
                     raise EncodeError(f'Invalid value specified for signal '

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -2,7 +2,17 @@
 
 import logging
 from copy import deepcopy
-from typing import TYPE_CHECKING, ByteString, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    ByteString,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 from ...typechecking import (
     Codec,

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -4,7 +4,6 @@ import logging
 from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
-    ByteString,
     Dict,
     List,
     Optional,
@@ -687,7 +686,7 @@ class Message:
                               f'must be a list of (Message, SignalDict) tuples')
 
         for header, payload in input_data:
-            if isinstance(header, int) and isinstance(payload, ByteString):
+            if isinstance(header, int) and isinstance(payload, bytes):
                 # contained message specified as raw data
                 continue
 
@@ -710,7 +709,7 @@ class Message:
                 raise EncodeError(f'Could not associate "{header}" with any '
                                   f'contained message')
 
-            if isinstance(payload, ByteString):
+            if isinstance(payload, bytes):
                 if len(payload) != contained_message.length:
                     raise EncodeError(f'Payload for contained message '
                                       f'"{contained_message.name}" is '
@@ -835,7 +834,7 @@ class Message:
                                   f'to header {header}')
 
             if contained_message is None:
-                if isinstance(value, ByteString) and isinstance(header, int):
+                if isinstance(value, bytes) and isinstance(header, int):
                     # the contained message was specified as raw data
                     header_id = header
                 else:
@@ -845,7 +844,7 @@ class Message:
                 assert contained_message.header_id is not None
                 header_id = contained_message.header_id
 
-            if isinstance(value, ByteString):
+            if isinstance(value, bytes):
                 # raw data
 
                 # ensure that the size of the blob corresponds to the
@@ -954,7 +953,7 @@ class Message:
 
     def _decode(self,
                 node: Codec,
-                data: ByteString,
+                data: bytes,
                 decode_choices: bool,
                 scaling: bool,
                 allow_truncated: bool) -> SignalDictType:
@@ -990,7 +989,7 @@ class Message:
         return decoded
 
     def unpack_container(self,
-                         data: ByteString,
+                         data: bytes,
                          allow_truncated: bool = False) \
                          -> ContainerUnpackResultType:
         """Unwrap the contents of a container message.
@@ -1053,7 +1052,7 @@ class Message:
         return result
 
     def decode(self,
-               data: ByteString,
+               data: bytes,
                decode_choices: bool = True,
                scaling: bool = True,
                decode_containers: bool = False,
@@ -1102,7 +1101,7 @@ class Message:
                                   allow_truncated)
 
     def decode_simple(self,
-                      data: ByteString,
+                      data: bytes,
                       decode_choices: bool = True,
                       scaling: bool = True,
                       allow_truncated: bool = False) \
@@ -1128,7 +1127,7 @@ class Message:
                             allow_truncated)
 
     def decode_container(self,
-                         data: ByteString,
+                         data: bytes,
                          decode_choices: bool = True,
                          scaling: bool = True,
                          allow_truncated: bool = False) \

--- a/cantools/database/can/signal.py
+++ b/cantools/database/can/signal.py
@@ -1,6 +1,6 @@
 # A CAN signal.
 import decimal
-from typing import cast, TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
 
 from ...typechecking import ByteOrder, Choices, Comments, SignalValueType
 from ..namedsignalvalue import NamedSignalValue

--- a/cantools/database/can/signal.py
+++ b/cantools/database/can/signal.py
@@ -1,6 +1,6 @@
 # A CAN signal.
 import decimal
-from typing import cast, TYPE_CHECKING, List, Optional, Union
+from typing import cast, TYPE_CHECKING, Dict, List, Optional, Union
 
 from ...typechecking import ByteOrder, Choices, Comments, SignalValueType
 from ..namedsignalvalue import NamedSignalValue
@@ -162,6 +162,9 @@ class Signal:
 
         #: "A dictionary mapping signal values to enumerated choices, or
         #: ``None`` if unavailable.
+        self.choices: Optional[Choices]
+        #: The inverse of ``choices``
+        self._inverse_choices: Optional[Dict[str, int]]
         self.set_choices(choices)
 
         #: The start bit position of the signal within its message.
@@ -329,8 +332,7 @@ class Signal:
             self.comments = {None: value}
 
     def set_choices(self, choices: Optional[Choices]) -> None:
-        self.choices: Optional[Choices] = choices
-        self._inverse_choices: Optional[Dict[str, int]] = None
+        self.choices = choices
         if choices is not None:
             # we simply assume that the choices are invertible
             self._inverse_choices = { str(x[1]): x[0] for x in choices.items() }

--- a/cantools/database/diagnostics/data.py
+++ b/cantools/database/diagnostics/data.py
@@ -1,8 +1,8 @@
 # DID data.
 from typing import Optional, Union
 
-from ..can.signal import NamedSignalValue
 from ...typechecking import ByteOrder, Choices, SignalValueType
+from ..can.signal import NamedSignalValue
 
 
 class Data:
@@ -71,9 +71,9 @@ class Data:
         :return:
             The calculated scaled value
         """
-        if decode_choices:
-            with contextlib.suppress(KeyError, TypeError):
-                return self.choices[raw]  # type: ignore[index]
+        if decode_choices and self.choices and raw in self.choices:
+            assert isinstance(raw, int)
+            return self.choices[raw]
 
         if self.offset == 0 and self.scale == 1:
             # treat special case to avoid introduction of unnecessary rounding error
@@ -97,11 +97,11 @@ class Data:
             return _transform((scaled - self.offset) / self.scale)  # type: ignore[operator,no-any-return]
 
         if isinstance(scaled, (str, NamedSignalValue)):
-            return self.choice_string_to_number(str(scaled))
+            return self.choice_to_number(str(scaled))
 
         raise TypeError(f"Conversion of type {type(scaled)} is not supported.")
 
-    def choice_string_to_number(self, string: str) -> int:
+    def choice_to_number(self, string: Union[str, NamedSignalValue]) -> int:
         if self.choices is None:
             raise ValueError(f"Data {self.name} has no choices.")
 

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -5,6 +5,7 @@ import re
 from collections import OrderedDict
 from typing import (
     TYPE_CHECKING,
+    ByteString,
     Callable,
     Dict,
     Final,
@@ -111,7 +112,7 @@ def encode_data(data: SignalMappingType,
     return packed_union
 
 
-def decode_data(data: bytes,
+def decode_data(data: ByteString,
                 expected_length: int,
                 signals: Sequence[Union["Signal", "Data"]],
                 formats: Formats,
@@ -122,11 +123,11 @@ def decode_data(data: bytes,
 
     actual_length = len(data)
     if allow_truncated and actual_length < expected_length:
-        data = data.ljust(expected_length, b"\xFF")
+        data = bytes(data).ljust(expected_length, b"\xFF")
 
     unpacked = {
-        **formats.big_endian.unpack(data),
-        **formats.little_endian.unpack(data[::-1]),
+        **formats.big_endian.unpack(bytes(data)),
+        **formats.little_endian.unpack(bytes(data[::-1])),
     }
 
     if allow_truncated and actual_length < expected_length:

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -77,15 +77,10 @@ def _encode_signals(signals: Sequence[Union["Signal", "Data"]],
 
         raw_value: Union[int, float]
         if scaling:
-            if not isinstance(value, (int, float, str, NamedSignalValue)):
-                raise TypeError(
-                    f"Unable to encode signal '{signal.name}' "
-                    f"of type '{type(value).__name__}'."
-                )
             raw_value = signal.scaled_to_raw(value)
         else:
             if isinstance(value, (str, NamedSignalValue)):
-                raw_value = signal.choice_string_to_number(value)
+                raw_value = signal.choice_to_number(value)
             elif not isinstance(value, (float, int)):
                 raise TypeError(
                     f"Unable to encode signal '{signal.name}' "

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -7,7 +7,6 @@ from typing import (
     TYPE_CHECKING,
     ByteString,
     Callable,
-    cast,
     Dict,
     Final,
     List,
@@ -16,6 +15,7 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+    cast,
 )
 
 from ..database.namedsignalvalue import NamedSignalValue

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -7,6 +7,7 @@ from typing import (
     TYPE_CHECKING,
     ByteString,
     Callable,
+    cast,
     Dict,
     Final,
     List,
@@ -154,14 +155,10 @@ def decode_data(data: ByteString,
                 raise
             continue
 
-        if decode_choices and signal.choices is not None and value in signal.choices:
-            decoded[signal.name] = signal.choices[value]
-            continue
-
         if scaling:
-            offset, scale = signal.offset, signal.scale
-            decoded[signal.name] = scale*value + offset
-            continue
+            decoded[signal.name] = signal.raw_to_scaled(value, decode_choices)
+        elif decode_choices and signal.choices is not None and value in signal.choices:
+            decoded[signal.name] = signal.choices[cast(int, value)]
         else:
             decoded[signal.name] = value
 

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -67,9 +67,9 @@ def start_bit(data: Union["Data", "Signal"]) -> int:
 
 
 def _encode_signals(signals: Sequence[Union["Signal", "Data"]],
-                   data: SignalMappingType,
-                   scaling: bool,
-                   ) -> Dict[str, Union[int, float]]:
+                    data: SignalMappingType,
+                    scaling: bool,
+                    ) -> Dict[str, Union[int, float]]:
     unpacked = {}
     for signal in signals:
         value = data[signal.name]
@@ -77,12 +77,13 @@ def _encode_signals(signals: Sequence[Union["Signal", "Data"]],
         if isinstance(value, (float, int)):
             _transform = float if signal.is_float else round
             if scaling:
-                if signal.offset == 0 and signal.scale == 1:
+                offset, scale = signal.offset, signal.scale
+                if offset == 0 and scale == 1:
                     # treat special case to avoid introduction of unnecessary rounding error
                     unpacked[signal.name] = _transform(value)  # type: ignore[operator]
                     continue
 
-                unpacked[signal.name] = _transform((value - signal.offset) / signal.scale)  # type: ignore[operator]
+                unpacked[signal.name] = _transform((value - offset) / scale)  # type: ignore[operator]
                 continue
 
             unpacked[signal.name] = _transform(value)  # type: ignore[operator]
@@ -162,7 +163,8 @@ def decode_data(data: bytes,
                     pass
 
             if scaling:
-                decoded[signal.name] = signal.scale * value + signal.offset
+                offset, scale = signal.offset, signal.scale
+                decoded[signal.name] = scale * value + offset
                 continue
             else:
                 decoded[signal.name] = value

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -5,7 +5,6 @@ import re
 from collections import OrderedDict
 from typing import (
     TYPE_CHECKING,
-    ByteString,
     Callable,
     Dict,
     Final,
@@ -113,7 +112,7 @@ def encode_data(data: SignalMappingType,
     return packed_union
 
 
-def decode_data(data: ByteString,
+def decode_data(data: bytes,
                 expected_length: int,
                 signals: Sequence[Union["Signal", "Data"]],
                 formats: Formats,

--- a/cantools/logreader.py
+++ b/cantools/logreader.py
@@ -2,7 +2,6 @@ import binascii
 import datetime
 import enum
 import re
-from typing import ByteString
 
 
 class TimestampFormat(enum.Enum):
@@ -20,7 +19,7 @@ class DataFrame:
 
     def __init__(self, channel: str,
                  frame_id: int,
-                 data: ByteString,
+                 data: bytes,
                  timestamp: datetime.datetime,
                  timestamp_format: TimestampFormat):
         """Constructor for DataFrame

--- a/cantools/logreader.py
+++ b/cantools/logreader.py
@@ -1,8 +1,8 @@
 import binascii
 import datetime
 import enum
-from typing import ByteString
 import re
+from typing import ByteString
 
 
 class TimestampFormat(enum.Enum):

--- a/cantools/logreader.py
+++ b/cantools/logreader.py
@@ -1,6 +1,7 @@
 import binascii
 import datetime
 import enum
+from typing import ByteString
 import re
 
 
@@ -19,7 +20,7 @@ class DataFrame:
 
     def __init__(self, channel: str,
                  frame_id: int,
-                 data: bytes,
+                 data: ByteString,
                  timestamp: datetime.datetime,
                  timestamp_format: TimestampFormat):
         """Constructor for DataFrame
@@ -32,7 +33,7 @@ class DataFrame:
         : """
         self.channel = channel
         self.frame_id = frame_id
-        self.data = data
+        self.data = bytes(data)
         self.timestamp = timestamp
         self.timestamp_format = timestamp_format
 

--- a/cantools/subparsers/__utils__.py
+++ b/cantools/subparsers/__utils__.py
@@ -1,7 +1,4 @@
-from typing import (
-    ByteString,
-    Iterable,
-)
+from typing import Iterable
 
 from ..database.can.database import Database
 from ..database.can.message import Message
@@ -106,7 +103,7 @@ def _format_container_multi_line(message : Message,
 
 def format_message_by_frame_id(dbase : Database,
                                frame_id : int,
-                               data : ByteString,
+                               data : bytes,
                                decode_choices : bool,
                                single_line : bool,
                                decode_containers : bool) -> str:
@@ -127,7 +124,7 @@ def format_message_by_frame_id(dbase : Database,
     return format_message(message, data, decode_choices, single_line)
 
 def format_container_message(message : Message,
-                             data : ByteString,
+                             data : bytes,
                              decode_choices : bool,
                              single_line : bool,
                              allow_truncated : bool = False) -> str:
@@ -153,7 +150,7 @@ def format_container_message(message : Message,
 
 
 def format_message(message : Message,
-                   data : ByteString,
+                   data : bytes,
                    decode_choices : bool,
                    single_line : bool,
                    allow_truncated : bool = False) -> str:
@@ -172,7 +169,7 @@ def format_message(message : Message,
         return _format_message_multi_line(message, formatted_signals)
 
 def format_multiplexed_name(message : Message,
-                            data : ByteString,
+                            data : bytes,
                             decode_choices : bool,
                             allow_truncated : bool = False) -> str:
     decoded_signals : SignalDictType \

--- a/cantools/subparsers/__utils__.py
+++ b/cantools/subparsers/__utils__.py
@@ -1,4 +1,5 @@
 from typing import (
+    ByteString,
     Iterable,
     Union,
 )
@@ -75,7 +76,7 @@ def _format_container_single_line(message : Message,
             data = unpacked_data[i][1]
             contained_list.append(
                 f'(Unknown contained message: Header ID: 0x{header_id:x}, '
-                f'Data: {data.hex()})')
+                f'Data: {bytes(data).hex()})')
 
     return f' {message.name}({", ".join(contained_list)})'
 
@@ -88,7 +89,7 @@ def _format_container_multi_line(message : Message,
         if isinstance(cm, Message):
             formatted_cm_signals = _format_signals(cm, signals)
             formatted_cm = f'{cm.header_id:06x}##'
-            formatted_cm += f'{unpacked_data[i][1].hex()} ::'
+            formatted_cm += f'{bytes(unpacked_data[i][1]).hex()} ::'
             formatted_cm += _format_message_multi_line(cm, formatted_cm_signals)
             formatted_cm = formatted_cm.replace('\n', '\n    ')
             contained_list.append('    '+formatted_cm.strip())
@@ -97,7 +98,7 @@ def _format_container_multi_line(message : Message,
             data = unpacked_data[i][1]
             contained_list.append(
                 f'    Unknown contained message (Header ID: 0x{header_id:x}, '
-                f'Data: {data.hex()})')
+                f'Data: {bytes(data).hex()})')
 
     return \
         f'\n{message.name}(\n' + \
@@ -106,7 +107,7 @@ def _format_container_multi_line(message : Message,
 
 def format_message_by_frame_id(dbase : Database,
                                frame_id : int,
-                               data : Union[bytes, bytearray],
+                               data : ByteString,
                                decode_choices : bool,
                                single_line : bool,
                                decode_containers : bool) -> str:
@@ -127,7 +128,7 @@ def format_message_by_frame_id(dbase : Database,
     return format_message(message, data, decode_choices, single_line)
 
 def format_container_message(message : Message,
-                             data : Union[bytes, bytearray],
+                             data : ByteString,
                              decode_choices : bool,
                              single_line : bool,
                              allow_truncated : bool = False) -> str:
@@ -153,7 +154,7 @@ def format_container_message(message : Message,
 
 
 def format_message(message : Message,
-                   data : Union[bytes, bytearray],
+                   data : ByteString,
                    decode_choices : bool,
                    single_line : bool,
                    allow_truncated : bool = False) -> str:
@@ -172,7 +173,7 @@ def format_message(message : Message,
         return _format_message_multi_line(message, formatted_signals)
 
 def format_multiplexed_name(message : Message,
-                            data : Union[bytes, bytearray],
+                            data : ByteString,
                             decode_choices : bool,
                             allow_truncated : bool = False) -> str:
     decoded_signals : SignalDictType \

--- a/cantools/subparsers/__utils__.py
+++ b/cantools/subparsers/__utils__.py
@@ -1,7 +1,6 @@
 from typing import (
     ByteString,
     Iterable,
-    Union,
 )
 
 from ..database.can.database import Database

--- a/cantools/typechecking.py
+++ b/cantools/typechecking.py
@@ -1,7 +1,6 @@
 from typing import (
     TYPE_CHECKING,
     Any,
-    ByteString,
     Callable,
     Dict,
     List,
@@ -52,8 +51,8 @@ SignalValueType = Union[int, float, str, "NamedSignalValue"]
 SignalDictType = Dict[str, SignalValueType]
 SignalMappingType = Mapping[str, SignalValueType]
 ContainerHeaderSpecType = Union["Message", str, int]
-ContainerUnpackResultType = Sequence[Union[Tuple["Message", ByteString], Tuple[int, ByteString]]]
-ContainerUnpackListType = List[Union[Tuple["Message", ByteString], Tuple[int, ByteString]]]
+ContainerUnpackResultType = Sequence[Union[Tuple["Message", bytes], Tuple[int, bytes]]]
+ContainerUnpackListType = List[Union[Tuple["Message", bytes], Tuple[int, bytes]]]
 ContainerDecodeResultType = Sequence[
     Union[Tuple["Message", SignalMappingType], Tuple[int, bytes]]
 ]
@@ -61,9 +60,9 @@ ContainerDecodeResultListType = List[
     Union[Tuple["Message", SignalDictType], Tuple[int, bytes]]
 ]
 ContainerEncodeInputType = Sequence[
-    Tuple[ContainerHeaderSpecType, Union[ByteString, SignalMappingType]]
+    Tuple[ContainerHeaderSpecType, Union[bytes, SignalMappingType]]
 ]
 DecodeResultType = Union[SignalDictType, ContainerDecodeResultType]
 EncodeInputType = Union[SignalMappingType, ContainerEncodeInputType]
 
-SecOCAuthenticatorFn = Callable[["Message", ByteString, int], ByteString]
+SecOCAuthenticatorFn = Callable[["Message", bytes, int], bytes]

--- a/cantools/typechecking.py
+++ b/cantools/typechecking.py
@@ -1,6 +1,7 @@
 from typing import (
     TYPE_CHECKING,
     Any,
+    ByteString,
     Callable,
     Dict,
     List,
@@ -51,8 +52,8 @@ SignalValueType = Union[int, float, str, "NamedSignalValue"]
 SignalDictType = Dict[str, SignalValueType]
 SignalMappingType = Mapping[str, SignalValueType]
 ContainerHeaderSpecType = Union["Message", str, int]
-ContainerUnpackResultType = Sequence[Union[Tuple["Message", bytes], Tuple[int, bytes]]]
-ContainerUnpackListType = List[Union[Tuple["Message", bytes], Tuple[int, bytes]]]
+ContainerUnpackResultType = Sequence[Union[Tuple["Message", ByteString], Tuple[int, ByteString]]]
+ContainerUnpackListType = List[Union[Tuple["Message", ByteString], Tuple[int, ByteString]]]
 ContainerDecodeResultType = Sequence[
     Union[Tuple["Message", SignalMappingType], Tuple[int, bytes]]
 ]
@@ -60,9 +61,9 @@ ContainerDecodeResultListType = List[
     Union[Tuple["Message", SignalDictType], Tuple[int, bytes]]
 ]
 ContainerEncodeInputType = Sequence[
-    Tuple[ContainerHeaderSpecType, Union[bytes, SignalMappingType]]
+    Tuple[ContainerHeaderSpecType, Union[ByteString, SignalMappingType]]
 ]
 DecodeResultType = Union[SignalDictType, ContainerDecodeResultType]
 EncodeInputType = Union[SignalMappingType, ContainerEncodeInputType]
 
-SecOCAuthenticatorFn = Callable[["Message", bytearray, int], bytearray]
+SecOCAuthenticatorFn = Callable[["Message", ByteString, int], ByteString]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -780,7 +780,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             (
                 'Message1',
                 3,
-                'Expected signal "Signal1" value less than or equal to 2 in '
+                'Expected signal "Signal1" value smaller than or equal to 2 in '
                 'message "Message1", but got 3.'
             ),
             (
@@ -792,7 +792,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             (
                 'Message3',
                 3,
-                'Expected signal "Signal1" value less than or equal to 2 in '
+                'Expected signal "Signal1" value smaller than or equal to 2 in '
                 'message "Message3", but got 3.'
             ),
             (
@@ -804,7 +804,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             (
                 'Message4',
                 8.1,
-                'Expected signal "Signal1" value less than or equal to 8 in '
+                'Expected signal "Signal1" value smaller than or equal to 8 in '
                 'message "Message4", but got 8.1.'
             )
         ]


### PR DESCRIPTION
this renames the `field` variables of the encoding and decoding utility functions back to `signal` and prepares them for piecewise linear functions.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)