### PR TITLE
Fix CAN-FD detection for dbc files

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -1566,10 +1566,8 @@ def _load_messages(tokens,
             except (KeyError, TypeError):
                 return None
 
-    def get_protocol(frame_id_dbc):
-        """Get protocol for a given message.
-
-        """
+    def get_frame_format(frame_id_dbc):
+        """Get frame format for a given message"""
 
         message_attributes = get_attributes(frame_id_dbc)
 
@@ -1581,6 +1579,15 @@ def _load_messages(tokens,
                 frame_format = definitions['VFrameFormat'].default_value
             except (KeyError, TypeError):
                 frame_format = None
+
+        return frame_format
+
+    def get_protocol(frame_id_dbc):
+        """Get protocol for a given message.
+
+        """
+
+        frame_format = get_frame_format(frame_id_dbc)
 
         if frame_format == 'J1939PG':
             return 'j1939'
@@ -1614,6 +1621,11 @@ def _load_messages(tokens,
         frame_id_dbc = int(message[1])
         frame_id = frame_id_dbc & 0x7fffffff
         is_extended_frame = bool(frame_id_dbc & 0x80000000)
+        frame_format = get_frame_format(frame_id_dbc)
+        if frame_format is not None:
+            is_fd = frame_format.endswith("CAN_FD")
+        else:
+            is_fd = False
 
         # Senders.
         senders = [_get_node_name(attributes, message[5])]
@@ -1664,7 +1676,8 @@ def _load_messages(tokens,
                     protocol=get_protocol(frame_id_dbc),
                     bus_name=bus_name,
                     signal_groups=get_signal_groups(frame_id_dbc),
-                    sort_signals=sort_signals))
+                    sort_signals=sort_signals,
+                    is_fd=is_fd))
 
     return messages
 

--- a/tests/files/dbc/fd_test.dbc
+++ b/tests/files/dbc/fd_test.dbc
@@ -1,0 +1,78 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_:
+
+
+BO_ 2147483651 TestMsg_Ex: 8 Vector__XXX
+ SG_ TestSig_Copy_1 : 0|8@1- (1,0) [0|0] "" Vector__XXX
+
+BO_ 2 TestMsg_Std: 8 Vector__XXX
+ SG_ TestSig_Copy_3 : 0|8@1- (1,0) [0|0] "" Vector__XXX
+
+BO_ 1 TestMsg_FDStd: 8 Vector__XXX
+ SG_ TestSig_Copy_2 : 0|8@1- (1,0) [0|0] "" Vector__XXX
+
+BO_ 2147483648 TestMsg_FDEx: 8 Vector__XXX
+ SG_ TestSig : 0|8@1- (1,0) [0|0] "" Vector__XXX
+
+
+
+BA_DEF_ BO_  "CANFD_BRS" ENUM  "0","1";
+BA_DEF_  "DBName" STRING ;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_ BU_  "NodeLayerModules" STRING ;
+BA_DEF_ BU_  "ECU" STRING ;
+BA_DEF_ BU_  "CANoeJitterMax" INT 0 0;
+BA_DEF_ BU_  "CANoeJitterMin" INT 0 0;
+BA_DEF_ BU_  "CANoeDrift" INT 0 0;
+BA_DEF_ BU_  "CANoeStartDelay" INT 0 0;
+BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","StandardCAN_FD","ExtendedCAN_FD";
+BA_DEF_DEF_  "CANFD_BRS" "1";
+BA_DEF_DEF_  "DBName" "";
+BA_DEF_DEF_  "BusType" "";
+BA_DEF_DEF_  "NodeLayerModules" "";
+BA_DEF_DEF_  "ECU" "";
+BA_DEF_DEF_  "CANoeJitterMax" 0;
+BA_DEF_DEF_  "CANoeJitterMin" 0;
+BA_DEF_DEF_  "CANoeDrift" 0;
+BA_DEF_DEF_  "CANoeStartDelay" 0;
+BA_DEF_DEF_  "VFrameFormat" "StandardCAN";
+BA_ "BusType" "CAN FD";
+BA_ "DBName" "fd_test";
+BA_ "VFrameFormat" BO_ 2147483651 1;
+BA_ "VFrameFormat" BO_ 1 14;
+BA_ "VFrameFormat" BO_ 2147483648 15;
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6397,6 +6397,26 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         self.assertNotIn('BA_ "SystemSignalLongSymbol"', long_output)
 
+    def test_fd_detection(self):
+        filename = "tests/files/dbc/fd_test.dbc"
+        db = cantools.db.load_file(filename)
+
+        msgfdex = db.get_message_by_name('TestMsg_FDEx')
+        self.assertEqual(True, msgfdex.is_fd)
+        self.assertEqual(True, msgfdex.is_extended_frame)
+
+        msgfdstd = db.get_message_by_name('TestMsg_FDStd')
+        self.assertEqual(True, msgfdstd.is_fd)
+        self.assertEqual(False, msgfdstd.is_extended_frame)
+
+        msgstd = db.get_message_by_name('TestMsg_Std')
+        self.assertEqual(False, msgstd.is_fd)
+        self.assertEqual(False, msgstd.is_extended_frame)
+
+        msgex = db.get_message_by_name('TestMsg_Ex')
+        self.assertEqual(False, msgex.is_fd)
+        self.assertEqual(True, msgex.is_extended_frame)
+
 
 # This file is not '__main__' when executed via 'python setup.py3
 # test'.


### PR DESCRIPTION
Properly populates the `is_fd` flag for messages loaded from dbc files. 

Also indirectly fixes the dbc file dump of previously loaded files that either contain FD frames or have values other than `StandardCAN` as a default in their frame format definition.