### PR TITLE
Container improvements

### DIFF
--- a/examples/dbc_io/main.py
+++ b/examples/dbc_io/main.py
@@ -4,6 +4,7 @@
 #
 
 import os
+
 import cantools
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -11,7 +12,7 @@ INPUT_DBC_PATH = os.path.join(SCRIPT_DIR, 'dbc_input.dbc')
 OUTPUT_DBC_PATH = os.path.join(SCRIPT_DIR, 'dbc_output.dbc')
 
 # Read the DBC.
-print("Loading DBC database from '{}'.".format(INPUT_DBC_PATH))
+print(f"Loading DBC database from '{INPUT_DBC_PATH}'.")
 db = cantools.db.load_file(INPUT_DBC_PATH)
 
 # Get a message to manipulate.
@@ -31,7 +32,7 @@ print("Input frame id: ", hex(message.frame_id))
 message.frame_id = 0x234
 print("Output frame id:", hex(message.frame_id))
 
-print("Writing modified DBC database to '{}'.".format(OUTPUT_DBC_PATH))
+print(f"Writing modified DBC database to '{OUTPUT_DBC_PATH}'.")
 
 with open(OUTPUT_DBC_PATH, 'w', newline="\r\n") as fout:
     fout.write(db.as_dbc_string())

--- a/examples/diagnostics/did.py
+++ b/examples/diagnostics/did.py
@@ -8,8 +8,8 @@
 
 import os
 from binascii import hexlify
-import cantools
 
+import cantools
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 EXAMPLE_PATH = os.path.join(SCRIPT_DIR,

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -8,8 +8,8 @@
 
 import os
 from binascii import hexlify
-import cantools
 
+import cantools
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 MOTOHAWK_PATH = os.path.join(SCRIPT_DIR,

--- a/examples/motor_tester/main.py
+++ b/examples/motor_tester/main.py
@@ -4,9 +4,10 @@
 #
 
 import os
-import cantools
+
 import can
 
+import cantools
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 WASHING_MACHINE_KCD_PATH = os.path.join(SCRIPT_DIR, 'system.kcd')

--- a/examples/motor_tester/motor.py
+++ b/examples/motor_tester/motor.py
@@ -5,7 +5,9 @@
 #
 
 import struct
+
 import can
+
 
 def create_message(speed, load):
     return can.Message(arbitration_id=0x010,
@@ -25,7 +27,7 @@ def main():
 
         if message.arbitration_id == 0x011:
             speed = struct.unpack('<H', message.data)[0]
-            print('Received motor speed of {} rpm.'.format(speed))
+            print(f'Received motor speed of {speed} rpm.')
             task.modify_data(create_message(speed, 12))
 
             if message.data == b'\xff\xff':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,9 @@ windows-all = [
 cantools = "cantools.__init__:_main"
 
 [project.urls]
-homepage = "https://github.com/eerimoq/cantools"
+homepage = "https://github.com/cantools/cantools"
 documentation = "https://cantools.readthedocs.io/"
-repository = "https://github.com/eerimoq/cantools"
+repository = "https://github.com/cantools/cantools"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -1173,7 +1173,7 @@ class Message:
                                                    decode_containers=False,
                                                    allow_truncated=allow_truncated,
                                                    allow_excess=allow_excess)
-            except ValueError:
+            except (ValueError, DecodeError):
                 result.append((contained_message, bytes(contained_data)))
                 continue
 

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -851,15 +851,16 @@ class Message:
             if isinstance(value, bytes):
                 # raw data
 
-                # ensure that the size of the blob corresponds to the
-                # one specified by the featured message.
+                # produce a message if size of the blob does not
+                # correspond to the size specified by the message
+                # which it represents.
                 if contained_message is not None and \
-                   len(value) != contained_message.length:
+                    len(value) != contained_message.length:
 
-                    raise EncodeError(f'Specified data for contained message '
-                                      f'{contained_message.name} is '
-                                      f'{len(value)} bytes instead of '
-                                      f'{contained_message.length} bytes')
+                    LOGGER.info(f'Specified data for contained message '
+                                f'{contained_message.name} is '
+                                f'{len(value)} bytes instead of '
+                                f'{contained_message.length} bytes')
 
                 contained_payload = value
 

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -960,14 +960,16 @@ class Message:
                 data: bytes,
                 decode_choices: bool,
                 scaling: bool,
-                allow_truncated: bool) -> SignalDictType:
+                allow_truncated: bool,
+                allow_excess: bool) -> SignalDictType:
         decoded = decode_data(data,
                               self.length,
                               node['signals'],
                               node['formats'],
                               decode_choices,
                               scaling,
-                              allow_truncated)
+                              allow_truncated,
+                              allow_excess)
 
         multiplexers = node['multiplexers']
 
