### PR TITLE
ARXML parsing: scientific and hexadecimal numbers

### DIFF
--- a/src/cantools/database/can/formats/arxml/utils.py
+++ b/src/cantools/database/can/formats/arxml/utils.py
@@ -15,15 +15,17 @@ def parse_number_string(in_string : str, allow_float : bool=False) \
     - Some ARXML editors seem to sometimes include a dot in integer
       numbers (e.g., they produce "123.0" instead of "123")
     """
-
     # the string literals "true" and "false" are interpreted as 1 and 0
     if in_string == 'true':
         return 1
     elif in_string == 'false':
         return 0
     # the input string contains a dot -> floating point value
-    elif '.' in in_string:
-        tmp = float(in_string)
+    else:
+        if in_string.lower().startswith('0x'):
+            tmp = float.fromhex(in_string)
+        else:
+            tmp = float(in_string)
 
         if not allow_float and tmp != int(tmp):
             raise ValueError('Floating point value specified where integer '

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -1202,7 +1202,7 @@
                 <COMPU-RATIONAL-COEFFS>
                   <COMPU-NUMERATOR>
                     <V>0</V>
-                    <V>10</V>
+                    <V>1e1</V>
                   </COMPU-NUMERATOR>
                   <COMPU-DENOMINATOR>
                     <V>2</V>


### PR DESCRIPTION
My local arxml dealer got me some stuff with scientific notations and hexadecimal numbers in it. I am not sure if that is pure, but it works with some small tweaks to the parse_number_string function.