### PR TITLE
Add support for ranged enums in SYM databases

### DIFF
--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -98,12 +98,14 @@ class Parser60(textparser.Parser):
         }
 
         re_string = r'"(\\"|[^"])*?"'
+        re_number = r'-?\d+(\.\d+)?([eE][+-]?\d+)?'
 
         token_specs = [
             ('SKIP',               r'[ \r\n\t]+'),
             ('COMMENT',            r'//.*?\n'),
             ('HEXNUMBER',          r'-?\d+\.?[0-9A-F]*([eE][+-]?\d+)?(h)'),
-            ('NUMBER',             r'-?\d+(\.\d+)?([eE][+-]?\d+)?'),
+            ('RANGE',              fr'{re_number}\.\.{re_number}'),
+            ('NUMBER',             re_number),
             ('STRING',             re_string),
             ('U',                  fr'/u:({re_string}|\S+)'),
             ('F',                  r'/f:'),
@@ -170,7 +172,7 @@ class Parser60(textparser.Parser):
         float_decimal_places = Sequence('FloatDecimalPlaces' , '=', 'NUMBER')
         bit_rate_switch = Sequence('BRS' , '=', word)
 
-        enum_value = Sequence('NUMBER', '=', 'STRING')
+        enum_value = Sequence(choice('RANGE', 'NUMBER'), '=', 'STRING')
         delim = Sequence(',', Optional('COMMENT'))
         enum = Sequence('Enum', '=', word,
                         '(', Optional(DelimitedList(enum_value, delim=delim)), ')',
@@ -285,6 +287,20 @@ def _load_enums(tokens):
     for _, _, name, _, values, _, _ in section:
         if values:
             values = values[0]
+
+        i = 0
+        while i < len(values):
+            if ".." in values[i][0]:
+                ranged_value = values.pop(i)
+                range_start, range_end = map(num, ranged_value[0].split('..'))
+
+                expanded_values = [[str(value), ranged_value[1], ranged_value[2]]
+                                   for value in range(range_start, range_end + 1)]
+
+                values[i:i] = expanded_values
+
+            else:
+                i += 1
 
         enum = odict()
         for v in values:


### PR DESCRIPTION
SYM databases support ranged enum values, at least in version 6.0.  
They look like this:  
`Enum=EnumName(0="Value0", 1="Value 1", 2..5="Ranged Value 2-5")`

This commit adds support by expanding the 2..5 range (where the last number is included, as one might expect it to work like `range()`) into individual values.  

It might not be the best way to do this. I also don't know how to write a proper test for this.