@@ -988,7 +990,8 @@ class Message:
                                         data,
                                         decode_choices,
                                         scaling,
-                                        allow_truncated))
+                                        allow_truncated,
+                                        allow_excess))
 
         return decoded
 
@@ -1060,7 +1063,8 @@ class Message:
                decode_choices: bool = True,
                scaling: bool = True,
                decode_containers: bool = False,
-               allow_truncated: bool = False
+               allow_truncated: bool = False,
+               allow_excess: bool = True,
                ) \
                -> DecodeResultType:
         """Decode given data as a message of this type.
@@ -1091,24 +1095,30 @@ class Message:
         ``False``, `DecodeError` will be raised when trying to decode
         incomplete messages.
 
+        If `allow_excess` is ``True``, data that is are longer than
+        the expected message length is decoded, else a `ValueError` is
+        raised if such data is encountered.
         """
 
         if decode_containers and self.is_container:
             return self.decode_container(data,
                                          decode_choices,
                                          scaling,
-                                         allow_truncated)
+                                         allow_truncated,
+                                         allow_excess)
 
         return self.decode_simple(data,
                                   decode_choices,
                                   scaling,
-                                  allow_truncated)
+                                  allow_truncated,
+                                  allow_excess)
 
     def decode_simple(self,
                       data: bytes,
                       decode_choices: bool = True,
                       scaling: bool = True,
-                      allow_truncated: bool = False) \
+                      allow_truncated: bool = False,
+                      allow_excess: bool = True) \
                       -> SignalDictType:
         """Decode given data as a container message.
 
@@ -1122,19 +1132,19 @@ class Message:
         elif self._codecs is None:
             raise ValueError('Codec is not initialized.')
 
-        data = bytes(data[:self._length])
-
         return self._decode(self._codecs,
                             data,
                             decode_choices,
                             scaling,
-                            allow_truncated)
+                            allow_truncated,
+                            allow_excess)
 
     def decode_container(self,
                          data: bytes,
                          decode_choices: bool = True,
                          scaling: bool = True,
-                         allow_truncated: bool = False) \
+                         allow_truncated: bool = False,
+                         allow_excess: bool = True) \
                          -> ContainerDecodeResultType:
         """Decode given data as a container message.
 
@@ -1155,10 +1165,17 @@ class Message:
                 result.append((contained_message, bytes(contained_data)))
                 continue
 
-            decoded = contained_message.decode(contained_data,
-                                               decode_choices,
-                                               scaling,
-                                               allow_truncated)
+            try:
+                decoded = contained_message.decode(contained_data,
+                                                   decode_choices,
+                                                   scaling,
+                                                   decode_containers=False,
+                                                   allow_truncated=allow_truncated,
+                                                   allow_excess=allow_excess)
+            except ValueError:
+                result.append((contained_message, bytes(contained_data)))
+                continue
+
             result.append((contained_message, decoded)) # type: ignore
 
         return result

--- a/src/cantools/database/diagnostics/did.py
+++ b/src/cantools/database/diagnostics/did.py
@@ -101,7 +101,8 @@ class Did:
                data,
                decode_choices=True,
                scaling=True,
-               allow_truncated=False):
+               allow_truncated=False,
+               allow_excess=True):
         """Decode given data as a DID of this type.
 
         If `decode_choices` is ``False`` scaled values are not
@@ -121,7 +122,8 @@ class Did:
                            self._codec['formats'],
                            decode_choices,
                            scaling,
-                           allow_truncated)
+                           allow_truncated,
+                           allow_excess)
 
     def refresh(self):
         """Refresh the internal DID state.

--- a/src/cantools/database/utils.py
+++ b/src/cantools/database/utils.py
@@ -150,9 +150,6 @@ def decode_data(data: bytes,
         **formats.little_endian.unpack(bytes(data[::-1])),
     }
 
-    if allow_truncated and not (scaling or decode_choices):
-        return unpacked
-
     if allow_truncated and actual_length < expected_length:
         # remove signals that are outside available data bytes
         actual_bit_count = actual_length * 8

--- a/src/cantools/database/utils.py
+++ b/src/cantools/database/utils.py
@@ -127,25 +127,20 @@ def decode_data(data: bytes,
                 ) -> SignalDictType:
 
     actual_length = len(data)
-
     if actual_length != expected_length:
