### PR TITLE
Add type annotations to c_source.py

### DIFF
--- a/src/cantools/database/can/__init__.py
+++ b/src/cantools/database/can/__init__.py
@@ -1,7 +1,15 @@
-from .bus import Bus as Bus
-from .database import Database as Database
-from .message import DecodeError as DecodeError
-from .message import EncodeError as EncodeError
-from .message import Message as Message
-from .node import Node as Node
-from .signal import Signal as Signal
+__all__ = [
+    "Bus",
+    "Database",
+    "DecodeError",
+    "EncodeError",
+    "Message",
+    "Node",
+    "Signal",
+]
+
+from .bus import Bus
+from .database import Database
+from .message import DecodeError, EncodeError, Message
+from .node import Node
+from .signal import Signal

--- a/src/cantools/database/can/__init__.py
+++ b/src/cantools/database/can/__init__.py
@@ -1,13 +1,3 @@
-__all__ = [
-    "Bus",
-    "Database",
-    "DecodeError",
-    "EncodeError",
-    "Message",
-    "Node",
-    "Signal",
-]
-
 from .bus import Bus
 from .database import Database
 from .message import DecodeError, EncodeError, Message

--- a/src/cantools/database/can/__init__.py
+++ b/src/cantools/database/can/__init__.py
@@ -1,5 +1,7 @@
-from .bus import Bus
-from .database import Database
-from .message import DecodeError, EncodeError, Message
-from .node import Node
-from .signal import Signal
+from .bus import Bus as Bus
+from .database import Database as Database
+from .message import DecodeError as DecodeError
+from .message import EncodeError as EncodeError
+from .message import Message as Message
+from .node import Node as Node
+from .signal import Signal as Signal

--- a/src/cantools/database/can/c_source.py
+++ b/src/cantools/database/can/c_source.py
@@ -699,7 +699,7 @@ class CodeGenSignal:
         return unique_choices
 
     @property
-    def minimum_type_value(self) -> Optional[int]:
+    def minimum_ctype_value(self) -> Optional[int]:
         if self.type_name == 'int8_t':
             return -2**7
         elif self.type_name == 'int16_t':
@@ -714,7 +714,7 @@ class CodeGenSignal:
             return None
 
     @property
-    def maximum_type_value(self) -> Optional[int]:
+    def maximum_ctype_value(self) -> Optional[int]:
         if self.type_name == 'int8_t':
             return 2**7 - 1
         elif self.type_name == 'int16_t':
@@ -735,7 +735,7 @@ class CodeGenSignal:
             return None
 
     @property
-    def minimum_value(self) -> Optional[int]:
+    def minimum_can_raw_value(self) -> Optional[int]:
         if self.signal.conversion.is_float:
             return None
         elif self.signal.is_signed:
@@ -744,7 +744,7 @@ class CodeGenSignal:
             return 0
 
     @property
-    def maximum_value(self) -> Optional[int]:
+    def maximum_can_raw_value(self) -> Optional[int]:
         if self.signal.conversion.is_float:
             return None
         elif self.signal.is_signed:
@@ -1263,17 +1263,17 @@ def _generate_is_in_range(cg_signal: "CodeGenSignal") -> str:
     if maximum is not None:
         maximum = cg_signal.signal.scaled_to_raw(maximum)
 
-    if minimum is None and cg_signal.minimum_value is not None:
-        if cg_signal.minimum_type_value is None:
-            minimum = cg_signal.minimum_value
-        elif cg_signal.minimum_value > cg_signal.minimum_type_value:
-            minimum = cg_signal.minimum_value
+    if minimum is None and cg_signal.minimum_can_raw_value is not None:
+        if cg_signal.minimum_ctype_value is None:
+            minimum = cg_signal.minimum_can_raw_value
+        elif cg_signal.minimum_can_raw_value > cg_signal.minimum_ctype_value:
+            minimum = cg_signal.minimum_can_raw_value
 
-    if maximum is None and cg_signal.maximum_value is not None:
-        if cg_signal.maximum_type_value is None:
-            maximum = cg_signal.maximum_value
-        elif cg_signal.maximum_value < cg_signal.maximum_type_value:
-            maximum = cg_signal.maximum_value
+    if maximum is None and cg_signal.maximum_can_raw_value is not None:
+        if cg_signal.maximum_ctype_value is None:
+            maximum = cg_signal.maximum_can_raw_value
+        elif cg_signal.maximum_can_raw_value < cg_signal.maximum_ctype_value:
+            maximum = cg_signal.maximum_can_raw_value
 
     suffix = cg_signal.type_suffix
     check = []
@@ -1284,9 +1284,9 @@ def _generate_is_in_range(cg_signal: "CodeGenSignal") -> str:
         else:
             minimum = float(minimum)
 
-        minimum_type_value = cg_signal.minimum_type_value
+        minimum_ctype_value = cg_signal.minimum_ctype_value
 
