### PR TITLE
Encode the given NamedSignalValue 'value' when explicitly given

### DIFF
--- a/src/cantools/database/utils.py
+++ b/src/cantools/database/utils.py
@@ -89,8 +89,18 @@ def _encode_signal_values(signals: Sequence[Union["Signal", "Data"]],
             raw_values[name] = value if conversion.is_float else round(value)
             continue
 
-        if isinstance(value, (str, NamedSignalValue)):
+        if isinstance(value, str):
             raw_values[name] = conversion.choice_to_number(value)
+            continue
+
+        if isinstance(value, NamedSignalValue):
+            # validate the given NamedSignalValue first
+            if value != conversion.raw_to_scaled(value.value, decode_choices=True):
+                raise EncodeError(
+                    f"Invalid 'NamedSignalValue' name/value pair not found! Name {value.name}, value {value.value}"
+                )
+
+            raw_values[name] = value.value
             continue
 
         raise EncodeError(


### PR DESCRIPTION
Some signal definitions may have multiple 'named signal values' with the same name but different raw numeric values (things like "reserved"). Currently, when the `encode()` function is called with signal values of type `NamedSignalValue`, the `.name` attribute is used to look up the appropriate raw numeric value. In the case of multiple 'named signal values' with the same name, this may not be encoding what the caller wants.

This PR changes the `encode()` behavior to encode the NamedSignalValue `.value` attribute, while still checking that the given name/value pair exists in the signal definition.