### PR TITLE
Add prog option to argparse for help messages

### DIFF
--- a/cantools/__init__.py
+++ b/cantools/__init__.py
@@ -49,6 +49,7 @@ def _load_subparser(subparser_name, subparsers):
 
 def _main():
     parser = argparse.ArgumentParser(
+        prog='cantools',
         description='Various CAN utilities.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )


### PR DESCRIPTION
When running cantools, depending on how it is launched, the help message will give different program names after the word `usage:` which can be set to a distinct name. Instead of deferring this to the default (os.path.basename(sys.argv[0])) in argparse, specify program name explicitly in argparse options.

## Before:
```
$ python -m cantools --help
usage: __main__.py [-h] [-d] [--version] {decode,monitor,plot,convert,dump,generate_c_source,list} ...

Various CAN utilities.
...
```

(pip installed)
```
$ cantools --help
usage: cantools [-h] [-d] [--version]
                {decode,monitor,dump,convert,generate_c_source} ...

Various CAN utilities.
...
```

## After:
```
$ python -m cantools --help
usage: cantools [-h] [-d] [--version] {decode,monitor,plot,convert,dump,generate_c_source,list} ...

Various CAN utilities.
...
```

(pip installed)
```
$ cantools --help
usage: cantools [-h] [-d] [--version] {decode,monitor,plot,convert,dump,generate_c_source,list} ...

Various CAN utilities.
...
```