### PR TITLE
slight modification to regex to enable small scaling factors that have scientific numbers in them

### DIFF
--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -103,7 +103,7 @@ class Parser60(textparser.Parser):
             ('SKIP',               r'[ \r\n\t]+'),
             ('COMMENT',            r'//.*?\n'),
             ('HEXNUMBER',          r'-?\d+\.?[0-9A-F]*([eE][+-]?\d+)?(h)'),
-            ('NUMBER',             r'-?\d+\.?[0-9A-F]*([eE][+-]?\d+)?'),
+            ('NUMBER',             r'-?\d+(\.\d+)?([eE][+-]?\d+)?'),
             ('STRING',             re_string),
             ('U',                  fr'/u:({re_string}|\S+)'),
             ('F',                  r'/f:'),


### PR DESCRIPTION
I ran into issues when I had a really small scaling factor in a sym file and it had a scientific number and this update to the tokenizer fixed the issue.