### PR TITLE
fix(dump_string): remove unnecessary space to maintian proper format

### DIFF
--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -663,13 +663,13 @@ def _dump_attribute_definitions(database: InternalDatabase) -> list[str]:
             choices = ','.join([f'"{choice}"'
                                 for choice in definition.choices])
             ba_def.append(
-                f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name}  {choices};')
+                f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name} {choices};')
         elif definition.type_name in ['INT', 'FLOAT', 'HEX']:
             ba_def.append(
                 f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name}{get_minimum(definition)}{get_maximum(definition)};')
         elif definition.type_name == 'STRING':
             ba_def.append(
-                f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name} ;')
+                f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name};')
 
     return ba_def
 
@@ -707,7 +707,7 @@ def _dump_attribute_definitions_rel(database):
                 f'BA_DEF_REL_ {definition.kind}  "{definition.name}" {definition.type_name}{get_minimum(definition)}{get_maximum(definition)};')
         elif definition.type_name == 'STRING':
             ba_def_rel.append(
-                f'BA_DEF_REL_ {definition.kind}  "{definition.name}" {definition.type_name} ;')
+                f'BA_DEF_REL_ {definition.kind}  "{definition.name}" {definition.type_name};')
 
     return ba_def_rel
 


### PR DESCRIPTION
remove unnecessary space to maintain proper format while dumping into string