### PR TITLE
fix decode choices

### DIFF
--- a/src/cantools/database/conversion.py
+++ b/src/cantools/database/conversion.py
@@ -245,7 +245,7 @@ class NamedSignalConversion(BaseConversion):
         raw_value: Union[int, float],
         decode_choices: bool = True,
     ) -> SignalValueType:
-        if decode_choices and (choice := self.choices.get(raw_value)) is not None:  # type: ignore[arg-type]
+        if decode_choices and (choice := self.choices.get(self._conversion.raw_to_scaled(raw_value, False))) is not None:  # type: ignore[arg-type]
             return choice
         return self._conversion.raw_to_scaled(raw_value, False)
 


### PR DESCRIPTION
hi ：
I noticed that the values used for decoding choices are not scaled. Is this a bug or is there some other consideration? For example, here is my choice list [-1: good, 0: ok, 1: good], with a scale and shift of 1, -1. When the value is 2, after decoding, it becomes 2 * 1 - 1 = 1, which means "good." However, when I select the decode choice, it is interpreted as the numerical value 1 instead of "good." This is because 2 is not in the choice list, so it returns the decoded value of 2 * 1 - 1 = 1, rather than "good." If the value is 1, it actually equals 1 * 1 - 1 = 0. However, in this case, it returns "good." Is there a bug or is there a specific reason for this behavior?