### PR TITLE
Enable cache via env variable and improve cache key

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -61,7 +61,7 @@ jobs:
         python -m pip install -e ".[windows-all]"
     - name: Test
       run: |
-        tox -e gh
+        tox -e gh,gh_cache
     - name: Coveralls
       if: matrix.os == 'ubuntu-latest'
       uses: AndreMiras/coveralls-python-action@develop

--- a/src/cantools/database/__init__.py
+++ b/src/cantools/database/__init__.py
@@ -130,11 +130,11 @@ def load_file(filename: StringPathLike,
     `cache_dir` specifies the database cache location in the file
     system. Give as ``None`` to disable the cache. By default the
     cache is disabled, but can be enabled with environment variable
-    `CANTOOLS_CACHE_DIR`. The cache key is the contents of given
-    file. Using a cache will significantly reduce the load time when
-    reloading the same file. The cache directory is automatically
-    created if it does not exist. Remove the cache directory
-    `cache_dir` to clear the cache.
+    `CANTOOLS_CACHE_DIR`. The cache key is db path with modification
+    time and all arguments that may influence the result. Using a
+    cache will significantly reduce the load time when reloading the
+    same file. The cache directory is automatically created if it does
+    not exist. Remove the cache directory `cache_dir` to clear the cache.
 
     See :func:`~cantools.database.load_string()` for descriptions of
     other arguments.
@@ -165,16 +165,16 @@ def load_file(filename: StringPathLike,
             # the key cannot be created if function is local or depends on context
             # pickle serializer will fail anyway
             if not callable(sort_signals) or sort_signals.__module__ == 'cantools.database.utils':
-                with open(filename, 'rb') as fin:
-                    cache_key = (
-                        database_format,
-                        encoding,
-                        frame_id_mask,
-                        prune_choices,
-                        strict,
-                        sort_signals,
-                        fin.read(),
-                    )
+                cache_key = (
+                    database_format,
+                    encoding,
+                    frame_id_mask,
+                    prune_choices,
+                    strict,
+                    sort_signals,
+                    filename,
+                    os.path.getmtime(filename),
+                )
 
         db: Union[can.Database, diagnostics.Database]
         if cache_key:

--- a/src/cantools/database/__init__.py
+++ b/src/cantools/database/__init__.py
@@ -158,7 +158,8 @@ def load_file(filename: StringPathLike,
 
     `cache_dir` specifies the database cache location in the file
     system. Give as ``None`` to disable the cache. By default the
-    cache is disabled. The cache key is the contents of given
+    cache is disabled, but can be enabled with environment variable
+    `CANTOOLS_CACHE_DIR`. The cache key is the contents of given
     file. Using a cache will significantly reduce the load time when
     reloading the same file. The cache directory is automatically
     created if it does not exist. Remove the cache directory
@@ -182,6 +183,9 @@ def load_file(filename: StringPathLike,
         database_format,
         encoding,
         filename)
+
+    if not cache_dir:
+        cache_dir = os.getenv("CANTOOLS_CACHE_DIR", None)
 
     if cache_dir is None:
         with open(filename, encoding=encoding, errors='replace') as fin:

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,19 @@ extras =
 commands =
     pytest {posargs} --cov=cantools --cov-config=tox.ini --cov-report=xml --cov-report=term
 
+[testenv:cache]
+setenv = CANTOOLS_CACHE_DIR=cache_dir
+
 [testenv:gh]
 passenv =
     GITHUB_*
     PY_COLORS
+
+[testenv:gh_cache]
+passenv =
+    GITHUB_*
+    PY_COLORS
+setenv = CANTOOLS_CACHE_DIR=cache_dir
 
 [pytest]
 testpaths = tests


### PR DESCRIPTION
Enable database cache via environment variable `CANTOOLS_CACHE_DIR` so tools like `monitor`, `dump` or any other user scripts can start faster without any source code modification:

```shell-session
$ export CANTOOLS_CACHE_DIR=/tmp
$ cantools dump somebig.arxml
```

Cache key is extended with all `load` arguments like `prune_choices` or `frame_id_mask` as they influence the resulting database. Few unit tests were failing because different database load configurations had same cache key.

Database raw file content is removed from the key and replaced with file path and last modification time. Otherwise cache grows quickly in hundreds of megabytes.




