### PR TITLE
Make database.add_dbc_string not overwrite nodes, buses, version and dbc

### DIFF
--- a/src/cantools/database/can/database.py
+++ b/src/cantools/database/can/database.py
@@ -307,10 +307,19 @@ class Database:
         database = dbc.load_string(string, self._strict, sort_signals=self._sort_signals)
 
         self._messages += database.messages
-        self._nodes = database.nodes
-        self._buses = database.buses
-        self._version = database.version
-        self._dbc = database.dbc
+        self._nodes += database.nodes
+        self._buses += database.buses
+
+        if self._version is None:
+            self._version = database.version
+        elif database.version is not None:
+            self._version += database.version
+
+        if self._dbc is None:
+            self._dbc = database.dbc
+        else:
+            self._dbc += database.dbc
+
         self.refresh()
 
     def add_kcd(self, fp: TextIO) -> None:

--- a/src/cantools/database/can/formats/dbc_specifics.py
+++ b/src/cantools/database/can/formats/dbc_specifics.py
@@ -91,3 +91,20 @@ class DbcSpecifics:
         """
 
         return self._attribute_definitions_rel
+
+    def __add__(self, other):
+        new = self.__class__(attributes=self._attributes,
+                             attribute_definitions=self._attribute_definitions,
+                             environment_variables=self._environment_variables,
+                             value_tables=self._value_tables,
+                             attributes_rel=self._attributes_rel,
+                             attribute_definitions_rel=self._attribute_definitions_rel)
+
+        new._attributes.update(other._attributes)
+        new._attribute_definitions.update(other._attribute_definitions)
+        new._environment_variables.update(other._environment_variables)
+        new._value_tables.update(other._value_tables)
+        new._attributes_rel.update(other._attributes_rel)
+        new._attribute_definitions_rel.update(other._attribute_definitions_rel)
+
+        return new

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6207,6 +6207,42 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(False, msgex.is_fd)
         self.assertEqual(True, msgex.is_extended_frame)
 
+    def test_dropping_attribute_definitions(self):
+        """Test against dropping attribute definitions when adding dbc files
+
+        When adding dbc files to a present database, the previous and the added
+        attribute definitions must be present in the resulting database.
+        """
+        filename1 = "tests/files/dbc/attributes.dbc"
+        filename2 = "tests/files/dbc/attributes_relation.dbc"
+        filename3 = "tests/files/dbc/add_two_dbc_files_1.dbc"
+
+        # Load dbc file that contains attribute definition "TheSignalStringAttribute".
+        db = cantools.db.load_file(filename1)
+
+        # Make sure the attribute definition "TheSignalStringAttribute" is present in db
+        # but "MsgProject" is not.
+        self.assertIn("TheSignalStringAttribute", db.dbc.attribute_definitions)
+        self.assertNotIn("MsgProject", db.dbc.attribute_definitions)
+
+        # add another dbc file. This file does not contain the attribute definition
+        # "TheSignalStringAttribute", but instead "MsgProject".
+        db.add_dbc_file(filename2)
+
+        # Now, both attribute definitions must be present in the database.
+        self.assertIn("TheSignalStringAttribute", db.dbc.attribute_definitions)
+        self.assertIn("MsgProject", db.dbc.attribute_definitions)
+
+        # Load another dbc file that does not have any attribute definitions
+        db = cantools.db.load_file(filename3)
+
+        # This attribute definition must not be in the new database.
+        self.assertNotIn("TheSignalStringAttribute", db.dbc.attribute_definitions)
+
+        db.add_dbc_file(filename1)
+
+        self.assertIn("TheSignalStringAttribute", db.dbc.attribute_definitions)
+
 
 # This file is not '__main__' when executed via 'python setup.py3
 # test'.


### PR DESCRIPTION
First up, sorry if I messed stuff up. This is my first time working with github, my first pull request. Please be extra mindful before merging.

I have a use-case where I would need to merge dbc-files. I have found that database.add_dbc_file actually breaks some of my databases. This seems to stem from the behavior in add_dbc_string, where only the messages of the added file are added to the database, everything else seems to simply be overwritten. 

This was likely also the issue for #162. 

This pull request modifies Database.add_dbc_string to not just overwrite _nodes, _buses, _version, and _dbc. Instead the new structures are added to the existing structures. For this, an __add__ method is added to DbcSpecifics class. 

A test case, test_dropping_attribute_definitions was added to check basic functionality.

This pull request should fix this issue and works for my use case. There are, however, no checks for collisions between existing and added db. As the existing OrderedDicts are merely updated with the new OrderedDict, entries in the added dbc will overwrite the previously stored entries. Also, #578 seems to be a similar issue with add_kcd_string, which I did not touch as I have zero experience with kcd files.