### PR TITLE
monitor: fix crash while decoding message with bad length

### DIFF
--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -984,7 +984,7 @@ class Message:
             try:
                 node = multiplexers[signal][mux]
             except KeyError:
-                raise DecodeError(f'expected multiplexer id {format_or(list(multiplexers[signal].keys()))}, but got {mux}') from None
+                raise DecodeError(f'expected multiplexer id {format_or(sorted(multiplexers[signal].keys()))}, but got {mux}') from None
 
             decoded.update(self._decode(node,
                                         data,

--- a/src/cantools/database/utils.py
+++ b/src/cantools/database/utils.py
@@ -143,10 +143,14 @@ def decode_data(data: bytes,
             raise DecodeError(f"Wrong data size: {actual_length} instead of "
                               f"{expected_length} bytes")
 
-    unpacked = {
-        **formats.big_endian.unpack(data),
-        **formats.little_endian.unpack(data[::-1]),
-    }
+    try:
+        unpacked = {
+            **formats.big_endian.unpack(data),
+            **formats.little_endian.unpack(data[::-1]),
+        }
+    except (bitstruct.Error, ValueError) as e:
+        # bitstruct returns different errors in PyPy and cpython
+        raise DecodeError("unpacking failed") from e
 
     if actual_length < expected_length and allow_truncated:
         # remove signals that are outside available data bytes

--- a/src/cantools/subparsers/__utils__.py
+++ b/src/cantools/subparsers/__utils__.py
@@ -1,5 +1,7 @@
 from typing import Iterable
 
+from cantools.database.errors import DecodeError
+
 from ..database.can.database import Database
 from ..database.can.message import Message
 from ..database.namedsignalvalue import NamedSignalValue
@@ -142,7 +144,7 @@ def format_message_by_frame_id(dbase : Database,
                             single_line,
                             allow_truncated=allow_truncated,
                             allow_excess=allow_excess)
-    except Exception as e:
+    except DecodeError as e:
         return f' {e}'
 
 def format_container_message(message : Message,
@@ -161,8 +163,8 @@ def format_container_message(message : Message,
                                                    allow_truncated=allow_truncated,
                                                    allow_excess=allow_excess)
 
-    except Exception as e:
-        return ' ' + str(e)
+    except DecodeError as e:
+        return f' {e}'
 
     if single_line:
         return _format_container_single_line(message,

--- a/src/cantools/subparsers/__utils__.py
+++ b/src/cantools/subparsers/__utils__.py
@@ -135,12 +135,15 @@ def format_message_by_frame_id(dbase : Database,
         else:
             return f' Frame 0x{frame_id:x} is a container message'
 
-    return format_message(message,
-                          data,
-                          decode_choices,
-                          single_line,
-                          allow_truncated=allow_truncated,
-                          allow_excess=allow_excess)
+    try:
+        return format_message(message,
+                            data,
+                            decode_choices,
+                            single_line,
+                            allow_truncated=allow_truncated,
+                            allow_excess=allow_excess)
+    except Exception as e:
+        return f' {e}'
 
 def format_container_message(message : Message,
                              data : bytes,
@@ -177,13 +180,10 @@ def format_message(message : Message,
                    single_line : bool,
                    allow_truncated : bool,
                    allow_excess : bool) -> str:
-    try:
-        decoded_signals = message.decode_simple(data,
-                                                decode_choices,
-                                                allow_truncated=allow_truncated,
-                                                allow_excess=allow_excess)
-    except Exception as e:
-        return ' ' + str(e)
+    decoded_signals = message.decode_simple(data,
+                                            decode_choices,
+                                            allow_truncated=allow_truncated,
+                                            allow_excess=allow_excess)
 
     formatted_signals = _format_signals(message, decoded_signals)
 

--- a/src/cantools/subparsers/monitor.py
+++ b/src/cantools/subparsers/monitor.py
@@ -8,6 +8,8 @@ import time
 import can
 from argparse_addons import Integer
 
+from cantools.database.errors import DecodeError
+
 from .. import database
 from .__utils__ import format_message, format_multiplexed_name
 
@@ -400,7 +402,7 @@ class Monitor(can.Listener):
                 formatted += [14 * ' ' + line for line in lines[2:]]
 
             self._update_formatted_message(name, formatted)
-        except Exception as e:
+        except DecodeError as e:
             # Discard the message in case of any decoding error, like we do when the
             # CAN message ID or length doesn't match what's specified in the DBC.
             self._update_message_error(timestamp, name, data, str(e))


### PR DESCRIPTION
Decoding message with bad length (and using `--no-strict`) raises exception in decoding that is caught in `format_message` and returned as a string that causes uncaught exception when `--single-line` is not used:
```shell-session
$ ip link add dev vcan0 type vcan
$ ip link set up vcan0
$ cantools -d monitor -c vcan0 tests/files/dbc/bad_message_length.dbc --no-strict
  File "monitor.py", line 540, in update
    modified = self.update_messages()
  File "monitor.py", line 531, in update_messages
    self.try_update_message()
  File "monitor.py",line 417, in try_update_message
    formatted = [f'{timestamp:12.3f}  {lines[1]}']
IndexError: list index out of range
# in another window
$ cansend vcan0 001#11
```

This patch handles all decoding exceptions directly in monitor in a single place.