### PR TITLE
Fix frame collisions between extended and standard frames

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ bus using the `python-can`_ package.
    >>> import can
    >>> can_bus = can.interface.Bus('vcan0', bustype='socketcan')
    >>> data = example_message.encode({'Temperature': 250.1, 'AverageRadius': 3.2, 'Enable': 1})
-   >>> message = can.Message(arbitration_id=example_message.frame_id, data=data)
+   >>> message = can.Message(arbitration_id=example_message.frame_id, is_extended_id=example_message.is_extended_frame, data=data)
    >>> can_bus.send(message)
 
 Alternatively, a message can be encoded using the `encode_message()`_

--- a/examples/motor_tester/motor.py
+++ b/examples/motor_tester/motor.py
@@ -11,7 +11,7 @@ import can
 
 def create_message(speed, load):
     return can.Message(arbitration_id=0x010,
-                       extended_id=False,
+                       is_extended_id=False,
                        data=struct.pack('<HB', speed, load))
 
 

--- a/src/cantools/database/can/database.py
+++ b/src/cantools/database/can/database.py
@@ -472,12 +472,12 @@ class Database:
 
         return self._name_to_message[name]
 
-    def get_message_by_frame_id(self, frame_id: int, is_extended_frame: Optional[bool] = None) -> Message:
+    def get_message_by_frame_id(self, frame_id: int, force_extended_id: bool = False) -> Message:
         """Find the message object for given frame id `frame_id`.
 
         """
 
-        if is_extended_frame or frame_id > 0x7FF:
+        if force_extended_id or frame_id > 0x7FF:
             frame_id |= 0x80000000
 
         return self._frame_id_to_message[frame_id & (0x80000000 | self._frame_id_mask)]
@@ -510,7 +510,7 @@ class Database:
                        scaling: bool = True,
                        padding: bool = False,
                        strict: bool = True,
-                       is_extended_frame: Optional[bool] = None,
+                       force_extended_id: bool = False,
                        ) -> bytes:
         """Encode given signal data `data` as a message of given frame id or
         name `frame_id_or_name`. For regular Messages, `data` is a
@@ -533,7 +533,7 @@ class Database:
         """
 
         if isinstance(frame_id_or_name, int):
-            if is_extended_frame or frame_id_or_name > 0x7FF:
+            if force_extended_id or frame_id_or_name > 0x7FF:
                 frame_id_or_name |= 0x80000000
             message = self._frame_id_to_message[frame_id_or_name]
         elif isinstance(frame_id_or_name, str):
@@ -550,7 +550,7 @@ class Database:
                        scaling: bool = True,
                        decode_containers: bool = False,
                        allow_truncated:  bool = False,
-                       is_extended_frame: Optional[bool] = None,
+                       force_extended_id: bool = False,
                        ) \
         -> DecodeResultType:
 
