### PR TITLE
Make Exceptions Picklable

### DIFF
--- a/src/cantools/database/__init__.py
+++ b/src/cantools/database/__init__.py
@@ -9,45 +9,7 @@ from . import can, diagnostics, utils
 
 # Remove once less users are using the old package structure.
 from .can import *  # noqa: F403
-from .errors import Error, ParseError
-
-
-class UnsupportedDatabaseFormatError(Error):
-    """This exception is raised when
-    :func:`~cantools.database.load_file()`,
-    :func:`~cantools.database.load()` and
-    :func:`~cantools.database.load_string()` are unable to parse given
-    database file or string.
-
-    """
-
-    def __init__(self, e_arxml, e_dbc, e_kcd, e_sym, e_cdd):
-        message = []
-
-        if e_arxml is not None:
-            message.append(f'ARXML: "{e_arxml}"')
-
-        if e_dbc is not None:
-            message.append(f'DBC: "{e_dbc}"')
-
-        if e_kcd is not None:
-            message.append(f'KCD: "{e_kcd}"')
-
-        if e_sym is not None:
-            message.append(f'SYM: "{e_sym}"')
-
-        if e_cdd is not None:
-            message.append(f'CDD: "{e_cdd}"')
-
-        message = ', '.join(message)
-
-        super().__init__(message)
-
-        self.e_arxml = e_arxml
-        self.e_dbc = e_dbc
-        self.e_kcd = e_kcd
-        self.e_sym = e_sym
-        self.e_cdd = e_cdd
+from .errors import Error, UnsupportedDatabaseFormatError
 
 
 def _resolve_database_format_and_encoding(database_format,

--- a/src/cantools/database/errors.py
+++ b/src/cantools/database/errors.py
@@ -1,3 +1,5 @@
+from typing import Any, Optional, Union
+
 from ..errors import Error as _Error
 
 
@@ -15,3 +17,49 @@ class EncodeError(Error):
 
 class DecodeError(Error):
     pass
+
+
+class UnsupportedDatabaseFormatError(Error):
+    """This exception is raised when
+    :func:`~cantools.database.load_file()`,
+    :func:`~cantools.database.load()` and
+    :func:`~cantools.database.load_string()` are unable to parse given
+    database file or string.
+
+    """
+
+    def __init__(self,
+                 e_arxml: Optional[Exception],
+                 e_dbc: Optional[Exception],
+                 e_kcd: Optional[Exception],
+                 e_sym: Optional[Exception],
+                 e_cdd: Optional[Exception]) -> None:
+        message_chunks: list[str] = []
+
+        if e_arxml is not None:
+            message_chunks.append(f'ARXML: "{e_arxml}"')
+
+        if e_dbc is not None:
+            message_chunks.append(f'DBC: "{e_dbc}"')
+
+        if e_kcd is not None:
+            message_chunks.append(f'KCD: "{e_kcd}"')
+
+        if e_sym is not None:
+            message_chunks.append(f'SYM: "{e_sym}"')
+
+        if e_cdd is not None:
+            message_chunks.append(f'CDD: "{e_cdd}"')
+
+        message = ', '.join(message_chunks)
+
+        super().__init__(message)
+
+        self.e_arxml = e_arxml
+        self.e_dbc = e_dbc
+        self.e_kcd = e_kcd
+        self.e_sym = e_sym
+        self.e_cdd = e_cdd
+
+    def __reduce__(self) -> Union[str, tuple[Any, ...]]:
+        return type(self), (self.e_arxml, self.e_dbc, self.e_kcd, self.e_sym, self.e_cdd), {}

--- a/tests/test_diagnostics_database.py
+++ b/tests/test_diagnostics_database.py
@@ -2,6 +2,7 @@ import logging
 import unittest
 
 import cantools
+from cantools.database.errors import ParseError
 
 
 class CanToolsDiagnosticsDatabaseTest(unittest.TestCase):
@@ -485,7 +486,7 @@ class CanToolsDiagnosticsDatabaseTest(unittest.TestCase):
     def test_unknown_byteorder(self):
         db = cantools.db.diagnostics.Database()
 
-        with self.assertRaises(cantools.database.ParseError) as pe:
+        with self.assertRaises(ParseError) as pe:
             db.add_cdd_file('tests/files/cdd/invalid-bo-example.cdd', encoding = 'iso-8859-1')
 
         self.assertEqual(str(pe.exception), "Unknown byte order code: 4321")


### PR DESCRIPTION
@andlaus unrelated, but the `from .can import *` should be removed. The comment says `# Remove once less users are using the old package structure` for seven years now