### PR TITLE
Signal: __init__: accept initial= as deprecated synonym for raw_initial=

### DIFF
--- a/cantools/database/can/signal.py
+++ b/cantools/database/can/signal.py
@@ -1,5 +1,6 @@
 # A CAN signal.
 import decimal
+import logging
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from ...typechecking import ByteOrder, Choices, Comments, SignalValueType
@@ -9,6 +10,7 @@ from ..namedsignalvalue import NamedSignalValue
 if TYPE_CHECKING:
     from ...database.can.formats.dbc import DbcSpecifics
 
+LOGGER = logging.getLogger(__name__)
 
 class Decimal:
     """Holds the same values as
@@ -137,8 +139,15 @@ class Signal:
         multiplexer_signal: Optional[str] = None,
         decimal: Optional[Decimal] = None,
         spn: Optional[int] = None,
+        initial: Optional[Union[int, float]] = None, # for backward compatibility
     ) -> None:
         # avoid using properties to improve encoding/decoding performance
+
+        if initial is not None:
+            if raw_initial is not None:
+                raise ValueError('cannot pass both initial= and raw_initial=')
+            LOGGER.warning('initial= is deprecated, use raw_initial=')
+            raw_initial = initial
 
         #: The signal name as a string.
         self.name: str = name

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -93,6 +93,15 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(i, 15)
         self.assert_dbc_dump(db, filename)
 
+    def test_signal_initial_synonym(self):
+        with self.assertLogs(logger=cantools.db.Signal.__module__,
+                             level='WARNING'):
+            s = cantools.db.Signal('foo', 0, 8, initial=47)
+        self.assertEqual(s.raw_initial, 47)
+
+        with self.assertRaises(ValueError):
+            cantools.db.Signal('foo', 0, 8, initial=47, raw_initial=47)
+
     def test_dbc_signal_initial_value(self):
         filename = 'tests/files/dbc/vehicle.dbc'
         db = cantools.database.load_file(filename)


### PR DESCRIPTION
I have code that creates DBC files from scratch that is broken by the rename of initial= to raw_initial= in be9abad6d3835b2b2fa55410dac29908e9347fbc. This PR adds initial= as a synonym for raw_initial which prints a deprecation warning.