### PR TITLE
Fix ImportError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ homepage = "https://github.com/eerimoq/cantools"
 documentation = "https://cantools.readthedocs.io/"
 repository = "https://github.com/eerimoq/cantools"
 
-[tool.setuptools]
-packages = ["cantools"]
+[tool.setuptools.packages.find]
+include = ["cantools*"]
 
 [tool.setuptools.package-data]
 cantools = ["py.typed"]


### PR DESCRIPTION
Closes #584 

Maybe we should switch to a `src/cantools` package structure in the future. The tests would have failed in this case.