### PR TITLE
fix ruff linter errors

### DIFF
--- a/src/cantools/database/can/c_source.py
+++ b/src/cantools/database/can/c_source.py
@@ -957,12 +957,9 @@ def _format_pack_code_signal(cg_message: "CodeGenMessage",
         variable = f'    uint{cg_signal.type_length}_t {cg_signal.snake_name};'
 
         if cg_signal.signal.conversion.is_float:
-            conversion = '    memcpy(&{0}, &src_p->{0}, sizeof({0}));'.format(
-                cg_signal.snake_name)
+            conversion = f'    memcpy(&{cg_signal.snake_name}, &src_p->{cg_signal.snake_name}, sizeof({cg_signal.snake_name}));'
         else:
-            conversion = '    {0} = (uint{1}_t)src_p->{0};'.format(
-                cg_signal.snake_name,
-                cg_signal.type_length)
+            conversion = f'    {cg_signal.snake_name} = (uint{cg_signal.type_length}_t)src_p->{cg_signal.snake_name};'
 
         variable_lines.append(variable)
         body_lines.append(conversion)
@@ -1102,8 +1099,7 @@ def _format_unpack_code_signal(cg_message: "CodeGenMessage",
         helper_kinds.add((shift_direction, cg_signal.type_length))
 
     if cg_signal.signal.conversion.is_float:
-        conversion = '    memcpy(&dst_p->{0}, &{0}, sizeof(dst_p->{0}));'.format(
-            cg_signal.snake_name)
+        conversion = f'    memcpy(&dst_p->{cg_signal.snake_name}, &{cg_signal.snake_name}, sizeof(dst_p->{cg_signal.snake_name}));'
         body_lines.append(conversion)
     elif cg_signal.signal.is_signed:
         mask = ((1 << (cg_signal.type_length - cg_signal.signal.length)) - 1)
@@ -1116,8 +1112,7 @@ def _format_unpack_code_signal(cg_message: "CodeGenMessage",
                                                   suffix=cg_signal.conversion_type_suffix)
             body_lines.extend(formatted.splitlines())
 
-        conversion = '    dst_p->{0} = (int{1}_t){0};'.format(cg_signal.snake_name,
-                                                              cg_signal.type_length)
+        conversion = f'    dst_p->{cg_signal.snake_name} = (int{cg_signal.type_length}_t){cg_signal.snake_name};'
         body_lines.append(conversion)
 
 
@@ -1312,10 +1307,7 @@ def _generate_frame_id_defines(database_name: str,
                                cg_messages: List["CodeGenMessage"],
                                node_name: Optional[str]) -> str:
     return '\n'.join([
-        '#define {}_{}_FRAME_ID (0x{:02x}u)'.format(
-            database_name.upper(),
-            cg_message.snake_name.upper(),
-            cg_message.message.frame_id)
+        f'#define {database_name.upper()}_{cg_message.snake_name.upper()}_FRAME_ID (0x{cg_message.message.frame_id:02x}u)'
         for cg_message in cg_messages if _is_sender_or_receiver(cg_message, node_name)
     ])
 
@@ -1324,10 +1316,7 @@ def _generate_frame_length_defines(database_name: str,
                                    cg_messages: List["CodeGenMessage"],
                                    node_name: Optional[str]) -> str:
     result = '\n'.join([
-        '#define {}_{}_LENGTH ({}u)'.format(
-            database_name.upper(),
-            cg_message.snake_name.upper(),
-            cg_message.message.length)
+        f'#define {database_name.upper()}_{cg_message.snake_name.upper()}_LENGTH ({cg_message.message.length}u)'
         for cg_message in cg_messages if _is_sender_or_receiver(cg_message, node_name)
     ])
 
@@ -1338,10 +1327,7 @@ def _generate_frame_cycle_time_defines(database_name: str,
                                        cg_messages: List["CodeGenMessage"],
                                        node_name: Optional[str]) -> str:
     result = '\n'.join([
-        '#define {}_{}_CYCLE_TIME_MS ({}u)'.format(
-            database_name.upper(),
-            cg_message.snake_name.upper(),
-            cg_message.message.cycle_time)
+        f'#define {database_name.upper()}_{cg_message.snake_name.upper()}_CYCLE_TIME_MS ({cg_message.message.cycle_time}u)'
         for cg_message in cg_messages if cg_message.message.cycle_time is not None and
                                       _is_sender_or_receiver(cg_message, node_name)
     ])
@@ -1353,10 +1339,7 @@ def _generate_is_extended_frame_defines(database_name: str,
                                         cg_messages: List["CodeGenMessage"],
                                         node_name: Optional[str]) -> str:
     result = '\n'.join([
-        '#define {}_{}_IS_EXTENDED ({})'.format(
-            database_name.upper(),
-            cg_message.snake_name.upper(),
-            int(cg_message.message.is_extended_frame))
+        f'#define {database_name.upper()}_{cg_message.snake_name.upper()}_IS_EXTENDED ({int(cg_message.message.is_extended_frame)})'
         for cg_message in cg_messages if _is_sender_or_receiver(cg_message, node_name)
     ])
 
@@ -1390,10 +1373,7 @@ def _generate_frame_name_macros(database_name: str,
                                 cg_messages: List["CodeGenMessage"],
                                 node_name: Optional[str]) -> str:
     result = '\n'.join([
-        '#define {}_{}_NAME "{}"'.format(
-            database_name.upper(),
-            cg_message.snake_name.upper(),
-            cg_message.message.name)
+        f'#define {database_name.upper()}_{cg_message.snake_name.upper()}_NAME "{cg_message.message.name}"'
         for cg_message in cg_messages if _is_sender_or_receiver(cg_message, node_name)
     ])
 
@@ -1404,11 +1384,7 @@ def _generate_signal_name_macros(database_name: str,
                                  cg_messages: List["CodeGenMessage"],
                                  node_name: Optional[str]) -> str:
     result = '\n'.join([
-        '#define {}_{}_{}_NAME "{}"'.format(
-            database_name.upper(),
-            cg_message.snake_name.upper(),
-            cg_signal.snake_name.upper(),
-            cg_signal.signal.name)
+        f'#define {database_name.upper()}_{cg_message.snake_name.upper()}_{cg_signal.snake_name.upper()}_NAME "{cg_signal.signal.name}"'
         for cg_message in cg_messages if _is_sender_or_receiver(cg_message, node_name) for cg_signal in cg_message.cg_signals
     ])
 

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -510,11 +510,7 @@ def _dump_messages(database, sort_signals):
     for message in database.messages:
         msg = []
         msg.append(
-            'BO_ {frame_id} {name}: {length} {senders}'.format(
-                frame_id=get_dbc_frame_id(message),
-                name=message.name,
-                length=message.length,
-                senders=format_senders(message)))
+            f'BO_ {get_dbc_frame_id(message)} {message.name}: {message.length} {format_senders(message)}')
 
         if sort_signals:
             signals = sort_signals(message.signals)
@@ -601,10 +597,7 @@ def _dump_signal_types(database):
                 continue
 
             valtype.append(
-                'SIG_VALTYPE_ {} {} : {};'.format(
-                    get_dbc_frame_id(message),
-                    signal.name,
-                    FLOAT_LENGTH_TO_SIGNAL_TYPE[signal.length]))
+                f'SIG_VALTYPE_ {get_dbc_frame_id(message)} {signal.name} : {FLOAT_LENGTH_TO_SIGNAL_TYPE[signal.length]};')
 
     return valtype
 
