### PR TITLE
Update CDD parser to load all possible data types

### DIFF
--- a/src/cantools/database/diagnostics/formats/cdd.py
+++ b/src/cantools/database/diagnostics/formats/cdd.py
@@ -62,11 +62,7 @@ def _load_data_types(ecu_doc):
 
     data_types = {}
 
-    types = ecu_doc.findall('DATATYPES/IDENT')
-    types += ecu_doc.findall('DATATYPES/LINCOMP')
-    types += ecu_doc.findall('DATATYPES/TEXTTBL')
-    types += ecu_doc.findall('DATATYPES/STRUCTDT')
-    types += ecu_doc.findall('DATATYPES/EOSITERDT')
+    types = ecu_doc.findall('DATATYPES/*')
 
     for data_type in types:
         # Default values.


### PR DESCRIPTION
This allows a CDD with types not explicitly specified to be loaded in the intermediate list of data types. Only data types used/referenced by DIDs are actually included in the internal database.