@@ -578,7 +578,7 @@ class Database:
         """
 
         if isinstance(frame_id_or_name, int):
-            if is_extended_frame or frame_id_or_name > 0x7FF:
+            if force_extended_id or frame_id_or_name > 0x7FF:
                 frame_id_or_name |= 0x80000000
             message = self._frame_id_to_message[frame_id_or_name]
         elif isinstance(frame_id_or_name, str):

--- a/src/cantools/subparsers/monitor.py
+++ b/src/cantools/subparsers/monitor.py
@@ -375,7 +375,7 @@ class Monitor(can.Listener):
         timestamp = raw_message.timestamp - self._basetime
 
         try:
-            message = self._dbase.get_message_by_frame_id(raw_message.arbitration_id) # type: ignore[union-attr]
+            message = self._dbase.get_message_by_frame_id(raw_message.arbitration_id, raw_message.is_extended_id) # type: ignore[union-attr]
         except KeyError:
             return MessageFormattingResult.UnknownMessage
 

--- a/src/cantools/tester.py
+++ b/src/cantools/tester.py
@@ -88,8 +88,7 @@ class Listener(can.Listener):
             return
 
         try:
-            database_message = self._database.get_message_by_frame_id(
-                msg.arbitration_id)
+            database_message = self._database.get_message_by_frame_id(msg.arbitration_id, msg.is_extended_id)
         except KeyError:
             return
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -401,7 +401,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         ]
 
         for frame_id in frame_ids:
-            db.get_message_by_frame_id(frame_id)
+            db.get_message_by_frame_id(frame_id, is_extended_frame=True)
 
     def test_dbc_dump_val_table(self):
         filename = 'tests/files/dbc/val_table.dbc'
@@ -1926,10 +1926,10 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(decoded, {})
 
         frame_id = 0x022
-        encoded = db.encode_message(frame_id, {'Signal3': 'bar'})
+        encoded = db.encode_message(frame_id, {'Signal3': 'bar'}, is_extended_frame=True)
         self.assertEqual(len(encoded), 8)
         self.assertEqual(encoded, b'\x00\x08\x00\x00\x00\x00\x00\x00')
-        decoded = db.decode_message(frame_id, encoded)
+        decoded = db.decode_message(frame_id, encoded, is_extended_frame=True)
         self.assertEqual(decoded['Signal3'], 'bar')
 
     def test_jopp_6_0_sym(self):
@@ -3466,7 +3466,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(attribute.definition.choices, None)
 
         # Message send type.
-        message = db.get_message_by_frame_id(0x39)
+        message = db.get_message_by_frame_id(0x39, is_extended_frame=True)
         self.assertEqual(message.cycle_time, 1000)
         self.assertEqual(message.send_type, 'Cyclic')
 
@@ -3528,11 +3528,11 @@ class CanToolsDatabaseTest(unittest.TestCase):
         with open('tests/files/dbc/attributes.dbc') as fin:
             db = cantools.db.load(fin)
 
-        message = db.get_message_by_frame_id(0x39)
+        message = db.get_message_by_frame_id(0x39, is_extended_frame=True)
         self.assertEqual(message.name, 'TheMessage')
         message.frame_id = 0x40
         db.refresh()
-        message = db.get_message_by_frame_id(0x40)
+        message = db.get_message_by_frame_id(0x40, is_extended_frame=True)
         self.assertEqual(message.name, 'TheMessage')
         self.assertEqual(message.frame_id, 0x40)
 
@@ -3548,9 +3548,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(str(cm.exception), "'TheMissingMessage'")
 
         with self.assertRaises(KeyError) as cm:
-            db.get_message_by_frame_id(0x41)
+            db.get_message_by_frame_id(0x41, is_extended_frame=True)
 
-        self.assertEqual(cm.exception.args[0], 0x41)
+        self.assertEqual(cm.exception.args[0], 0x80000000 | 0x41)
 
     def test_missing_dbc_specifics(self):
         db = cantools.db.Database()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -401,7 +401,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         ]
 
         for frame_id in frame_ids:
-            db.get_message_by_frame_id(frame_id, is_extended_frame=True)
+            db.get_message_by_frame_id(frame_id, force_extended_id=True)
 
     def test_dbc_dump_val_table(self):
         filename = 'tests/files/dbc/val_table.dbc'
@@ -1926,10 +1926,10 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(decoded, {})
 
         frame_id = 0x022
-        encoded = db.encode_message(frame_id, {'Signal3': 'bar'}, is_extended_frame=True)
+        encoded = db.encode_message(frame_id, {'Signal3': 'bar'}, force_extended_id=True)
         self.assertEqual(len(encoded), 8)
         self.assertEqual(encoded, b'\x00\x08\x00\x00\x00\x00\x00\x00')
-        decoded = db.decode_message(frame_id, encoded, is_extended_frame=True)
+        decoded = db.decode_message(frame_id, encoded, force_extended_id=True)
         self.assertEqual(decoded['Signal3'], 'bar')
 
     def test_jopp_6_0_sym(self):
@@ -3466,7 +3466,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(attribute.definition.choices, None)
 
         # Message send type.
-        message = db.get_message_by_frame_id(0x39, is_extended_frame=True)
+        message = db.get_message_by_frame_id(0x39, force_extended_id=True)
         self.assertEqual(message.cycle_time, 1000)
         self.assertEqual(message.send_type, 'Cyclic')
 
@@ -3528,11 +3528,11 @@ class CanToolsDatabaseTest(unittest.TestCase):
         with open('tests/files/dbc/attributes.dbc') as fin:
             db = cantools.db.load(fin)
 
-        message = db.get_message_by_frame_id(0x39, is_extended_frame=True)
+        message = db.get_message_by_frame_id(0x39, force_extended_id=True)
         self.assertEqual(message.name, 'TheMessage')
         message.frame_id = 0x40
         db.refresh()
-        message = db.get_message_by_frame_id(0x40, is_extended_frame=True)
+        message = db.get_message_by_frame_id(0x40, force_extended_id=True)
         self.assertEqual(message.name, 'TheMessage')
         self.assertEqual(message.frame_id, 0x40)
 
@@ -3548,7 +3548,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(str(cm.exception), "'TheMissingMessage'")
 
         with self.assertRaises(KeyError) as cm:
-            db.get_message_by_frame_id(0x41, is_extended_frame=True)
+            db.get_message_by_frame_id(0x41, force_extended_id=True)
 
         self.assertEqual(cm.exception.args[0], 0x80000000 | 0x41)
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -183,6 +183,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=496,
+            is_extended_id=False,
             data=b'\xc0\x06\xe0\x00\x00\x00\x00\x00'))
         monitor.run(1)
 
@@ -232,6 +233,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=496,
+            is_extended_id=False,
             data=b'\xc0\x06\xe0\x00\x00\x00\x00\x00'))
         monitor.run(1)
 
@@ -279,6 +281,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x24\x00\x98\x98\x0b\x00'))
         monitor.run(1)
 
@@ -317,6 +320,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x00\x00\x98\x98\x0b\x00'))
         monitor.run(1)
 
@@ -366,6 +370,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x00\x00\x98\x98\x0b\x00'))
         monitor.run(1)
 
@@ -414,18 +419,22 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=0xc00fefe,
+            is_extended_id=True,
             data=b'\x00\x00\x00\x00\x02\x00\x00\x00',
             timestamp=0.0))
         monitor.on_message_received(can.Message(
             arbitration_id=0xc00fefe,
+            is_extended_id=True,
             data=b'\x00\x00\x00\x00\x01\x00\x00\x00',
             timestamp=1.0))
         monitor.on_message_received(can.Message(
             arbitration_id=0xc00fefe,
+            is_extended_id=True,
             data=b'\x01\x00\x00\x00\x01\x00\x00\x00',
             timestamp=2.0))
         monitor.on_message_received(can.Message(
             arbitration_id=0xc00fefe,
+            is_extended_id=True,
             data=b'\x20\x00\x00\x00\x01\x00\x00\x00',
             timestamp=3.0))
         monitor.run(1)
@@ -482,10 +491,12 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=496,
+            is_extended_id=False,
             data=b'\xc0\x06\xe0\x00\x00\x00\x00\x00',
             timestamp=1.0))
         monitor.on_message_received(can.Message(
             arbitration_id=496,
+            is_extended_id=False,
             data=b'\xc0\x06\xd0\x00\x00\x00\x00\x00',
             timestamp=2.1))
         monitor.run(1)
@@ -537,6 +548,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=496,
+            is_extended_id=False,
             data=b'\xc0\x06\xe0\x00\x00\x00\x00\x00'))
         monitor.run(1)
 
@@ -789,9 +801,11 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x00\x00\x98\x98\x0b\x00'))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x01\x00\x98\x98\x0b\x00'))
         monitor.run(1)
 
@@ -922,6 +936,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=102,
+            is_extended_id=False,
             data=b'\x0A\x0B\x0C\x09\xE2\xD8\x7F\xD6\x00\x86\xB2\x65\x4F\x1D\x2E\x3F\x07\xC0\x00\x5C\x84\x00\x00\x00\x01\x02\x03\x04\x7A\x0E\x00\x00\x04\x05\x06\x06\x2D\x04\x00\x00\x76\x03\x07\x08\x09\x0A\xC6\xEA\x00\x00\x00\x00\x00\x00\x00\x00'))
         monitor.run(1)
 
@@ -1129,10 +1144,12 @@ class CanToolsMonitorTest(unittest.TestCase):
         # OneToContainThemAll with message1 and multiplexed SELECT_HELLO
         monitor.on_message_received(can.Message(
             arbitration_id=102,
+            is_extended_id=False,
             data=b'\n\x0b\x0c\t{\x00\xc8\x01\x01\x00\x00\xa0@\x07\x08\t\n\x11\x02\x00\x00\x00\x00\x00\x00\x00\x00'))
         # OneToContainThemAll with message1 and multiplexed SELECT_WORLD
         monitor.on_message_received(can.Message(
             arbitration_id=102,
+            is_extended_id=False,
             timestamp=10,
             data=b'\n\x0b\x0c\tA\x01\x8e\x02\x00\x00\x00\x80@\x07\x08\t\nQ\x02\x00\x00\x00\x00\x00\x00\x00\x00'))
         monitor.run(1)
@@ -1197,6 +1214,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         # OneToContainThemAll with message1 and undecoded trailing data
         monitor.on_message_received(can.Message(
             arbitration_id=102,
+            is_extended_id=False,
             data=b'\n\x0b\x0c\t{\x00\xc8\x01\x04V\x0eI@\x00\x00\x00\x00'))
         monitor.run(1)
 
@@ -1251,10 +1269,12 @@ class CanToolsMonitorTest(unittest.TestCase):
         # OneToContainThemAll with message1 and multiplexed SELECT_HELLO
         monitor.on_message_received(can.Message(
             arbitration_id=102,
+            is_extended_id=False,
             data=b'\n\x0b\x0c\t{\x00\xc8\x01\x01\x00\x00\xa0@\x07\x08\t\n\x11\x02\x00\x00\x00\x00\x00\x00\x00\x00'))
         # OneToContainThemAll with message1 and multiplexed SELECT_WORLD
         monitor.on_message_received(can.Message(
             arbitration_id=102,
+            is_extended_id=False,
             timestamp=10,
             data=b'\n\x0b\x0c\tA\x01\x8e\x02\x00\x00\x00\x80@\x07\x08\t\nQ\x02\x00\x00\x00\x00\x00\x00\x00\x00'))
         monitor.run(1)
@@ -1299,12 +1319,14 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=496,
+            is_extended_id=False,
             data=b'\xc0\x06\xe0\x00\x00\x00\x00\x00',
             timestamp=3))
 
         # Discarded.
         monitor.on_message_received(can.Message(
             arbitration_id=497,
+            is_extended_id=False,
             data=b'\xc0\x06\xb0\x00\x00\x00\x00\x00',
             timestamp=6))
 
@@ -1315,6 +1337,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         # Input another before pause.
         monitor.on_message_received(can.Message(
             arbitration_id=496,
+            is_extended_id=False,
             data=b'\xc0\x06\xc0\x00\x00\x00\x00\x00',
             timestamp=7))
 
@@ -1323,6 +1346,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         # Input when paused. Will not be displayed.
         monitor.on_message_received(can.Message(
             arbitration_id=496,
+            is_extended_id=False,
             data=b'\xc0\x06\xd0\x00\x00\x00\x00\x00',
             timestamp=10))
 
@@ -1333,6 +1357,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         # Input after reset.
         monitor.on_message_received(can.Message(
             arbitration_id=496,
+            is_extended_id=False,
             data=b'\xc0\x06\x00\x00\x00\x00\x00\x00',
             timestamp=11))
 
@@ -1447,6 +1472,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         for timestamp in range(4):
             monitor.on_message_received(can.Message(
                 arbitration_id=496,
+                is_extended_id=False,
                 data=b'\xc0\x06\xe0\x00\x00\x00\x00\x00',
                 timestamp=timestamp))
 
@@ -1460,6 +1486,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         for timestamp in range(5, 7):
             monitor.on_message_received(can.Message(
                 arbitration_id=496,
+                is_extended_id=False,
                 data=b'\xc0\x06\xe0\x00\x00\x00\x00\x00',
                 timestamp=timestamp))
 
@@ -1592,6 +1619,7 @@ class CanToolsMonitorTest(unittest.TestCase):
 
         monitor.on_message_received(can.Message(
             arbitration_id=496,
+            is_extended_id=False,
             data=b'\xc0\x06\xe0\x00\x00\x00\x00\x00',
             timestamp=1))
 
@@ -1660,78 +1688,97 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x00\x00\x98\x98\x0b\x00',
             timestamp=0))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x01\x00\x98\x98\x0b\x00',
             timestamp=1))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x02\x00\x98\x98\x0b\x00',
             timestamp=2))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x03\x00\x98\x98\x0b\x00',
             timestamp=3))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x04\x00\x98\x98\x0b\x00',
             timestamp=4))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x05\x00\x98\x98\x0b\x00',
             timestamp=5))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x06\x00\x98\x98\x0b\x00',
             timestamp=6))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x07\x00\x98\x98\x0b\x00',
             timestamp=7))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x08\x00\x98\x98\x0b\x00',
             timestamp=8))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x09\x00\x98\x98\x0b\x00',
             timestamp=9))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x0a\x00\x98\x98\x0b\x00',
             timestamp=10))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x0b\x00\x98\x98\x0b\x00',
             timestamp=11))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x0c\x00\x98\x98\x0b\x00',
             timestamp=12))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x0d\x00\x98\x98\x0b\x00',
             timestamp=13))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x0e\x00\x98\x98\x0b\x00',
             timestamp=14))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x0f\x00\x98\x98\x0b\x00',
             timestamp=15))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x10\x00\x98\x98\x0b\x00',
             timestamp=16))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x11\x00\x98\x98\x0b\x00',
             timestamp=17))
         monitor.on_message_received(can.Message(
             arbitration_id=1025,
+            is_extended_id=False,
             data=b'\x12\x00\x98\x98\x0b\x00',
             timestamp=18))
         monitor.tick(1)
@@ -1931,6 +1978,7 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor = Monitor(stdscr, args)
         monitor.on_message_received(can.Message(
             arbitration_id=1,
+            is_extended_id=False,
             data=b'\x24'))
         monitor.run(1)
 

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -145,9 +145,9 @@ class CanToolsTesterTest(unittest.TestCase):
         tester.start()
 
         # Input the three messages.
-        can_bus.input_message(can.Message(arbitration_id=0x101, data=b'\x00\x00'))
-        can_bus.input_message(can.Message(arbitration_id=0x101, data=b'\x00\x01'))
-        can_bus.input_message(can.Message(arbitration_id=0x101, data=b'\x02\x03'))
+        can_bus.input_message(can.Message(arbitration_id=0x101, is_extended_id=False, data=b'\x00\x00'))
+        can_bus.input_message(can.Message(arbitration_id=0x101, is_extended_id=False, data=b'\x00\x01'))
+        can_bus.input_message(can.Message(arbitration_id=0x101, is_extended_id=False, data=b'\x02\x03'))
 
         # Expect Message1 with no filtering.
         message = tester.expect('Message1')
@@ -166,22 +166,22 @@ class CanToolsTesterTest(unittest.TestCase):
         self.assertIsNone(message)
 
         # Expect with timeout, with Message2 discarded when expecting Message1.
-        can_bus.input_message(can.Message(arbitration_id=0x102, data=b'\x00\x00\x00'))
+        can_bus.input_message(can.Message(arbitration_id=0x102, is_extended_id=False, data=b'\x00\x00\x00'))
         message = tester.expect('Message1', timeout=0.5)
         self.assertIsNone(message)
         message = tester.expect('Message2', timeout=0.0)
         self.assertIsNone(message)
 
         # Expect with timeout 0.0 with wrong message in queue.
-        can_bus.input_message(can.Message(arbitration_id=0x102, data=b'\x00\x00\x00'))
+        can_bus.input_message(can.Message(arbitration_id=0x102, is_extended_id=False, data=b'\x00\x00\x00'))
         time.sleep(0.1)
         message = tester.expect('Message1', timeout=0.0)
         self.assertIsNone(message)
 
         # Expect with discard_other_messages set to False.
-        can_bus.input_message(can.Message(arbitration_id=0x102, data=b'\x03\x00\x00'))
-        can_bus.input_message(can.Message(arbitration_id=0x102, data=b'\x04\x00\x00'))
-        can_bus.input_message(can.Message(arbitration_id=0x101, data=b'\x05\x00'))
+        can_bus.input_message(can.Message(arbitration_id=0x102, is_extended_id=False, data=b'\x03\x00\x00'))
+        can_bus.input_message(can.Message(arbitration_id=0x102, is_extended_id=False, data=b'\x04\x00\x00'))
+        can_bus.input_message(can.Message(arbitration_id=0x101, is_extended_id=False, data=b'\x05\x00'))
         message = tester.expect('Message1', discard_other_messages=False)
         self.assertEqual(message, {'Signal1': 5, 'Signal2': 0})
         message = tester.expect('Message1', timeout=0.0, discard_other_messages=False)
@@ -205,8 +205,8 @@ class CanToolsTesterTest(unittest.TestCase):
         tester, can_bus = setup_tester('Node1')
         tester.start()
 
-        can_bus.input_message(can.Message(arbitration_id=0x101, data=b'\x00\x00'))
-        can_bus.input_message(can.Message(arbitration_id=0x102, data=b'\x00\x00\x00'))
+        can_bus.input_message(can.Message(arbitration_id=0x101, is_extended_id=False, data=b'\x00\x00'))
+        can_bus.input_message(can.Message(arbitration_id=0x102, is_extended_id=False, data=b'\x00\x00\x00'))
         time.sleep(0.1)
         self.assertIsNone(tester.flush_input())
         message = tester.expect('Message1', timeout=0.0)
@@ -361,13 +361,13 @@ class CanToolsTesterTest(unittest.TestCase):
         tester.start()
 
         # Bad message id.
-        can_bus.input_message(can.Message(arbitration_id=0x7ff, data=b'\x00\x00'))
+        can_bus.input_message(can.Message(arbitration_id=0x7ff, is_extended_id=False, data=b'\x00\x00'))
 
         # Disabled message.
-        can_bus.input_message(can.Message(arbitration_id=0x102, data=b'\x00\x00\x00'))
+        can_bus.input_message(can.Message(arbitration_id=0x102, is_extended_id=False, data=b'\x00\x00\x00'))
 
         # Good message
-        can_bus.input_message(can.Message(arbitration_id=0x101, data=b'\x00\x00'))
+        can_bus.input_message(can.Message(arbitration_id=0x101, is_extended_id=False, data=b'\x00\x00'))
 
         # Check that only the good message was passed to on_message().
         decoded_message = message_queue.get()


### PR DESCRIPTION
If an extended frame was having an ID that would be <= 0x7FF, then it would collide with the ID of a standard frame

This is fixed by setting the top bit i.e. OR'ing the frame by 0x80000000 similar to what is done in DBC files and in the Linux kernel

Fixes #654