### PR TITLE
Skip dumping KCD version if unset

### DIFF
--- a/src/cantools/database/can/formats/kcd.py
+++ b/src/cantools/database/can/formats/kcd.py
@@ -419,7 +419,8 @@ def _dump_message(message, bus, node_refs, sort_signals):
 
 
 def _dump_version(version, parent):
-    SubElement(parent, 'Document', version=version)
+    if version is not None:
+        SubElement(parent, 'Document', version=version)
 
 
 def _dump_nodes(nodes, node_refs, parent):


### PR DESCRIPTION
Dumping a newly populated DB to KCD fails since the default value of the `version` attribute is `None` and the XML writer cannot handle it. This PR skips setting that value altogether if it is `None`, similarly to [what is done for the DBC format](https://github.com/cantools/cantools/blob/116333d1e1a01dc3afa3f03c5b646a6d512392af/src/cantools/database/can/formats/dbc.py#L458).

```python3
db = cantools.database.Database()
signal = cantools.database.Signal(name="Sig", start=0, length=8)
message = cantools.database.Message(frame_id=0x42, name="CAN_Message_Name", length=1, signals=[signal], strict=True)
db.messages.append(message)
db.refresh()
cantools.database.dump_file(db, "test.kcd")
```
```plaintext
Traceback (most recent call last):
  File "/usr/lib64/python3.12/xml/etree/ElementTree.py", line 1027, in _escape_attrib
    if "&" in text:
       ^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<input>", line 1, in <module>
    cantools.database.dump_file(can_db, "test.kcd")
  File "/venv/lib/python3.12/site-packages/cantools/database/__init__.py", line 245, in dump_file
    output = database.as_kcd_string(sort_signals=sort_signals)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/cantools/database/can/database.py", line 447, in as_kcd_string
    return kcd.dump_string(InternalDatabase(self._messages,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/cantools/database/can/formats/kcd.py", line 460, in dump_string
    return ElementTree.tostring(network_definition, encoding='unicode')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/xml/etree/ElementTree.py", line 1084, in tostring
    ElementTree(element).write(stream, encoding,
  File "/usr/lib64/python3.12/xml/etree/ElementTree.py", line 729, in write
    serialize(write, self._root, qnames, namespaces,
  File "/usr/lib64/python3.12/xml/etree/ElementTree.py", line 892, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  File "/usr/lib64/python3.12/xml/etree/ElementTree.py", line 885, in _serialize_xml
    v = _escape_attrib(v)
        ^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/xml/etree/ElementTree.py", line 1050, in _escape_attrib
    _raise_serialization_error(text)
  File "/usr/lib64/python3.12/xml/etree/ElementTree.py", line 1004, in _raise_serialization_error
    raise TypeError(
TypeError: cannot serialize None (type NoneType)
```