### PR TITLE
set name option for multiplexer signal

### DIFF
--- a/cantools/database/can/formats/sym.py
+++ b/cantools/database/can/formats/sym.py
@@ -923,7 +923,7 @@ def _dump_message(message: Message, signals: List[Signal], min_frame_id: TypingO
         hex_multiplexer_id = format(multiplexer_id, 'x').upper()
         multiplexer_signal_name = multiplexer_signal.name
         if not multiplexer_signal_name:
-            multiplexer_signal_name = hex_multiplexer_id
+            raise ValueError(f"The name of the multiplexer signal with ID {str(hex_multiplexer_id)} is empty. The database is corrupt.")
         message_str += f'Mux="{multiplexer_signal_name}" {_convert_start(multiplexer_signal.start, multiplexer_signal.byte_order)},{multiplexer_signal.length} {hex_multiplexer_id}h {m_flag}\n'
     for signal in signals:
         message_str += f'Sig="{_get_signal_name(signal)}" {_convert_start(signal.start, signal.byte_order)}\n'

--- a/cantools/database/can/formats/sym.py
+++ b/cantools/database/can/formats/sym.py
@@ -921,7 +921,10 @@ def _dump_message(message: Message, signals: List[Signal], min_frame_id: TypingO
         if multiplexer_signal.byte_order == 'big_endian':
             m_flag = '-m'
         hex_multiplexer_id = format(multiplexer_id, 'x').upper()
-        message_str += f'Mux="{hex_multiplexer_id}" {_convert_start(multiplexer_signal.start, multiplexer_signal.byte_order)},{multiplexer_signal.length} {hex_multiplexer_id}h {m_flag}\n'
+        multiplexer_signal_name = hex_multiplexer_id
+        if multiplexer_signal.name != '':
+            multiplexer_signal_name = multiplexer_signal.name
+        message_str += f'Mux="{multiplexer_signal_name}" {_convert_start(multiplexer_signal.start, multiplexer_signal.byte_order)},{multiplexer_signal.length} {hex_multiplexer_id}h {m_flag}\n'
     for signal in signals:
         message_str += f'Sig="{_get_signal_name(signal)}" {_convert_start(signal.start, signal.byte_order)}\n'
     return message_str

--- a/cantools/database/can/formats/sym.py
+++ b/cantools/database/can/formats/sym.py
@@ -921,9 +921,9 @@ def _dump_message(message: Message, signals: List[Signal], min_frame_id: TypingO
         if multiplexer_signal.byte_order == 'big_endian':
             m_flag = '-m'
         hex_multiplexer_id = format(multiplexer_id, 'x').upper()
-        multiplexer_signal_name = hex_multiplexer_id
-        if multiplexer_signal.name != '':
-            multiplexer_signal_name = multiplexer_signal.name
+        multiplexer_signal_name = multiplexer_signal.name
+        if not multiplexer_signal_name:
+            multiplexer_signal_name = hex_multiplexer_id
         message_str += f'Mux="{multiplexer_signal_name}" {_convert_start(multiplexer_signal.start, multiplexer_signal.byte_order)},{multiplexer_signal.length} {hex_multiplexer_id}h {m_flag}\n'
     for signal in signals:
         message_str += f'Sig="{_get_signal_name(signal)}" {_convert_start(signal.start, signal.byte_order)}\n'

--- a/cantools/typechecking.py
+++ b/cantools/typechecking.py
@@ -32,14 +32,10 @@ class Formats(NamedTuple):
 
 StringPathLike = Union[str, "os.PathLike[str]"]
 Comments = Dict[Optional[str], str]
-Codec = TypedDict(
-    "Codec",
-    {
-        "signals": List["Signal"],
-        "formats": Formats,
-        "multiplexers": Mapping[str, Mapping[int, Any]],  # "Any" should be "Codec" (cyclic definition is not possible though)
-    },
-)
+class Codec(TypedDict):
+    signals: List["Signal"]
+    formats: Formats
+    multiplexers: Mapping[str, Mapping[int, Any]]
 
 ByteOrder = Literal["little_endian", "big_endian"]
 Choices = OrderedDict[int, Union[str, "NamedSignalValue"]]

--- a/tests/files/sym/test_multiplex_dump.sym
+++ b/tests/files/sym/test_multiplex_dump.sym
@@ -3,6 +3,7 @@ Title="Untitled"
 
 {SIGNALS}
 Sig=MultiplexedSig unsigned 8 /max:1
+Sig=NormalSig unsigned 8 /max:1
 
 {SENDRECEIVE}
 
@@ -11,3 +12,9 @@ ID=100h
 Len=8
 Mux=MultiplexorSig 0,16 002Ah
 Sig=MultiplexedSig 16
+
+[TestMultiplexer]
+ID=200h
+Len=8
+Mux=TestMultiplexerSignal 0,16 002Ah
+Sig=NormalSig 24

--- a/tests/files/sym/test_multiplex_dump.sym
+++ b/tests/files/sym/test_multiplex_dump.sym
@@ -3,7 +3,6 @@ Title="Untitled"
 
 {SIGNALS}
 Sig=MultiplexedSig unsigned 8 /max:1
-Sig=NormalSig unsigned 8 /max:1
 
 {SENDRECEIVE}
 
@@ -12,9 +11,3 @@ ID=100h
 Len=8
 Mux=MultiplexorSig 0,16 002Ah
 Sig=MultiplexedSig 16
-
-[TestMultiplexer]
-ID=200h
-Len=8
-Mux=TestMultiplexerSignal 0,16 002Ah
-Sig=NormalSig 24

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3411,7 +3411,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_multiplex_sym_dump(self):
         db = cantools.db.load_file('tests/files/sym/test_multiplex_dump.sym')
-        dumped_db = cantools.db.load_string(db.as_dbc_string())
+        dumped_db = cantools.db.load_string(db.as_sym_string())
 
         # message 1 MuxedFrame
         dumped_msg = dumped_db.get_message_by_frame_id(0x100)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3413,7 +3413,6 @@ class CanToolsDatabaseTest(unittest.TestCase):
         db = cantools.db.load_file('tests/files/sym/test_multiplex_dump.sym')
         dumped_db = cantools.db.load_string(db.as_sym_string())
 
-        # message 1 MuxedFrame
         dumped_msg = dumped_db.get_message_by_frame_id(0x100)
         self.assertEqual(dumped_msg.signals[0].name, "MultiplexorSig")
         self.assertEqual(dumped_msg.signals[0].is_multiplexer, True)
@@ -3422,19 +3421,10 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(dumped_msg.signals[1].is_multiplexer, False)
         self.assertEqual(dumped_msg.signals[1].multiplexer_ids[0], 0x2a)
 
-        # message 2 TestMultiplexer
-        test_multiplexer_msg = dumped_db.get_message_by_frame_id(0x200)
-        self.assertEqual(test_multiplexer_msg.signals[0].name, "TestMultiplexerSignal")
-        self.assertEqual(test_multiplexer_msg.signals[0].is_multiplexer, True)
-        self.assertEqual(test_multiplexer_msg.signals[0].multiplexer_ids, None)
-        self.assertEqual(test_multiplexer_msg.signals[1].name, "NormalSig")
-        self.assertEqual(test_multiplexer_msg.signals[1].is_multiplexer, False)
-        self.assertEqual(test_multiplexer_msg.signals[1].multiplexer_ids[0], 0x2a)
-
     def test_multiplex_sym_with_empty_signal_name_dump(self):
         db = cantools.db.load_file('tests/files/sym/test_multiplex_dump.sym')
         # change the name of the multiplexer signal to empty to trigger the condition in function _dump_message
-        db.messages[1].signals[0].name = ''
+        db.messages[0].signals[0].name = ''
         with self.assertRaises(ValueError) as context:
             cantools.db.load_string(db.as_sym_string())
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3426,12 +3426,12 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         # message 2 TestMultiplexer
         test_multiplexer_msg = dumped_db.get_message_by_frame_id(0x200)
-        self.assertEqual(dumped_msg.signals[0].name, "2A")
-        self.assertEqual(dumped_msg.signals[0].is_multiplexer, True)
-        self.assertEqual(dumped_msg.signals[0].multiplexer_ids, None)
-        self.assertEqual(dumped_msg.signals[1].name, "NormalSig")
-        self.assertEqual(dumped_msg.signals[1].is_multiplexer, False)
-        self.assertEqual(dumped_msg.signals[1].multiplexer_ids[0], 0x2a)
+        self.assertEqual(test_multiplexer_msg.signals[0].name, "2A")
+        self.assertEqual(test_multiplexer_msg.signals[0].is_multiplexer, True)
+        self.assertEqual(test_multiplexer_msg.signals[0].multiplexer_ids, None)
+        self.assertEqual(test_multiplexer_msg.signals[1].name, "NormalSig")
+        self.assertEqual(test_multiplexer_msg.signals[1].is_multiplexer, False)
+        self.assertEqual(test_multiplexer_msg.signals[1].multiplexer_ids[0], 0x2a)
 
 
     def test_string_attribute_definition_dump(self):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3414,7 +3414,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         dumped_db = cantools.db.load_string(db.as_sym_string())
         dumped_msg = dumped_db.get_message_by_frame_id(0x100)
 
-        self.assertEqual(dumped_msg.signals[0].name, "MultiplexedSig")
+        self.assertEqual(dumped_msg.signals[0].name, "MultiplexorSig")
         self.assertEqual(dumped_msg.signals[0].is_multiplexer, True)
         self.assertEqual(dumped_msg.signals[0].multiplexer_ids, None)
         self.assertEqual(dumped_msg.signals[1].name, "MultiplexedSig")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3411,9 +3411,10 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_multiplex_sym_dump(self):
         db = cantools.db.load_file('tests/files/sym/test_multiplex_dump.sym')
+        dumped_db = cantools.db.load_string(db.as_dbc_string())
 
         # message 1 MuxedFrame
-        dumped_msg = db.get_message_by_frame_id(0x100)
+        dumped_msg = dumped_db.get_message_by_frame_id(0x100)
         self.assertEqual(dumped_msg.signals[0].name, "MultiplexorSig")
         self.assertEqual(dumped_msg.signals[0].is_multiplexer, True)
         self.assertEqual(dumped_msg.signals[0].multiplexer_ids, None)
@@ -3422,7 +3423,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(dumped_msg.signals[1].multiplexer_ids[0], 0x2a)
 
         # message 2 TestMultiplexer
-        test_multiplexer_msg = db.get_message_by_frame_id(0x200)
+        test_multiplexer_msg = dumped_db.get_message_by_frame_id(0x200)
         self.assertEqual(test_multiplexer_msg.signals[0].name, "TestMultiplexerSignal")
         self.assertEqual(test_multiplexer_msg.signals[0].is_multiplexer, True)
         self.assertEqual(test_multiplexer_msg.signals[0].multiplexer_ids, None)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1896,10 +1896,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(symbol_3.signals), 4)
         self.assertSequenceEqual(symbol_3.senders, ['ECU', 'Peripherals'])
         multiplexer = symbol_3.signals[0]
-        if test_sym_string:
-            self.assertEqual(multiplexer.name, '0')
-        else:
-            self.assertEqual(multiplexer.name, 'Multiplexer1')
+        self.assertEqual(multiplexer.name, 'Multiplexer1')
         self.assertEqual(multiplexer.start, 0)
         self.assertEqual(multiplexer.length, 3)
         self.assertEqual(multiplexer.is_multiplexer, True)
@@ -3417,9 +3414,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         dumped_db = cantools.db.load_string(db.as_sym_string())
         dumped_msg = dumped_db.get_message_by_frame_id(0x100)
 
-        # Note: cantools database cannot support multiple multiplexer signal names, so SYM file names the multiplexer
-        # signal after the multiplexer id (Hence, 2A, not MultiplexerSig)
-        self.assertEqual(dumped_msg.signals[0].name, "2A")
+        self.assertEqual(dumped_msg.signals[0].name, "MultiplexedSig")
         self.assertEqual(dumped_msg.signals[0].is_multiplexer, True)
         self.assertEqual(dumped_msg.signals[0].multiplexer_ids, None)
         self.assertEqual(dumped_msg.signals[1].name, "MultiplexedSig")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3411,15 +3411,28 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_multiplex_sym_dump(self):
         db = cantools.db.load_file('tests/files/sym/test_multiplex_dump.sym')
+        # change the name of the multiplexer signal to empty to trigger the condition in function _dump_message
+        db.messages[1].signals[0].name = ''
         dumped_db = cantools.db.load_string(db.as_sym_string())
-        dumped_msg = dumped_db.get_message_by_frame_id(0x100)
 
+        # message 1 MuxedFrame
+        dumped_msg = dumped_db.get_message_by_frame_id(0x100)
         self.assertEqual(dumped_msg.signals[0].name, "MultiplexorSig")
         self.assertEqual(dumped_msg.signals[0].is_multiplexer, True)
         self.assertEqual(dumped_msg.signals[0].multiplexer_ids, None)
         self.assertEqual(dumped_msg.signals[1].name, "MultiplexedSig")
         self.assertEqual(dumped_msg.signals[1].is_multiplexer, False)
         self.assertEqual(dumped_msg.signals[1].multiplexer_ids[0], 0x2a)
+
+        # message 2 TestMultiplexer
+        test_multiplexer_msg = dumped_db.get_message_by_frame_id(0x200)
+        self.assertEqual(dumped_msg.signals[0].name, "2A")
+        self.assertEqual(dumped_msg.signals[0].is_multiplexer, True)
+        self.assertEqual(dumped_msg.signals[0].multiplexer_ids, None)
+        self.assertEqual(dumped_msg.signals[1].name, "NormalSig")
+        self.assertEqual(dumped_msg.signals[1].is_multiplexer, False)
+        self.assertEqual(dumped_msg.signals[1].multiplexer_ids[0], 0x2a)
+
 
     def test_string_attribute_definition_dump(self):
         db = cantools.db.load_file('tests/files/dbc/test_multiplex_dump.dbc')


### PR DESCRIPTION
The function `_dump_message` uses multiplexer signal id as the signal name. However, it might be incompatible in some platforms, such as the screenshot shown.

![image](https://github.com/cantools/cantools/assets/47024026/72571cad-6ed0-46ce-bd57-e8da42b6d2de)

In addition, using the ID as the name of the multiplexer signal is not clear enough for people to understand the meaning of this multiplexer. For this issue, I'd suggest that if the multiplexer signal has an original name, use the signal name rather than use the signal id.