### PR TITLE
add a strict par to fix #725

### DIFF
--- a/src/cantools/tester.py
+++ b/src/cantools/tester.py
@@ -122,7 +122,7 @@ class Message(UserDict):
                  decode_choices,
                  scaling,
                  padding,
-                 strict: bool = True):
+                 strict = True):
         super().__init__()
         self.database = database
         self._mplex_map = invert_signal_tree(database.signal_tree)

--- a/src/cantools/tester.py
+++ b/src/cantools/tester.py
@@ -121,7 +121,8 @@ class Message(UserDict):
                  input_queue,
                  decode_choices,
                  scaling,
-                 padding):
+                 padding,
+                 strict: bool = True):
         super().__init__()
         self.database = database
         self._mplex_map = invert_signal_tree(database.signal_tree)
@@ -130,6 +131,7 @@ class Message(UserDict):
         self.decode_choices = decode_choices
         self.scaling = scaling
         self.padding = padding
+        self.strict = strict
         self._input_list = input_list
         self.enabled = True
         self._can_message = None
@@ -250,7 +252,8 @@ class Message(UserDict):
         pruned_data = self.database.gather_signals(self.data)
         data = self.database.encode(pruned_data,
                                     self.scaling,
-                                    self.padding)
+                                    self.padding,
+                                    strict=self.strict)
         self._can_message = can.Message(arbitration_id=arbitration_id,
                                         is_extended_id=extended_id,
                                         data=data)
@@ -316,7 +319,8 @@ class Tester:
                  on_message=None,
                  decode_choices=True,
                  scaling=True,
-                 padding=False):
+                 padding=False,
+                 strict=True):
         self._dut_name = dut_name
         self._bus_name = bus_name
         self._database = database
@@ -351,7 +355,8 @@ class Tester:
                                                        self._input_queue,
                                                        decode_choices,
                                                        scaling,
-                                                       padding)
+                                                       padding,
+                                                       strict=strict)
 
         listener = Listener(self._database,
                             self._messages,

--- a/tests/files/dbc/issue_725.dbc
+++ b/tests/files/dbc/issue_725.dbc
@@ -1,0 +1,54 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: Node2 Node1
+
+
+BO_ 1 TestMessage: 1 Node1
+ SG_ Signal1 : 0|8@1+ (1,0) [0|250] ""  Node2
+
+
+
+BA_DEF_  "MultiplexExtEnabled" ENUM  "No","Yes";
+BA_DEF_  "BusType" STRING ;
+BA_DEF_  "DBName" STRING ;
+BA_DEF_ SG_  "GenSigStartValue" INT -2147483648 2147483647;
+BA_DEF_DEF_  "MultiplexExtEnabled" "No";
+BA_DEF_DEF_  "BusType" "CAN";
+BA_DEF_DEF_  "DBName" "";
+BA_DEF_DEF_  "GenSigStartValue" -2147483648;
+BA_ "DBName" "test";
+BA_ "GenSigStartValue" SG_ 1 Signal1 254;
+

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -315,6 +315,37 @@ class CanToolsTesterTest(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "expected bus name in ['TheBusName'], but got 'BadBus'")
 
+    def test_signal_init_out_range(self):
+        """The bus name should be None if no bus is given in the database.
+
+        """
+
+        database = cantools.db.load_file('tests/files/dbc/issue_725.dbc')
+        can_bus = CanBus()
+
+        with self.assertRaises(cantools.tester.Error) as cm:
+            cantools.tester.Tester("Node1",
+                                    database,
+                                    can_bus,
+                                    'test',
+                                    on_message=None,
+                                    decode_choices=False,
+                                    scaling=False)
+
+        self.assertEqual(str(cm.exception),
+                         'Expected signal "Signal1" value smaller than or equal to 250 in message "TestMessage", but got 254.')
+        try:
+            cantools.tester.Tester("Node1",
+                                    database,
+                                    can_bus,
+                                    'test',
+                                    on_message=None,
+                                    decode_choices=False,
+                                    scaling=False,
+                                    strict=False)
+        except Exception as e:
+            self.fail(f"Unexpected exception raised: {e}")
+
     def test_on_message(self):
         """Test the on_message callback.
 


### PR DESCRIPTION
add a strict parameter for Tester and Message, so that user can have control whether raise EncodeError for #725