### PR TITLE
fix floating-point precision issue in arxml 'parse_number_string'

### DIFF
--- a/src/cantools/database/can/formats/arxml/utils.py
+++ b/src/cantools/database/can/formats/arxml/utils.py
@@ -57,8 +57,6 @@ def parse_number_string(in_string: str, allow_float: bool=False) \
             if ret != int(ret):
                 raise ValueError('Floating point value specified where integer '
                                  'is required')
-
-
             # if an integer is required but a .0 floating point value is
             # specified, we accept the input anyway. (this seems to be an
             # ambiguity in the AUTOSAR specification.)

--- a/src/cantools/database/can/formats/arxml/utils.py
+++ b/src/cantools/database/can/formats/arxml/utils.py
@@ -26,34 +26,39 @@ def parse_number_string(in_string: str, allow_float: bool=False) \
         if in_string == 'false':
             ret = 0
 
-        # parse hex strings
-        if in_string.startswith('0x'):
-            ret = float.fromhex(in_string)
-
-        # allow octal notation without an "o" after the leading 0
+        # note: prefer parsing as integer first to prevent floating-point precision issues in large numbers.
+        # 1. try int parsing from octal notation without an "o" after the leading 0.
         if len(in_string) > 1 and in_string[0] == '0' and in_string[1].isdigit():
             # interpret strings starting with a 0 as octal because
             # python's int(*, 0) does not for some reason.
             ret = int(in_string, 8)
 
+        # 2. try int parsing with auto-detected base.
         if ret is None:
-            # try float parsing; throws an error, if non-numeric
-            # but handles for example scientific notation
+            # handles python integer literals
+            # see https://docs.python.org/3/reference/lexical_analysis.html#integers
             try:
-                ret = float(in_string)
+                ret = int(in_string, 0)
             except ValueError:
                 pass
 
+        # 3. try float parsing from hex string.
+        if ret is None and in_string.startswith('0x'):
+            ret = float.fromhex(in_string)
+
+        # 4. try float parsing from 'normal' float string
         if ret is None:
-            # try int parsing; handles python integer literals
-            # see https://docs.python.org/3/reference/lexical_analysis.html#integers
-            ret = int(in_string, 0)
+            # throws an error, if non-numeric
+            # but handles for example scientific notation
+            ret = float(in_string)
 
         # check for not allowed non-integer values
         if not allow_float:
             if ret != int(ret):
                 raise ValueError('Floating point value specified where integer '
                                  'is required')
+
+
             # if an integer is required but a .0 floating point value is
             # specified, we accept the input anyway. (this seems to be an
             # ambiguity in the AUTOSAR specification.)

--- a/src/cantools/subparsers/plot.py
+++ b/src/cantools/subparsers/plot.py
@@ -525,7 +525,7 @@ class Signals:
                 i12 = signals.index(self.SEP_AXES, i0)
             except ValueError:
                 i12 = None
-            if i1 is None or i12 is not None and i12 < i1:
+            if i1 is None or (i12 is not None and i12 < i1):
                 i1 = i12
 
             subplot_signals = signals[i0:i1]
@@ -792,7 +792,7 @@ class Graph:
     and one more generic matching the rest with another format.
     '''
 
-    __slots__ = ('x', 'y', 'plotted_signal')
+    __slots__ = ('plotted_signal', 'x', 'y')
 
     def __init__(self):
         self.x = []


### PR DESCRIPTION
Currently, the arxml `parse_number_string` utils function parses numeric values as a `float` first, and converts to integer if an integer is required. For very large integers, floating-point error causes the integer to be parsed incorrectly.

```
>>> int(2**64 -1)
18446744073709551615
>>> int(float(2**64 -1))
18446744073709551616
```

This pull request orders the parsing attempts to prevent using `float` at all for parsing integer strings when possible.