-        if actual_length < expected_length:
-            if not allow_truncated:
-                 raise ValueError(f"Wrong data size: {actual_length} instead of "
-                                  f"{expected_length} bytes")
-            else:
-                # pad the data with 0xff to prevent the codec from
-                # raising an exception. Note that all signals
-                # that contain garbage will be removed below.
-                data = data.ljust(expected_length, b"\xFF")
+        if allow_truncated:
+            # pad the data with 0xff to prevent the codec from
+            # raising an exception. Note that all signals
+            # that contain garbage will be removed below.
+            data = data.ljust(expected_length, b"\xFF")
 
-        if actual_length > expected_length:
-            if not allow_excess:
-                raise ValueError(f"Wrong data size: {actual_length} instead of "
-                                 f"{expected_length} bytes")
-            else:
-                # trim the payload data to match the expected size
-                data = data[:expected_length]
+        if allow_excess:
+            # trim the payload data to match the expected size
+            data = data[:expected_length]
+
+        if len(data) != expected_length:
+            raise ValueError(f"Wrong data size: {actual_length} instead of "
+                             f"{expected_length} bytes")
 
     unpacked = {
         **formats.big_endian.unpack(data),

--- a/src/cantools/database/utils.py
+++ b/src/cantools/database/utils.py
@@ -148,8 +148,8 @@ def decode_data(data: bytes,
                 data = data[:expected_length]
 
     unpacked = {
-        **formats.big_endian.unpack(bytes(data)),
-        **formats.little_endian.unpack(bytes(data[::-1])),
+        **formats.big_endian.unpack(data),
+        **formats.little_endian.unpack(data[::-1]),
     }
 
     if actual_length < expected_length and allow_truncated:

--- a/src/cantools/subparsers/decode.py
+++ b/src/cantools/subparsers/decode.py
@@ -17,6 +17,8 @@ def _do_decode(args):
                                strict=not args.no_strict)
     decode_choices = not args.no_decode_choices
     decode_containers = not args.no_decode_containers
+    allow_truncated = args.no_strict
+    allow_excess = args.no_strict
     parser = logreader.Parser(sys.stdin)
     for line, frame in parser.iterlines(keep_unknowns=True):
         if frame is not None:
@@ -26,7 +28,9 @@ def _do_decode(args):
                                                frame.data,
                                                decode_choices,
                                                args.single_line,
-                                               decode_containers)
+                                               decode_containers,
+                                               allow_truncated=allow_truncated,
+                                               allow_excess=allow_excess)
 
         print(line)
 

--- a/src/cantools/subparsers/monitor.py
+++ b/src/cantools/subparsers/monitor.py
@@ -383,7 +383,11 @@ class Monitor(can.Listener):
             # case, we just discard the message, like we do when the CAN
             # message ID or length doesn't match what's specified in the DBC.
             try:
-                name = format_multiplexed_name(message, data, True)
+                name = format_multiplexed_name(message,
+                                               data,
+                                               decode_choices=True,
+                                               allow_truncated=True,
+                                               allow_excess=True)
             except database.DecodeError:
                 formatted = [
                     f'{timestamp:12.3f} {message.name} '
@@ -395,10 +399,20 @@ class Monitor(can.Listener):
 
         if self._single_line:
             formatted = [
-                f'{timestamp:12.3f} {format_message(message, data, True, True)}'
+                f'''{timestamp:12.3f} {format_message(message,
+                                                      data,
+                                                      decode_choices=True,
+                                                      single_line=self._single_line,
+                                                      allow_truncated=True,
+                                                      allow_excess=True)}'''
             ]
         else:
-            formatted = format_message(message, data, True, False)
+            formatted = format_message(message,
+                                       data,
+                                       decode_choices=True,
+                                       single_line=self._single_line,
+                                       allow_truncated=True,
+                                       allow_excess=True)
             lines = formatted.splitlines()
             formatted = [f'{timestamp:12.3f}  {lines[1]}']
             formatted += [14 * ' ' + line for line in lines[2:]]
@@ -486,8 +500,10 @@ class Monitor(can.Listener):
                 full_name = f'{dbmsg.name} :: {cmsg.name}'
                 formatted = format_message(cmsg,
                                            data,
-                                           True,
-                                           False)
+                                           decode_choices=True,
+                                           single_line=self._single_line,
+                                           allow_truncated=True,
+                                           allow_excess=True)
                 lines = formatted.splitlines()
                 formatted = [f'{timestamp:12.3f}  {full_name}(']
                 formatted += [14 * ' ' + line for line in lines[2:]]

