### PR TITLE
Fix monitor by implementing abstractmethod can.Listener.stop

### DIFF
--- a/src/cantools/subparsers/monitor.py
+++ b/src/cantools/subparsers/monitor.py
@@ -558,6 +558,9 @@ class Monitor(can.Listener):
 
     def on_message_received(self, msg):
         self._queue.put(msg)
+    
+    def stop(self):
+        pass
 
 
 def _do_monitor(args):


### PR DESCRIPTION
Between `python-can`  [release-4.2](https://github.com/hardbyte/python-can/blob/release-4.2/can/listener.py) and [release-4.4.0](https://github.com/hardbyte/python-can/blob/release-4.4.0/can/listener.py), `can.Listener.stop` became an `abstractmethod`, which caused the `cantools` `monitor` command to fail with:
```
error: Can't instantiate abstract class Monitor with abstract method stop
```

See: https://github.com/cantools/cantools/issues/667

This implements a noop `stop()` method.