### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
-        python-version: ["3.9", "3.13", "pypy-3.9"]
+        python-version: ["3.9", "3.13"]
       fail-fast: false
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ lint.ignore = [
     "E501",   # line too long
     "F541",   # f-string-missing-placeholders
     "RUF012", # mutable-class-default
+    "A005",   # Module shadows a Python standard-library module (needed for signal)
 ]
 lint.isort.known-first-party = ["cantools"]
 lint.per-file-ignores."__init__.py" = ["F401"]


### PR DESCRIPTION
the CI system recently started failing on us:

- A new version of ruff has been released which seems to complain about naming conflicts between custom submodules and standard python modules. We disable that check because renaming `signal.py` would probably leave a path of destruction in user code.
- pypy currently seems to be unable to install the (indirect) "pillow" dependency. For this reason, we let's disable testing using pypy for now...

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)