### PR TITLE
Make cycle_time serialisation more consistent for DBC files

### DIFF
--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -451,7 +451,15 @@ class Message:
 
         """
 
-        return self._cycle_time
+        if self._cycle_time is not None or not self.dbc:
+            return self._cycle_time
+
+        # fall back to default cycle time for DBC files
+        try:
+            result = int(self.dbc.attribute_definitions['GenMsgCycleTime'].default_value)
+            return None if result == 0 else result
+        except (KeyError, TypeError):
+            return None
 
     @property
     def dbc(self) -> Optional['DbcSpecifics']:

--- a/tests/files/dbc/bus_comment_bare_out.dbc
+++ b/tests/files/dbc/bus_comment_bare_out.dbc
@@ -42,9 +42,6 @@ BU_:
 
 
 CM_ "Comment1Comment2";
-BA_DEF_ BO_  "GenMsgCycleTime" INT 0 65535;
-BA_DEF_DEF_  "GenMsgCycleTime" 0;
-
 
 
 

--- a/tests/files/dbc/comments_hex_and_motorola_converted_from_sym.dbc
+++ b/tests/files/dbc/comments_hex_and_motorola_converted_from_sym.dbc
@@ -58,8 +58,8 @@ CM_ SG_ 1568 sig22 "another comment for sig1=2";
 CM_ SG_ 1568 sig12 "another comment for sig1=1";
 CM_ SG_ 1568 sig1 "a comment";
 CM_ BO_ 1365 "test";
-BA_DEF_ BO_  "GenMsgCycleTime" INT 0 65535;
-BA_DEF_DEF_  "GenMsgCycleTime" 0;
+
+
 
 VAL_ 1365 Test7 1 "A" 2 "B" 3 "C" 4 "D" ;
 

--- a/tests/files/dbc/mod_name_len_dest.dbc
+++ b/tests/files/dbc/mod_name_len_dest.dbc
@@ -46,11 +46,9 @@ CM_ BU_ node_now_short "";
 BA_DEF_ BU_  "SystemNodeLongSymbol" STRING ;
 BA_DEF_ BO_  "SystemMessageLongSymbol" STRING ;
 BA_DEF_ SG_  "SystemSignalLongSymbol" STRING ;
-BA_DEF_ BO_  "GenMsgCycleTime" INT 0 65535;
 BA_DEF_DEF_  "SystemNodeLongSymbol" "";
 BA_DEF_DEF_  "SystemMessageLongSymbol" "";
 BA_DEF_DEF_  "SystemSignalLongSymbol" "";
-BA_DEF_DEF_  "GenMsgCycleTime" 0;
 
 
 


### PR DESCRIPTION
- Moves default fallback to the getter instead of the initial load from DBC
- Only creates the `GenMsgCycleTime` attribute if it's missing _and_ needed
- Doesn't serialise default values if they haven't been changed

It _feels_ like the current test suite is sufficient to validate this change, but feel free to request some more.

Closes #588, closes #540.