@@ -672,25 +665,13 @@ def _dump_attribute_definitions(database: InternalDatabase) -> List[str]:
             choices = ','.join([f'"{choice}"'
                                 for choice in definition.choices])
             ba_def.append(
-                'BA_DEF_ {kind} "{name}" {type_name}  {choices};'.format(
-                    kind=get_kind(definition),
-                    name=definition.name,
-                    type_name=definition.type_name,
-                    choices=choices))
+                f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name}  {choices};')
         elif definition.type_name in ['INT', 'FLOAT', 'HEX']:
             ba_def.append(
-                'BA_DEF_ {kind} "{name}" {type_name}{minimum}{maximum};'.format(
-                    kind=get_kind(definition),
-                    name=definition.name,
-                    type_name=definition.type_name,
-                    minimum=get_minimum(definition),
-                    maximum=get_maximum(definition)))
+                f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name}{get_minimum(definition)}{get_maximum(definition)};')
         elif definition.type_name == 'STRING':
             ba_def.append(
-                'BA_DEF_ {kind} "{name}" {type_name} ;'.format(
-                    kind=get_kind(definition),
-                    name=definition.name,
-                    type_name=definition.type_name))
+                f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name} ;')
 
     return ba_def
 
@@ -722,25 +703,13 @@ def _dump_attribute_definitions_rel(database):
             choices = ','.join([f'"{choice}"'
                                 for choice in definition.choices])
             ba_def_rel.append(
-                'BA_DEF_REL_ {kind}  "{name}" {type_name}  {choices};'.format(
-                    kind = definition.kind,
-                    name=definition.name,
-                    type_name=definition.type_name,
-                    choices=choices))
+                f'BA_DEF_REL_ {definition.kind}  "{definition.name}" {definition.type_name}  {choices};')
         elif definition.type_name in ['INT', 'FLOAT', 'HEX']:
             ba_def_rel.append(
-                'BA_DEF_REL_ {kind}  "{name}" {type_name}{minimum}{maximum};'.format(
-                    kind=definition.kind,
-                    name=definition.name,
-                    type_name=definition.type_name,
-                    minimum=get_minimum(definition),
-                    maximum=get_maximum(definition)))
+                f'BA_DEF_REL_ {definition.kind}  "{definition.name}" {definition.type_name}{get_minimum(definition)}{get_maximum(definition)};')
         elif definition.type_name == 'STRING':
             ba_def_rel.append(
-                'BA_DEF_REL_ {kind}  "{name}" {type_name} ;'.format(
-                    kind=definition.kind,
-                    name=definition.name,
-                    type_name=definition.type_name))
+                f'BA_DEF_REL_ {definition.kind}  "{definition.name}" {definition.type_name} ;')
 
     return ba_def_rel
 
