### PR TITLE
Make ruff happy: Use format strings and isinstance where possible

### DIFF
--- a/cantools/database/__init__.py
+++ b/cantools/database/__init__.py
@@ -331,7 +331,7 @@ def load_string(string: str,
     if database_format not in ['arxml', 'dbc', 'kcd', 'sym', 'cdd', None]:
         raise ValueError(
             "expected database format 'arxml', 'dbc', 'kcd', 'sym', 'cdd' or "
-            "None, but got '{}'".format(database_format))
+            f"None, but got '{database_format}'")
 
     e_arxml = None
     e_dbc = None

--- a/cantools/database/can/formats/arxml/system_loader.py
+++ b/cantools/database/can/formats/arxml/system_loader.py
@@ -1783,7 +1783,7 @@ class SystemLoader:
             if len(numerators) != 2:
                 raise ValueError(
                     'Expected 2 numerator values for linear scaling, but '
-                    'got {}.'.format(len(numerators)))
+                    f'got {len(numerators)}.')
 
             denominators = self._get_arxml_children(compu_rational_coeffs,
                                                     ['&COMPU-DENOMINATOR', '*&V'])
@@ -1791,7 +1791,7 @@ class SystemLoader:
             if len(denominators) != 1:
                 raise ValueError(
                     'Expected 1 denominator value for linear scaling, but '
-                    'got {}.'.format(len(denominators)))
+                    f'got {len(denominators)}.')
 
             denominator = parse_number_string(denominators[0].text, True)
             factor = parse_number_string(numerators[1].text, True) / denominator

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -93,12 +93,12 @@ class Message:
         if is_extended_frame:
             if frame_id_bit_length > 29:
                 raise Error(
-                    'Extended frame id 0x{:x} is more than 29 bits in '
-                    'message {}.'.format(frame_id, name))
+                    f'Extended frame id 0x{frame_id:x} is more than 29 bits in '
+                    f'message {name}.')
         elif frame_id_bit_length > 11:
             raise Error(
-                'Standard frame id 0x{:x} is more than 11 bits in '
-                'message {}.'.format(frame_id, name))
+                f'Standard frame id 0x{frame_id:x} is more than 11 bits in '
+                f'message {name}.')
 
         self._frame_id = frame_id
         self._header_id = header_id

--- a/cantools/subparsers/__utils__.py
+++ b/cantools/subparsers/__utils__.py
@@ -110,7 +110,7 @@ def format_message_by_frame_id(dbase : Database,
     try:
         message = dbase.get_message_by_frame_id(frame_id)
     except KeyError:
-        return ' Unknown frame id {0} (0x{0:x})'.format(frame_id)
+        return f' Unknown frame id {frame_id} (0x{frame_id:x})'
 
     if message.is_container:
         if decode_containers:

--- a/cantools/subparsers/monitor.py
+++ b/cantools/subparsers/monitor.py
@@ -68,8 +68,8 @@ class Monitor(can.Listener):
                            **kwargs)
         except Exception as exc:
             raise Exception(
-                "Failed to create CAN bus with bustype='{}' and "
-                "channel='{}'.".format(args.bus_type, args.channel)
+                f"Failed to create CAN bus with bustype='{args.bus_type}' and "
+                f"channel='{args.channel}'."
             ) from exc
 
     def run(self, max_num_keys_per_tick=-1):

--- a/cantools/subparsers/plot.py
+++ b/cantools/subparsers/plot.py
@@ -428,7 +428,7 @@ class Plotter:
             if self.show_unknown_frames:
                 self.x_unknown_frames.append(timestamp)
             if not self.ignore_unknown_frames:
-                print('Unknown frame id {0} (0x{0:x})'.format(frame_id))
+                print(f'Unknown frame id {frame_id} (0x{frame_id:x})')
             return
 
         try:

--- a/cantools/tester.py
+++ b/cantools/tester.py
@@ -58,7 +58,7 @@ def _invert_signal_tree(
                 next_mpx[mpx_name] = mpx_val
                 _invert_signal_tree(sig_tree, next_mpx, ret)
 
-        elif type(sigs) == str:
+        elif isinstance(sigs, str):
             ret.setdefault(sigs,[]).append(set(cur_mpx.items()))
         else:
             raise TypeError(repr(sigs))


### PR DESCRIPTION
Make ruff happier by making suggested changes and using f-strings and isinstance where possible. Get the pipeline passing again.