--- a/src/cantools/typechecking.py
+++ b/src/cantools/typechecking.py
@@ -50,10 +50,10 @@ ContainerHeaderSpecType = Union["Message", str, int]
 ContainerUnpackResultType = Sequence[Union[Tuple["Message", bytes], Tuple[int, bytes]]]
 ContainerUnpackListType = List[Union[Tuple["Message", bytes], Tuple[int, bytes]]]
 ContainerDecodeResultType = Sequence[
-    Union[Tuple["Message", SignalMappingType], Tuple[int, bytes]]
+    Union[Tuple["Message", SignalMappingType], Tuple["Message", bytes], Tuple[int, bytes]]
 ]
 ContainerDecodeResultListType = List[
-    Union[Tuple["Message", SignalDictType], Tuple[int, bytes]]
+    Union[Tuple["Message", SignalDictType], Tuple["Message", bytes], Tuple[int, bytes]]
 ]
 ContainerEncodeInputType = Sequence[
     Tuple[ContainerHeaderSpecType, Union[bytes, SignalMappingType]]

--- a/tests/test_autosar.py
+++ b/tests/test_autosar.py
@@ -1,12 +1,11 @@
 # unit tests for the autosar specifics of message and database objects
 # (message.autosar and db.autosar)
 import unittest
-import traceback
 
 import cantools
 import cantools.autosar
-
 from cantools.autosar.snakeauth import SnakeOilAuthenticator
+
 
 class CanToolsAutosarTest(unittest.TestCase):
     def test_autosar3_e2e_profile2(self):
@@ -163,6 +162,7 @@ class CanToolsAutosarTest(unittest.TestCase):
 
         self.assertEqual(encoded, bytes.fromhex('000000003130'))
 
+        print(f"{encoded}")
         decoded = dbmsg.decode(encoded)
         self.assertEqual(decoded['Message3_Freshness'], 0xcccc&0x3f)
         self.assertEqual(decoded['Message3_Authenticator'], 304)

--- a/tests/test_autosar.py
+++ b/tests/test_autosar.py
@@ -162,7 +162,6 @@ class CanToolsAutosarTest(unittest.TestCase):
 
         self.assertEqual(encoded, bytes.fromhex('000000003130'))
 
-        print(f"{encoded}")
         decoded = dbmsg.decode(encoded)
         self.assertEqual(decoded['Message3_Freshness'], 0xcccc&0x3f)
         self.assertEqual(decoded['Message3_Authenticator'], 304)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -7,10 +7,7 @@ import types
 import unittest
 from pathlib import Path
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from unittest.mock import patch
+from unittest.mock import patch
 
 try:
     from StringIO import StringIO

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1,16 +1,16 @@
-import sys
+import functools
 import os
 import re
+import sys
 import tempfile
-import unittest
 import types
-import functools
+import unittest
 from pathlib import Path
 
 try:
     from unittest.mock import patch
 except ImportError:
-    from mock import patch
+    from unittest.mock import patch
 
 try:
     from StringIO import StringIO
@@ -55,7 +55,7 @@ def remove_date_time(string):
 
 
 def read_file(filename):
-    with open(filename, 'r') as fin:
+    with open(filename) as fin:
         return remove_date_time(fin.read())
 
 
@@ -64,7 +64,7 @@ def read_utf8_file(filename):
 
     """
 
-    with open(filename, 'r', encoding='utf-8') as fin:
+    with open(filename, encoding='utf-8') as fin:
         return remove_date_time(fin.read())
 
 
@@ -96,10 +96,7 @@ SENSOR_SONARS(
     SENSOR_SONARS_right: 0.0,
     SENSOR_SONARS_rear: 0.0
 )
-  vcan0  064   [10]  F0 01 FF FF FF FF FF FF FF FF ::
-DRIVER_HEARTBEAT(
-    DRIVER_HEARTBEAT_cmd: 240
-)
+  vcan0  064   [10]  F0 01 FF FF FF FF FF FF FF FF :: Wrong data size: 10 instead of 1 bytes
   vcan0  ERROR
 
   vcan0  1F4   [4]  01 02 03 04 ::
@@ -145,10 +142,7 @@ SENSOR_SONARS(
     SENSOR_SONARS_right: 0.0,
     SENSOR_SONARS_rear: 0.0
 )
- (2020-12-19 12:04:48.597222)  vcan0  064   [8]  F0 01 FF FF FF FF FF FF ::
-DRIVER_HEARTBEAT(
-    DRIVER_HEARTBEAT_cmd: 240
-)
+ (2020-12-19 12:04:48.597222)  vcan0  064   [8]  F0 01 FF FF FF FF FF FF :: Wrong data size: 8 instead of 1 bytes
  (2020-12-19 12:04:56.805087)  vcan0  1F4   [4]  01 02 03 04 ::
 IO_DEBUG(
     IO_DEBUG_test_unsigned: 1,
@@ -192,10 +186,7 @@ SENSOR_SONARS(
     SENSOR_SONARS_right: 0.0,
     SENSOR_SONARS_rear: 0.0
 )
- (002.047817)  vcan0  064   [8]  F0 01 FF FF FF FF FF FF ::
-DRIVER_HEARTBEAT(
-    DRIVER_HEARTBEAT_cmd: 240
-)
+ (002.047817)  vcan0  064   [8]  F0 01 FF FF FF FF FF FF :: Wrong data size: 8 instead of 1 bytes
  (012.831664)  vcan0  1F4   [4]  01 02 03 04 ::
 IO_DEBUG(
     IO_DEBUG_test_unsigned: 1,
@@ -264,10 +255,7 @@ SENSOR_SONARS(
     SENSOR_SONARS_right: 0.0,
     SENSOR_SONARS_rear: 0.0
 )
-(1594172462.126542) vcan0 064#F001FFFFFFFFFFFFFFFF ::
-DRIVER_HEARTBEAT(
-    DRIVER_HEARTBEAT_cmd: 240
-)
+(1594172462.126542) vcan0 064#F001FFFFFFFFFFFFFFFF :: Wrong data size: 10 instead of 1 bytes
 (1594172462.127684) vcan0 ERROR
 
 (1594172462.356874) vcan0 1F4#01020304 ::
@@ -309,7 +297,7 @@ IO_DEBUG(
 
         expected_output = """\
   vcan0  0C8   [8]  F0 00 00 00 00 00 00 00 :: SENSOR_SONARS(SENSOR_SONARS_mux: 0, SENSOR_SONARS_err_count: 15, SENSOR_SONARS_left: 0.0, SENSOR_SONARS_middle: 0.0, SENSOR_SONARS_right: 0.0, SENSOR_SONARS_rear: 0.0)
-  vcan0  064   [10]  F0 01 FF FF FF FF FF FF FF FF :: DRIVER_HEARTBEAT(DRIVER_HEARTBEAT_cmd: 240)
+  vcan0  064   [10]  F0 01 FF FF FF FF FF FF FF FF :: Wrong data size: 10 instead of 1 bytes
   vcan0  ERROR
 
   vcan0  1F4   [4]  01 02 03 04 :: IO_DEBUG(IO_DEBUG_test_unsigned: 1, IO_DEBUG_test_enum: two, IO_DEBUG_test_signed: 3, IO_DEBUG_test_float: 2.0)
@@ -345,7 +333,7 @@ IO_DEBUG(
 
         expected_output = """\
 (1594172461.968006) vcan0 0C8#F000000000000000 :: SENSOR_SONARS(SENSOR_SONARS_mux: 0, SENSOR_SONARS_err_count: 15, SENSOR_SONARS_left: 0.0, SENSOR_SONARS_middle: 0.0, SENSOR_SONARS_right: 0.0, SENSOR_SONARS_rear: 0.0)
-(1594172462.126542) vcan0 064#F001FFFFFFFFFFFFFFFF :: DRIVER_HEARTBEAT(DRIVER_HEARTBEAT_cmd: 240)
+(1594172462.126542) vcan0 064#F001FFFFFFFFFFFFFFFF :: Wrong data size: 10 instead of 1 bytes
 (1594172462.127684) vcan0 ERROR
 
 (1594172462.356874) vcan0 1F4#01020304 :: IO_DEBUG(IO_DEBUG_test_unsigned: 1, IO_DEBUG_test_enum: two, IO_DEBUG_test_signed: 3, IO_DEBUG_test_float: 2.0)
@@ -1281,7 +1269,7 @@ BATTERY_VT(
                 argv = [
                     'cantools',
                     'generate_c_source',
-                    'tests/files/dbc/{}.dbc'.format(database),
+                    f'tests/files/dbc/{database}.dbc',
                     '-o',
                     str(tmpdir),
                 ]
@@ -1317,7 +1305,7 @@ BATTERY_VT(
                     'cantools',
                     'generate_c_source',
                     '--no-floating-point-numbers',
-                    'tests/files/dbc/{}.dbc'.format(database),
+                    f'tests/files/dbc/{database}.dbc',
                     '-o',
                     str(tmpdir),
                 ]
@@ -1356,7 +1344,7 @@ BATTERY_VT(
                     'generate_c_source',
                     '--no-floating-point-numbers',
                     '--node', node,
-                    'tests/files/dbc/{}.dbc'.format(database),
+                    f'tests/files/dbc/{database}.dbc',
                     '-o',
                     str(tmpdir),
                 ]
@@ -1387,7 +1375,7 @@ BATTERY_VT(
                     'cantools',
                     'generate_c_source',
                     '--database-name', 'my_database_name',
-                    'tests/files/dbc/{}.dbc'.format(database),
+                    f'tests/files/dbc/{database}.dbc',
                     '-o',
                     str(tmpdir),
                 ]
@@ -1409,7 +1397,7 @@ BATTERY_VT(
         argv = [
             'cantools',
             'generate_c_source',
-            'tests/files/dbc/{}.dbc'.format(database)
+            f'tests/files/dbc/{database}.dbc'
         ]
 
         database_h = database + '.h'
@@ -1444,8 +1432,8 @@ BATTERY_VT(
                     'cantools',
                     'generate_c_source',
                     '--bit-fields',
-                    '--database-name', '{}_bit_fields'.format(database),
-                    'tests/files/dbc/{}.dbc'.format(database),
+                    '--database-name', f'{database}_bit_fields',
+                    f'tests/files/dbc/{database}.dbc',
                     '-o',
                     str(tmpdir),
                 ]
@@ -1479,7 +1467,7 @@ BATTERY_VT(
                     'cantools',
                     'generate_c_source',
                     '--node', node,
-                    'tests/files/dbc/{}.dbc'.format(database),
+                    f'tests/files/dbc/{database}.dbc',
                     '-o',
                     str(tmpdir),
                 ]
@@ -1545,7 +1533,7 @@ BATTERY_VT(
                 argv = [
                     'cantools',
                     'generate_c_source',
-                    'tests/files/sym/{}.sym'.format(database),
+                    f'tests/files/sym/{database}.sym',
                     '-o',
                     str(tmpdir),
                 ]

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,5 +1,6 @@
 import unittest
 from collections import OrderedDict
+from typing import TYPE_CHECKING
 
 from cantools.database.conversion import (
     BaseConversion,
@@ -9,7 +10,9 @@ from cantools.database.conversion import (
     NamedSignalConversion,
 )
 from cantools.database.namedsignalvalue import NamedSignalValue
-from cantools.typechecking import Choices
+
+if TYPE_CHECKING:
+    from cantools.typechecking import Choices
 
 
 class TestConversions(unittest.TestCase):
@@ -48,7 +51,7 @@ class TestConversions(unittest.TestCase):
         assert conversion.choices == choices
 
         # Test the error handling
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(TypeError):
             BaseConversion.factory(scale="2", offset="3")
 
     def test_identity_conversion(self):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4,13 +4,12 @@ import math
 import os
 import re
 import shutil
-import textparser
 import timeit
 import unittest
-
-from collections import OrderedDict, namedtuple
-from typing import Any
+from collections import namedtuple
 from xml.etree import ElementTree
+
+import textparser
 
 import cantools.autosar
 from cantools.database.utils import sort_choices_by_value, sort_signals_by_name
@@ -23,7 +22,6 @@ except ImportError:
 import cantools
 from cantools.database import Message, Signal, UnsupportedDatabaseFormatError
 from cantools.database.can.formats import dbc
-
 
 
 class CanToolsDatabaseTest(unittest.TestCase):
@@ -59,13 +57,13 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def assert_sym_equal(self, db):
         sym_str = db.as_sym_string()
-        sym_db = cantools.database.load_string(sym_str)
+        cantools.database.load_string(sym_str)
 
         self.assertTrue(db.is_similar(db, include_format_specifics=False))
 
     def assert_kcd_equal(self, db):
         kcd_str = db.as_kcd_string()
-        kcd_db = cantools.database.load_string(kcd_str)
+        cantools.database.load_string(kcd_str)
 
         self.assertTrue(db.is_similar(db, include_format_specifics=False))
 
@@ -5699,8 +5697,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         # write access to version attribute
         my_version = "my_version"
         db.version = my_version
-        self.assertTrue(db.as_dbc_string().startswith('VERSION "{}"'.
-                                                      format(my_version)))
+        self.assertTrue(db.as_dbc_string().startswith(f'VERSION "{my_version}"'))
 
     def test_dbc_modify_names(self):
         """Test that modified object names are dumped correctly to dbc.

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -1,9 +1,13 @@
-# -*- coding: utf-8 -*-
 
-from parameterized import parameterized
 import unittest
 
-from cantools.database.utils import sawtooth_to_network_bitnum, cdd_offset_to_dbc_start_bit
+from parameterized import parameterized
+
+from cantools.database.utils import (
+    cdd_offset_to_dbc_start_bit,
+    sawtooth_to_network_bitnum,
+)
+
 
 class CanToolsDatabaseUtilsTest(unittest.TestCase):
 

--- a/tests/test_diagnostics_database.py
+++ b/tests/test_diagnostics_database.py
@@ -1,6 +1,5 @@
-import os
-import unittest
 import logging
+import unittest
 
 import cantools
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 
-import unittest
 import logging
+import unittest
 
 import cantools
 from cantools.subparsers.dump import formatting

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,16 +1,10 @@
 import unittest
-import traceback
 
 try:
-    from unittest.mock import Mock
-    from unittest.mock import patch
-    from unittest.mock import call
+    from unittest.mock import Mock, call, patch
 except ImportError:
-    from mock import Mock
-    from mock import patch
-    from mock import call
+    from unittest.mock import patch
 
-import can
 import cantools.subparsers.list as list_module
 
 try:
@@ -18,7 +12,7 @@ try:
 except ImportError:
     from io import StringIO
 
-class Args(object):
+class Args:
 
     def __init__(self, input_file_name):
         self.exclude_normal = False

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,9 +1,6 @@
 import unittest
 
-try:
-    from unittest.mock import Mock, call, patch
-except ImportError:
-    from unittest.mock import patch
+from unittest.mock import Mock, call, patch
 
 import cantools.subparsers.list as list_module
 

--- a/tests/test_logreader.py
+++ b/tests/test_logreader.py
@@ -1,5 +1,5 @@
-import unittest
 import io
+import unittest
 
 import cantools
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -10,10 +10,7 @@ except (ImportError, ModuleNotFoundError):
     # available, though)
     have_curses = False
 
-try:
-    from unittest.mock import Mock, call, patch
-except ImportError:
-    from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, call, patch
 
 import can
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,30 +1,27 @@
-import unittest
 import traceback
+import unittest
 
 try:
     import curses
     have_curses = True
-except (ImportError, ModuleNotFoundError) as e:
+except (ImportError, ModuleNotFoundError):
     # on windows, the batteries for the curses package are not
     # included by default (there is a "windows-curses" package
     # available, though)
     have_curses = False
 
 try:
-    from unittest.mock import Mock
-    from unittest.mock import patch
-    from unittest.mock import call
+    from unittest.mock import Mock, call, patch
 except ImportError:
-    from mock import Mock
-    from mock import patch
-    from mock import call
+    from unittest.mock import Mock, call, patch
 
 import can
+
 if have_curses:
     from cantools.subparsers.monitor import Monitor
 
 
-class Args(object):
+class Args:
 
     def __init__(self,
                  database,
@@ -41,7 +38,7 @@ class Args(object):
         self.channel = 'vcan0'
 
 
-class StdScr(object):
+class StdScr:
 
     def __init__(self, user_input=None, resolution=None):
         if resolution is None:
@@ -76,8 +73,8 @@ class CanToolsMonitorTest(unittest.TestCase):
             if verbose:
                 nl = ",\n "
                 print(f"Assertion failed:")
-                print(f"Expected: {nl.join(map(lambda x: str(x), expected))}")
-                print(f"Got: {nl.join(map(lambda x: str(x), mock.call_args_list))}")
+                print(f"Expected: {nl.join((str(x) for x in expected))}")
+                print(f"Got: {nl.join((str(x) for x in mock.call_args_list))}")
                 print("Traceback:")
                 traceback.print_stack()
             raise e
@@ -735,7 +732,7 @@ class CanToolsMonitorTest(unittest.TestCase):
                 call(29, 0, 'Filter regex: ', 'cyan'),
                 call(29, 14, ' ', 'cyan inverted'),
                 call(29, 15, '                                                 ', 'cyan'),
-                
+
                 # 'E' pressed.
                 call(0, 0, 'Received: 2, Discarded: 1, Errors: 0, Filter: E'),
                 call(1, 0, '   TIMESTAMP  MESSAGE                                           ', 'green'),

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 
-import os
-import sys
 import datetime
+import logging
+import os
 import re
 import unittest
-from unittest import mock
 from io import StringIO
+from unittest import mock
+
 import cantools
-import matplotlib.pyplot
-import logging
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -59,7 +58,7 @@ class SubplotMock(mock.Mock):
         self.__ignore_color = kw.pop('ignore_color', ignore)
 
         key_pattern = 'ignore_%s'
-        self.__kw = dict()
+        self.__kw = {}
         for a in self._ATTRIBUTES_WHICH_CAN_BE_IGNORED:
             key = key_pattern % a
             if kw.pop(key, ignore):
@@ -69,7 +68,7 @@ class SubplotMock(mock.Mock):
                 self.__kw[key] = False
 
         if kw:
-            raise TypeError("%s() got unexpected keyword argument(s): %s" % (type(self).__name__, ', '.join('%r'%key for key in kw.keys())))
+            raise TypeError("{}() got unexpected keyword argument(s): {}".format(type(self).__name__, ', '.join('%r'%key for key in kw.keys())))
 
         if parent:
             parent.attach_mock(self, 'subplot()')
@@ -822,7 +821,7 @@ BREMSE_33(
 """
 
         db = cantools.db.load_file(self.DBC_FILE_CHOICES)
-        choices = db.get_message_by_name("Foo").get_signal_by_name("Foo").choices
+        db.get_message_by_name("Foo").get_signal_by_name("Foo").choices
 
         xs  = self.parse_time(input_data, self.parse_absolute_time)
         ys = [1, 2, -5, 5, 0, 2, 5, 0, 2, 6]
@@ -2083,7 +2082,6 @@ Failed to parse line: 'invalid syntax'
         ]]
 
         stdout = StringIO()
-        expected_output = ""
 
         with mock.patch('sys.stdin', StringIO(input_data)):
             with mock.patch('sys.stdout', stdout):
@@ -2128,7 +2126,6 @@ Failed to parse line: 'invalid syntax'
         ]
 
         stdout = StringIO()
-        expected_output = ""
 
         with mock.patch('sys.stdin', StringIO(input_data)):
             with mock.patch('sys.stdout', stdout):
@@ -2172,7 +2169,6 @@ Failed to parse line: 'invalid syntax'
         ]
 
         stdout = StringIO()
-        expected_output = ""
 
         with mock.patch('sys.stdin', StringIO(input_data)):
             with mock.patch('sys.stdout', stdout):

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -821,7 +821,6 @@ BREMSE_33(
 """
 
         db = cantools.db.load_file(self.DBC_FILE_CHOICES)
-        db.get_message_by_name("Foo").get_signal_by_name("Foo").choices
 
         xs  = self.parse_time(input_data, self.parse_absolute_time)
         ys = [1, 2, -5, 5, 0, 2, 5, 0, 2, 6]

--- a/tests/test_plot_unittests.py
+++ b/tests/test_plot_unittests.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-import unittest
 import datetime
+import unittest
 
 import cantools.subparsers.plot as plot
+
 
 class CanToolsPlotUnittests(unittest.TestCase):
 

--- a/tests/test_plot_without_mock.py
+++ b/tests/test_plot_without_mock.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
 import os
-import sys
 import unittest
-from unittest import mock
 from io import StringIO
-import cantools
+from unittest import mock
+
 import matplotlib.pyplot as plt
+
+import cantools
 
 
 class CanToolsPlotTest(unittest.TestCase):

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -1,14 +1,12 @@
 import time
-import os
 import unittest
+
 import can
 
 try:
-    from queue import Queue
-    from queue import Empty
+    from queue import Empty, Queue
 except ImportError:
-    from Queue import Queue
-    from Queue import Empty
+    from Queue import Empty, Queue
 
 import cantools
 

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -3,10 +3,7 @@ import unittest
 
 import can
 
-try:
-    from queue import Empty, Queue
-except ImportError:
-    from Queue import Empty, Queue
+from queue import Empty, Queue
 
 import cantools
 


### PR DESCRIPTION
This pull request mainly contains a few improvements for working with container frames:

- The output of the `decode` utility is now quite a bit nicer (IMO)
- When encoding container frames and specifying the binary payload of child frames directly, the data do no longer needs to exhibit to the size specified by the message description (instead of raising an exception, a log message will be produced)
- by default, decoding frames now fails if the payload to be decoded is longer than expected. To decode such data, passing `allow_excess=True` to the respective decode function is now required
- besides ignoring some inconsistencies in the database, passing `--no-strict` to `cantools decode` now tries to decode incorrectly-sized frames on a best effort basis. (if the received data was too short, the decoded signal values might be incorrect, if it was too long, not all data can be decoded.)
- decoding container frames that contain incorrectly-sized child messages will no longer make decoding the whole container message fail: Instead of the decoded child message, the binary payload will be put into the result.

Besides this, this PR also corrects the URIs for the cantools homepage and the repository in `pyproject.toml`.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)