### PR TITLE
Enum newlines

### DIFF
--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -781,13 +781,13 @@ def _dump_choice(signal: Signal) -> str:
         return ''
 
     enum_str = f'Enum={_get_enum_name(signal)}('
-    is_first_choice = True
-    for choice_number, choice_value in signal.choices.items():
-        if choice_number % 10 == 0 and not choice_number == 0:
-            enum_str += f'{","+nl if not is_first_choice else ""}{choice_number}="{choice_value}"'
-        else:
-            enum_str += f'{", " if not is_first_choice else ""}{choice_number}="{choice_value}"'
-        is_first_choice = False
+    for choice_count, (choice_number, choice_value) in enumerate(signal.choices.items()):
+        if choice_count % 10 == 0 and not choice_count == 0:
+            enum_str += ","
+            enum_str += nl
+        elif choice_count > 0:
+            enum_str += ", "
+        enum_str += f'{choice_number}="{choice_value}"'
     enum_str += ')'
     return enum_str
 

--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -775,13 +775,15 @@ def _get_enum_name(signal: Signal) -> str:
 def _dump_choice(signal: Signal) -> str:
     # Example:
     # Enum=DPF_Actv_Options(0="notActive", 1="active", 2="rgnrtnNddAtmtcllyInttdActvRgnrt", 3="notAvailable")
+    new_line = '\n'
+
     if not signal.choices:
         return ''
 
     enum_str = f'Enum={_get_enum_name(signal)}('
     is_first_choice = True
     for choice_number, choice_value in signal.choices.items():
-        enum_str += f'{", " if not is_first_choice else ""}{choice_number}="{choice_value}"'
+        enum_str += f'{",{new_line}" if not is_first_choice else ""}{choice_number}="{choice_value}"'
         is_first_choice = False
     enum_str += ')'
     return enum_str

--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -782,7 +782,7 @@ def _dump_choice(signal: Signal) -> str:
 
     enum_str = f'Enum={_get_enum_name(signal)}('
     for choice_count, (choice_number, choice_value) in enumerate(signal.choices.items()):
-        if choice_count % 10 == 0 and not choice_count == 0:
+        if choice_count % 10 == 0 and choice_count != 0:
             enum_str += ","
             enum_str += nl
         elif choice_count > 0:

--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -783,8 +783,7 @@ def _dump_choice(signal: Signal) -> str:
     enum_str = f'Enum={_get_enum_name(signal)}('
     for choice_count, (choice_number, choice_value) in enumerate(signal.choices.items()):
         if choice_count % 10 == 0 and choice_count != 0:
-            enum_str += ","
-            enum_str += nl
+            enum_str += ',\n'
         elif choice_count > 0:
             enum_str += ", "
         enum_str += f'{choice_number}="{choice_value}"'

--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -775,6 +775,7 @@ def _get_enum_name(signal: Signal) -> str:
 def _dump_choice(signal: Signal) -> str:
     # Example:
     # Enum=DPF_Actv_Options(0="notActive", 1="active", 2="rgnrtnNddAtmtcllyInttdActvRgnrt", 3="notAvailable")
+    nl = '\n'
 
     if not signal.choices:
         return ''
@@ -782,7 +783,10 @@ def _dump_choice(signal: Signal) -> str:
     enum_str = f'Enum={_get_enum_name(signal)}('
     is_first_choice = True
     for choice_number, choice_value in signal.choices.items():
-        enum_str += f'{",{new_line}" if not is_first_choice else ""}{choice_number}="{choice_value}"'
+        if choice_number % 10 == 0 and not choice_number == 0:
+            enum_str += f'{","+nl if not is_first_choice else ""}{choice_number}="{choice_value}"'
+        else:
+            enum_str += f'{", " if not is_first_choice else ""}{choice_number}="{choice_value}"'
         is_first_choice = False
     enum_str += ')'
     return enum_str

--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -775,7 +775,6 @@ def _get_enum_name(signal: Signal) -> str:
 def _dump_choice(signal: Signal) -> str:
     # Example:
     # Enum=DPF_Actv_Options(0="notActive", 1="active", 2="rgnrtnNddAtmtcllyInttdActvRgnrt", 3="notAvailable")