-        if (minimum_type_value is None) or (minimum > minimum_type_value):
+        if (minimum_ctype_value is None) or (minimum > minimum_ctype_value):
             check.append(f'(value >= {minimum}{suffix})')
 
     if maximum is not None:
@@ -1295,9 +1295,9 @@ def _generate_is_in_range(cg_signal: "CodeGenSignal") -> str:
         else:
             maximum = float(maximum)
 
-        maximum_type_value = cg_signal.maximum_type_value
+        maximum_ctype_value = cg_signal.maximum_ctype_value
 
-        if (maximum_type_value is None) or (maximum < maximum_type_value):
+        if (maximum_ctype_value is None) or (maximum < maximum_ctype_value):
             check.append(f'(value <= {maximum}{suffix})')
 
     if not check:

--- a/src/cantools/database/can/c_source.py
+++ b/src/cantools/database/can/c_source.py
@@ -1,5 +1,6 @@
 import re
 import time
+from typing import List, Tuple
 
 from cantools import __version__
 
@@ -1205,26 +1206,28 @@ def _format_choices(signal, signal_name):
     return choices
 
 
-def _generate_encode_decode(message, use_float):
+def _generate_encode_decode(message: "Message", use_float: bool) -> List[Tuple[str, str]]:
     encode_decode = []
 
     floating_point_type = _get_floating_point_type(use_float)
     for signal in message.signals:
-        scale = float(signal.scale)
-        offset = float(signal.offset)
+        scale = signal.scale
+        offset = signal.offset
+        scale_literal = f"{scale}{'f' if isinstance(scale, float) and use_float else ''}"
+        offset_literal = f"{offset}{'f' if isinstance(offset, float) and use_float else ''}"
 
         if offset == 0 and scale == 1:
             encoding = 'value'
             decoding = f'({floating_point_type})value'
         elif offset != 0 and scale != 1:
-            encoding = f'(value - {offset}) / {scale}'
-            decoding = f'(({floating_point_type})value * {scale}) + {offset}'
+            encoding = f'(value - {offset_literal}) / {scale_literal}'
+            decoding = f'(({floating_point_type})value * {scale_literal}) + {offset_literal}'
         elif offset != 0:
-            encoding = f'value - {offset}'
-            decoding = f'({floating_point_type})value + {offset}'
+            encoding = f'value - {offset_literal}'
+            decoding = f'({floating_point_type})value + {offset_literal}'
         else:
-            encoding = f'value / {scale}'
-            decoding = f'({floating_point_type})value * {scale}'
+            encoding = f'value / {scale_literal}'
+            decoding = f'({floating_point_type})value * {scale_literal}'
 
         encode_decode.append((encoding, decoding))
 

--- a/tests/files/c_source/floating_point_use_float.c
+++ b/tests/files/c_source/floating_point_use_float.c
@@ -171,14 +171,14 @@ int floating_point_use_float_message1_init(struct floating_point_use_float_messa
     return 0;
 }
 
-double floating_point_use_float_message1_signal1_encode(float value)
+double floating_point_use_float_message1_signal1_encode(double value)
 {
     return (double)(value);
 }
 
-float floating_point_use_float_message1_signal1_decode(double value)
+double floating_point_use_float_message1_signal1_decode(double value)
 {
-    return ((float)value);
+    return ((double)value);
 }
 
 bool floating_point_use_float_message1_signal1_is_in_range(double value)
@@ -326,12 +326,12 @@ int floating_point_use_float_message3_init(struct floating_point_use_float_messa
 
 uint8_t floating_point_use_float_message3_signal3_encode(float value)
 {
-    return (uint8_t)((value - -0.125) / 0.001);
+    return (uint8_t)((value - -0.125f) / 0.001f);
 }
 
 float floating_point_use_float_message3_signal3_decode(uint8_t value)
 {
-    return (((float)value * 0.001) + -0.125);
+    return (((float)value * 0.001f) + -0.125f);
 }
 
 bool floating_point_use_float_message3_signal3_is_in_range(uint8_t value)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import types
 import unittest
+import warnings
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1292,8 +1293,13 @@ BATTERY_VT(
                 if database == 'floating_point_use_float':
                     argv.append('--use-float')
 
-                with patch('sys.argv', argv):
+                with patch('sys.argv', argv), warnings.catch_warnings(record=True) as w:
                     cantools._main()
+
+                    if database == 'floating_point_use_float':
+                        assert str(w[-1].message) == (
+                            "User selected `--use-float`, but database contains "
+                            "signal with data type `double`: \"Message1::Signal1\"")
 
                 database_h = basename + '.h'
                 database_c = basename + '.c'


### PR DESCRIPTION
- add type annotations to c_source.py
- use float literals if `--use-float` is set
- do not cast `double` to `float`

Closes #604 