@@ -1065,11 +1034,7 @@ def _dump_signal_mux_values(database):
             ])
 
             sig_mux_values.append(
-                'SG_MUL_VAL_ {frame_id} {name} {multiplexer} {ranges};'.format(
-                    frame_id=get_dbc_frame_id(message),
-                    name=signal.name,
-                    multiplexer=signal.multiplexer_signal,
-                    ranges=ranges))
+                f'SG_MUL_VAL_ {get_dbc_frame_id(message)} {signal.name} {signal.multiplexer_signal} {ranges};')
 
     return sig_mux_values
 

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -984,9 +984,7 @@ class Message:
             try:
                 node = multiplexers[signal][mux]
             except KeyError:
-                raise DecodeError('expected multiplexer id {}, but got {}'.format(
-                    format_or(list(multiplexers[signal].keys())),
-                    mux)) from None
+                raise DecodeError(f'expected multiplexer id {format_or(list(multiplexers[signal].keys()))}, but got {mux}') from None
 
             decoded.update(self._decode(node,
                                         data,
@@ -1264,10 +1262,7 @@ class Message:
             if signal_bit is not None:
                 if message_bits[offset] is not None:
                     raise Error(
-                        'The signals {} and {} are overlapping in message {}.'.format(
-                            signal.name,
-                            message_bits[offset],
-                            self.name))
+                        f'The signals {signal.name} and {message_bits[offset]} are overlapping in message {self.name}.')
 
                 message_bits[offset] = signal.name
 
@@ -1298,11 +1293,8 @@ class Message:
         for signal in self._signals:
             if signal.length <= 0:
                 raise Error(
-                    'The signal {} length {} is not greater than 0 in '
-                    'message {}.'.format(
-                        signal.name,
-                        signal.length,
-                        self.name))
+                    f'The signal {signal.name} length {signal.length} is not greater than 0 in '
+                    f'message {self.name}.')
 
     def refresh(self, strict: Optional[bool] = None) -> None:
         """Refresh the internal message state.

--- a/src/cantools/database/can/signal_group.py
+++ b/src/cantools/database/can/signal_group.py
@@ -54,6 +54,4 @@ class SignalGroup:
         self._signal_names = value
 
     def __repr__(self):
-        return "signal_group('{}', {}, {})".format(self._name,
-                                                   self._repetitions,
-                                                   self._signal_names)
+        return f"signal_group('{self._name}', {self._repetitions}, {self._signal_names})"

--- a/src/cantools/database/diagnostics/data.py
+++ b/src/cantools/database/diagnostics/data.py
@@ -147,14 +147,4 @@ class Data:
                 [f"{value}: '{text}'"
                  for value, text in self.choices.items()]))
 
-        return "data('{}', {}, {}, '{}', {}, {}, {}, {}, '{}', {})".format(
-            self.name,
-            self.start,
-            self.length,
-            self.byte_order,
-            self.conversion.scale,
-            self.conversion.offset,
-            self.minimum,
-            self.maximum,
-            self.unit,
-            choices)
+        return f"data('{self.name}', {self.start}, {self.length}, '{self.byte_order}', {self.conversion.scale}, {self.conversion.offset}, {self.minimum}, {self.maximum}, '{self.unit}', {choices})"

--- a/src/cantools/database/diagnostics/formats/cdd.py
+++ b/src/cantools/database/diagnostics/formats/cdd.py
@@ -104,7 +104,7 @@ def _load_data_types(ecu_doc):
         elif ctype.attrib['bo'] == '12':
             byte_order = 'little_endian'
         else:
-            raise ParseError("Unknown byte order code: %s" % ctype.attrib['bo'])
+            raise ParseError(f"Unknown byte order code: {ctype.attrib['bo']}")
 
         # Load from P-type element.
         ptype_unit = data_type.find('PVALUETYPE/UNIT')

--- a/src/cantools/j1939.py
+++ b/src/cantools/j1939.py
@@ -87,8 +87,7 @@ def pgn_pack(reserved, data_page, pdu_format, pdu_specific=0):
 
     if pdu_format < 240 and pdu_specific != 0:
         raise Error(
-            'Expected PDU specific 0 when PDU format is 0..239, but got {}.'.format(
-                pdu_specific))
+            f'Expected PDU specific 0 when PDU format is 0..239, but got {pdu_specific}.')
 
     try:
         packed = bitstruct.pack('u1u1u8u8',

--- a/src/cantools/subparsers/generate_c_source.py
+++ b/src/cantools/subparsers/generate_c_source.py
@@ -63,8 +63,7 @@ def _do_generate_c_source(args):
         print(f'Successfully generated {fuzzer_path_c} and {fuzzer_path_mk}.')
         print()
         print(
-            'Run "make -f {}" to build and run the fuzzer. Requires a'.format(
-                fuzzer_filename_mk))
+            f'Run "make -f {fuzzer_filename_mk}" to build and run the fuzzer. Requires a')
         print('recent version of clang.')
 
 

--- a/src/cantools/subparsers/plot.py
+++ b/src/cantools/subparsers/plot.py
@@ -170,7 +170,7 @@ class TimestampParser:
             if t is not None:
                 return t
 
-        raise ValueError("Failed to parse relative time %r.\n\nPlease note that an input like 'xx:xx' is ambiguous. It could be either 'HH:MM' or 'MM:SS'. Please specify what you want by adding a leading or trailing colon: 'HH:MM:' or ':MM:SS' (or 'MM:SS.')." % user_input)
+        raise ValueError(f"Failed to parse relative time {user_input!r}.\n\nPlease note that an input like 'xx:xx' is ambiguous. It could be either 'HH:MM' or 'MM:SS'. Please specify what you want by adding a leading or trailing colon: 'HH:MM:' or ':MM:SS' (or 'MM:SS.').")
 
     def strptimedelta_in_seconds(self, user_input, pattern):
         '''
@@ -234,7 +234,7 @@ class TimestampParser:
                     out = out.replace(**kw)
                     return out
 
-        raise ValueError("Failed to parse absolute time %r.\n\nPlease note that an input like 'xx:xx' is ambiguous. It could be either 'HH:MM' or 'MM:SS'. Please specify what you want by adding a leading or trailing colon: 'HH:MM:' or ':MM:SS' (or 'MM:SS.')." % user_input)
+        raise ValueError(f"Failed to parse absolute time {user_input!r}.\n\nPlease note that an input like 'xx:xx' is ambiguous. It could be either 'HH:MM' or 'MM:SS'. Please specify what you want by adding a leading or trailing colon: 'HH:MM:' or ':MM:SS' (or 'MM:SS.').")
 
     def first_parse_timestamp(self, timestamp, linenumber):
         if timestamp is None:
@@ -318,7 +318,7 @@ def _do_decode(args):
     if args.list_styles:
         print("available matplotlib styles:")
         for style in plt.style.available:
-            print("- %s" % style)
+            print(f"- {style}")
         return
 
     if args.show_errors:
@@ -452,7 +452,7 @@ class Plotter:
         if self.show_invalid_syntax:
             self.x_invalid_syntax.append(timestamp)
         if not self.ignore_invalid_syntax:
-            print("Failed to parse line: %r" % line)
+            print(f"Failed to parse line: {line!r}")
 
     # ------- at end -------
 
@@ -460,7 +460,7 @@ class Plotter:
         self.signals.plot(xlabel, self.x_invalid_syntax, self.x_unknown_frames, self.x_invalid_data)
         if self.output_filename:
             plt.savefig(self.output_filename)
-            print("Result written to %s" % self.output_filename)
+            print(f"Result written to {self.output_filename}")
         else:
             plt.show()
 
@@ -531,7 +531,7 @@ class Signals:
             subplot_signals = signals[i0:i1]
             subplot_args = self.subplot_argparser.parse_args(subplot_signals)
             if auto_color_ylabels and subplot_args.color is None:
-                subplot_args.color = "C%s" % self.subplot_axis
+                subplot_args.color = f"C{self.subplot_axis}"
             self.subplot_args[(self.subplot, self.subplot_axis)] = subplot_args
             self._ylabel = ""
             for sg in subplot_args.signals:
@@ -727,7 +727,7 @@ class Signals:
 
     def plot_error(self, splot, xs, label, color):
         if xs:
-            label += " (%s)" % len(xs)
+            label += f" ({len(xs)})"
             xs = iter(xs)
             splot.axvline(next(xs), color=color, linewidth=self.ERROR_LINEWIDTH, label=label)
             for x in xs:


### PR DESCRIPTION
This fixes all ruff linter errors and makes the Github workflow green.  Mostly auto-fixes from ruff, with manual inspection to verify sanity.