-    new_line = '\n'
 
     if not signal.choices:
         return ''

--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -775,8 +775,6 @@ def _get_enum_name(signal: Signal) -> str:
 def _dump_choice(signal: Signal) -> str:
     # Example:
     # Enum=DPF_Actv_Options(0="notActive", 1="active", 2="rgnrtnNddAtmtcllyInttdActvRgnrt", 3="notAvailable")
-    nl = '\n'
-
     if not signal.choices:
         return ''
 

--- a/tests/files/sym/test_multiline_enum.sym
+++ b/tests/files/sym/test_multiline_enum.sym
@@ -1,0 +1,70 @@
+FormatVersion=6.0 // Do not edit this line!
+Title="Jopp"
+
+{ENUMS}
+// pickled enum
+Enum=pickled(0="pickle",
+  1="onion", // barbar
+  2="carrot", // CARROT
+  3="banana", 4="plum", 5="beet", 6="tomato", 7="corn", 8="blueberry", 9="jalapenos", 10="peach", 11="cabbage",
+  12="egg")
+
+{SIGNALS}
+Sig=Signal1 unsigned 11 /u:A /max:255 /d:1 /spn:1234
+Sig=Signal2 float /u:V /o:48 /min:16 /max:130 /ln:"hhh" // bbb
+Sig=Signal3 signed 11 -m /min:0 /max:1
+Sig=Signal4 double /u:*UU /f:6 /o:5 /min:-1.7E308 /max:1.7E308
+Sig=Signal5 char
+Sig=Signal6 unsigned 8 /max:1 /e:pickled
+
+{SEND}
+
+[Symbol1]
+ID=009h
+Len=8
+
+{RECEIVE}
+
+[Message2]
+ID=00000022h-00000023h
+Type=Extended
+Len=8
+Sig=Signal3 2
+
+{SENDRECEIVE}
+
+[Message1]
+ID=000h // apa
+Len=8
+CycleTime=30
+Timeout=20
+MinInterval=10
+Sig=Signal2 32
+Sig=Signal1 0
+Sig=Signal6 24
+
+[Message3]
+ID=00Ah
+Len=8
+Sig=Signal3 0
+
+[Symbol2]
+ID=099h
+Len=8
+Sig=Signal4 0
+
+[Symbol3]
+ID=033h
+Len=8
+Mux=Multiplexer1 0,3 0
+Sig=Signal1 3
+
+[Symbol3]
+Len=8
+Mux=Multiplexer2 0,3 1
+Sig=Signal2 6
+
+[Symbol3]
+Len=8
+Mux=Multiplexer3 0,3 2
+Sig=Signal3 9

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1936,6 +1936,13 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_jopp_6_0_sym_re_read(self):
         self.internal_test_jopp_6_0_sym(True)
 
+    def test_multiline_enum_sym_parsing(self):
+        db = cantools.database.load_file('tests/files/sym/test_multiline_enum.sym')
+        cantools.database.dump_file(db, 'tests/files/sym/test_multiline_enum_dump.sym')
+        db_reloaded = cantools.database.load_file('tests/files/sym/test_multiline_enum_dump.sym')
+
+        self.assertTrue(db.is_similar(db_reloaded, include_format_specifics=False))
+
     def test_empty_6_0_sym(self):
         db = cantools.database.load_file('tests/files/sym/empty-6.0.sym')
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1942,6 +1942,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         db_reloaded = cantools.database.load_file('tests/files/sym/test_multiline_enum_dump.sym')
 
         self.assertTrue(db.is_similar(db_reloaded, include_format_specifics=False))
+        os.remove('tests/files/sym/test_multiline_enum_dump.sym')
 
     def test_empty_6_0_sym(self):
         db = cantools.database.load_file('tests/files/sym/empty-6.0.sym')


### PR DESCRIPTION
Fixes issue #642 by creating a newline every 10 choice entries for generated sym files as part of the _dump_choice(signal) function