### PR TITLE
Add cantools.db DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,5 +103,4 @@ lint.ignore = [
     "RUF012", # mutable-class-default
 ]
 lint.isort.known-first-party = ["cantools"]
-lint.per-file-ignores."__init__.py" = ["F401"]
 lint.per-file-ignores."signal.py" = ["A005"]

--- a/src/cantools/__init__.py
+++ b/src/cantools/__init__.py
@@ -1,16 +1,17 @@
+__all__ = ["Error", "__author__", "__version__", "database", "j1939", "logreader", "tester"]
+
 import argparse
 import importlib
 import logging
 import os
 import pathlib
 import sys
+import types
+import warnings
 from importlib.metadata import PackageNotFoundError, version
 
-from . import j1939, logreader, tester
+from . import database, j1939, logreader, tester
 from .errors import Error
-
-# Remove once less users are using the old package structure.
-from . import database as db  # isort: skip
 
 __author__ = 'Erik Moqvist'
 
@@ -19,6 +20,22 @@ try:
 except PackageNotFoundError:
     # package is not installed
     pass
+
+
+class _DeprecatedModule(types.ModuleType):
+    def __getattr__(self, name):
+        warnings.warn(
+            "'cantools.db' is deprecated. Please use 'cantools.database' instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        return getattr(database, name)
+
+    def __dir__(self):
+        return dir(database)
+
+# Replace `db` with a deprecation proxy
+db = _DeprecatedModule("cantools.db")
 
 
 class _ErrorSubparser:

--- a/src/cantools/autosar/__init__.py
+++ b/src/cantools/autosar/__init__.py
@@ -1,4 +1,28 @@
 # a collection of AUTOSAR specific functionality
+__all__ = [
+   "SecOCError",
+   "apply_authenticator",
+   "apply_profile2_crc",
+   "apply_profile5_crc",
+   "check_profile2_crc",
+   "check_profile5_crc",
+   "compute_authenticator",
+   "compute_profile2_crc",
+   "compute_profile5_crc",
+   "verify_authenticator",
+]
 
-from .end_to_end import *  # noqa: F403
-from .secoc import *  # noqa: F403
+from .end_to_end import (
+   apply_profile2_crc,
+   apply_profile5_crc,
+   check_profile2_crc,
+   check_profile5_crc,
+   compute_profile2_crc,
+   compute_profile5_crc,
+)
+from .secoc import (
+   SecOCError,
+   apply_authenticator,
+   compute_authenticator,
+   verify_authenticator,
+)

--- a/src/cantools/database/__init__.py
+++ b/src/cantools/database/__init__.py
@@ -1,3 +1,6 @@
+__all__ = ["Bus", "Database", "DecodeError", "EncodeError", "Message",
+           "Node", "Signal", "dump_file", "load", "load_file", "load_string"]
+
 import os
 from contextlib import nullcontext
 from typing import Any, Optional, TextIO, Union
@@ -6,10 +9,17 @@ import diskcache
 
 from ..typechecking import StringPathLike
 from . import can, diagnostics, utils
-
-# Remove once less users are using the old package structure.
-from .can import *  # noqa: F403
-from .errors import Error, UnsupportedDatabaseFormatError
+from .can.bus import Bus
+from .can.database import Database
+from .can.message import Message
+from .can.node import Node
+from .can.signal import Signal
+from .errors import (
+    DecodeError,
+    EncodeError,
+    Error,
+    UnsupportedDatabaseFormatError,
+)
 
 
 def _resolve_database_format_and_encoding(database_format,

--- a/src/cantools/database/can/__init__.py
+++ b/src/cantools/database/can/__init__.py
@@ -1,3 +1,6 @@
+__all__ = ["Bus", "Database", "DecodeError",
+           "EncodeError", "Message", "Node", "Signal"]
+
 from .bus import Bus
 from .database import Database
 from .message import DecodeError, EncodeError, Message

--- a/src/cantools/database/can/formats/arxml/__init__.py
+++ b/src/cantools/database/can/formats/arxml/__init__.py
@@ -1,3 +1,7 @@
+__all__ = ["AutosarBusSpecifics", "AutosarDatabaseSpecifics",
+           "AutosarEnd2EndProperties", "AutosarMessageSpecifics",
+           "AutosarNodeSpecifics", "AutosarSecOCProperties", "load_string"]
+
 import re
 from typing import Any
 from xml.etree import ElementTree

--- a/src/cantools/database/diagnostics/__init__.py
+++ b/src/cantools/database/diagnostics/__init__.py
@@ -1,3 +1,9 @@
+__all__ = [
+    "Data",
+    "Database",
+    "Did",
+]
+
 from .data import Data
 from .database import Database
 from .did import Did

--- a/tests/test_autosar.py
+++ b/tests/test_autosar.py
@@ -9,7 +9,7 @@ from cantools.autosar.snakeauth import SnakeOilAuthenticator
 
 class CanToolsAutosarTest(unittest.TestCase):
     def test_autosar3_e2e_profile2(self):
-        db = cantools.db.load_file('tests/files/arxml/system-3.2.3.arxml')
+        db = cantools.database.load_file('tests/files/arxml/system-3.2.3.arxml')
         msg = db.get_message_by_name('Status')
 
         # verify the parameters
@@ -45,7 +45,7 @@ class CanToolsAutosarTest(unittest.TestCase):
 
         # make sure that profile 5 protected messages cannot be used
         # with the functions for profile 2
-        db2 = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
+        db2 = cantools.database.load_file('tests/files/arxml/system-4.2.arxml')
         pr5msg = db2.get_message_by_name('Message3')
         self.assertIsNone(cantools.autosar.apply_profile2_crc(b'\xff\xff',
                                                               pr5msg))
@@ -53,7 +53,7 @@ class CanToolsAutosarTest(unittest.TestCase):
                                                               pr5msg))
 
     def test_autosar4_e2e_profile5(self):
-        db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
+        db = cantools.database.load_file('tests/files/arxml/system-4.2.arxml')
         msg = db.get_message_by_name('Message3')
 
         # verify the parameters
@@ -91,7 +91,7 @@ class CanToolsAutosarTest(unittest.TestCase):
 
         # make sure that profile 2 protected messages cannot be used
         # with the functions for profile 5
-        db2 = cantools.db.load_file('tests/files/arxml/system-3.2.3.arxml')
+        db2 = cantools.database.load_file('tests/files/arxml/system-3.2.3.arxml')
         pr2msg = db2.get_message_by_name('Status')
         self.assertIsNone(
             cantools.autosar.apply_profile5_crc(b'\xff\xff\xff\xff', pr2msg))
@@ -99,7 +99,7 @@ class CanToolsAutosarTest(unittest.TestCase):
             cantools.autosar.check_profile5_crc(b'\xff\xff\xff\xff', pr2msg))
 
     def test_autosar4_e2e(self):
-        db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
+        db = cantools.database.load_file('tests/files/arxml/system-4.2.arxml')
 
         # verify the E2E parameters for a message that uses profile 5
         msg = db.get_message_by_name('Message3')
@@ -136,7 +136,7 @@ class CanToolsAutosarTest(unittest.TestCase):
         self.assertEqual(msg.autosar.e2e.payload_length, 4)
 
     def test_autosar4_secoc(self):
-        db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
+        db = cantools.database.load_file('tests/files/arxml/system-4.2.arxml')
 
         dbmsg = db.get_message_by_name('Message3')
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -141,7 +141,7 @@ class CanToolsConvertFullTest(unittest.TestCase):
         fn_expected_output = self.get_test_file_name('dbc/motohawk_fd.dbc')
         fn_out = self.get_out_file_name(fn_expected_output, ext='.dbc')
 
-        db = cantools.db.load_file(fn_in)
+        db = cantools.database.load_file(fn_in)
 
         # make bus CAN FD
         bus_type_def = AttributeDefinition("BusType",

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2611,10 +2611,10 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(str(cm.exception), 'syntax error: line 1, column 0')
 
     def test_bus(self):
-        bus = cantools.db.bus.Bus('foo')
+        bus = cantools.db.Bus('foo')
         self.assertEqual(repr(bus), "bus('foo', None)")
 
-        bus = cantools.db.bus.Bus('foo', 'bar')
+        bus = cantools.db.Bus('foo', 'bar')
         self.assertEqual(repr(bus), "bus('foo', 'bar')")
 
     def test_num(self):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -158,9 +158,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_dbc_gensigstartval_from_raw_initial(self):
         sig = Signal(name='s', start=0, length=8, raw_initial=47)
         msg = Message(frame_id=0x42, name='m', length=8, signals=[sig])
-        expected_db = cantools.db.Database(messages=[msg])
+        expected_db = cantools.database.Database(messages=[msg])
 
-        actual_db = cantools.db.Database()
+        actual_db = cantools.database.Database()
         actual_db.add_dbc_string(expected_db.as_dbc_string())
 
         self.assertEqual(
@@ -171,7 +171,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         filename = 'tests/files/dbc/motohawk.dbc'
 
         with open(filename) as fin:
-            db = cantools.db.load(fin)
+            db = cantools.database.load(fin)
 
         self.assertEqual(db.buses, [])
         self.assertEqual(len(db.nodes), 2)
@@ -187,7 +187,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assert_dbc_dump(db, filename)
 
     def test_emc32(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
 
         with open('tests/files/dbc/emc32.dbc') as fin:
             db.add_dbc(fin)
@@ -246,7 +246,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             " 'DUMMY_NODE_VECTOR0', 'Vector__XXX', 'Elevation Head')")
 
     def test_foobar(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/foobar.dbc')
 
         self.assertEqual(len(db.nodes), 4)
@@ -314,7 +314,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message.signals[0].length, 64)
 
     def test_foobar_encode_decode(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/foobar.dbc')
 
         messages = [
@@ -354,7 +354,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             self.assertEqual(decoded, decoded_message)
 
     def test_foobar_encode_decode_frame_ids(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/foobar.dbc')
 
         messages = [
@@ -394,7 +394,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             self.assertEqual(decoded, decoded_message)
 
     def test_foobar_decode_masked_frame_id(self):
-        db = cantools.db.Database(frame_id_mask=0xff)
+        db = cantools.database.Database(frame_id_mask=0xff)
         db.add_dbc_file('tests/files/dbc/foobar.dbc')
 
         frame_ids = [
@@ -479,7 +479,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/padding_bit_order.dbc')
 
         # Message 0.
@@ -560,7 +560,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/motohawk.dbc')
 
         example_message_name = 'ExampleMessage'
@@ -663,7 +663,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/motohawk.dbc')
 
         msgname = 'ExampleMessage'
@@ -717,7 +717,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/motohawk.dbc')
 
         decoded_message = {
@@ -737,7 +737,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/socialledge.dbc')
 
         decoded_message = {
@@ -763,7 +763,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/motohawk.dbc')
 
         decoded_message = {
@@ -894,7 +894,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_encode_signal_strict_negative_scaling(self, value, scaling, expected_result):
         """Test encoding of a signal with negative scaling (=-0.01),
         a value range from 4070-4100 and a value table."""
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/issue_636_negative_scaling.dbc')
         msg = db.get_message_by_name("ExampleMessage")
 
@@ -913,7 +913,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/motohawk.dbc')
 
         decoded_message = {
@@ -935,7 +935,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(decoded, decoded_message)
 
     def test_socialledge(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/socialledge.dbc')
 
         # Verify nodes.
@@ -1022,7 +1022,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/socialledge.dbc')
 
         frame_id = 200
@@ -1047,7 +1047,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/socialledge.dbc')
 
         frame_id = 200
@@ -1072,7 +1072,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
+        db = cantools.database.load_file('tests/files/arxml/system-4.2.arxml')
 
         db_msg = db.get_message_by_name('OneToContainThemAll')
 
@@ -1170,7 +1170,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
                          b'\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8')
 
     def test_gather_signals(self):
-        db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
+        db = cantools.database.load_file('tests/files/arxml/system-4.2.arxml')
 
         db_msg = db.get_message_by_name('MultiplexedMessage')
 
@@ -1291,7 +1291,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_get_message_by_frame_id_and_name(self):
         with open('tests/files/dbc/motohawk.dbc') as fin:
-            db = cantools.db.load(fin)
+            db = cantools.database.load(fin)
 
         message = db.get_message_by_name('ExampleMessage')
         self.assertEqual(message.name, 'ExampleMessage')
@@ -1300,7 +1300,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message.frame_id, 496)
 
     def test_get_signal_by_name(self):
-        db = cantools.db.load_file('tests/files/dbc/foobar.dbc')
+        db = cantools.database.load_file('tests/files/dbc/foobar.dbc')
 
         message = db.get_message_by_name('Foo')
 
@@ -1326,7 +1326,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             ])[32:].decode('cp1252'))
 
     def test_the_homer(self):
-        db = cantools.db.load_file('tests/files/kcd/the_homer.kcd')
+        db = cantools.database.load_file('tests/files/kcd/the_homer.kcd')
 
         self.assertEqual(db.version, '1.23')
         self.assertEqual(len(db.nodes), 18)
@@ -1599,7 +1599,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message.length, 1)
 
     def test_the_homer_encode_length(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_kcd_file('tests/files/kcd/the_homer.kcd')
 
         frame_id = 0x400
@@ -1615,7 +1615,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(encoded, encoded_message)
 
     def test_the_homer_float(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_kcd_file('tests/files/kcd/the_homer.kcd')
 
         # Message 1 (binary64).
@@ -1643,7 +1643,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(decoded, decoded_message)
 
     def test_the_homer_encode_decode_choices(self):
-        db = cantools.db.load_file('tests/files/kcd/the_homer.kcd')
+        db = cantools.database.load_file('tests/files/kcd/the_homer.kcd')
 
         messages = [
             ({'EngagedGear': 'disengaged'}, b'\x00\x00'),
@@ -1695,7 +1695,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             self.assertEqual(decoded, decoded_message)
 
     def test_the_homer_encode_decode_big_endian(self):
-        db = cantools.db.load_file('tests/files/kcd/the_homer.kcd')
+        db = cantools.database.load_file('tests/files/kcd/the_homer.kcd')
 
         decoded_message = {
             'A': 0x140fa,
@@ -1710,7 +1710,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(decoded, decoded_message)
 
     def test_the_homer_encode_decode_signed(self):
-        db = cantools.db.load_file('tests/files/kcd/the_homer.kcd')
+        db = cantools.database.load_file('tests/files/kcd/the_homer.kcd')
 
         datas = [
             (
@@ -1738,14 +1738,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
             self.assertEqual(decoded, decoded_message)
 
     def test_empty_kcd(self):
-        db = cantools.db.load_file('tests/files/kcd/empty.kcd')
+        db = cantools.database.load_file('tests/files/kcd/empty.kcd')
 
         self.assertEqual(db.version, None)
         self.assertEqual(db.nodes, [])
 
     def test_invalid_kcd(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_string('<WrongRootElement/>',
+            cantools.database.load_string('<WrongRootElement/>',
                                     database_format='kcd')
 
         self.assertEqual(
@@ -1755,7 +1755,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             'got WrongRootElement."')
 
     def test_jopp_5_0_sym(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
 
         with self.assertRaises(ParseError) as cm:
             db.add_sym_file('tests/files/sym/jopp-5.0.sym')
@@ -1763,10 +1763,10 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(str(cm.exception), 'Only SYM version 6.0 is supported.')
 
     def internal_test_jopp_6_0_sym(self, test_sym_string):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_sym_file('tests/files/sym/jopp-6.0.sym')
         if test_sym_string:
-            db = cantools.db.load_string(db.as_sym_string())
+            db = cantools.database.load_string(db.as_sym_string())
 
         self.assertEqual(len(db.messages), 7)
         self.assertEqual(len(db.messages[0].signals), 0)
@@ -2346,7 +2346,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_5.multiplexer_ids, None)
 
     def test_add_bad_sym_string(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
 
         with self.assertRaises(textparser.ParseError) as cm:
             db.add_sym_string('FormatVersion=6.0\n'
@@ -2357,7 +2357,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             'Invalid syntax at line 2, column 1: ">>!<<Foo="Jopp""')
 
     def test_multiplexed_variables_sym(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_sym_file('tests/files/sym/multiplexed_variables.sym')
         message = db.get_message_by_name('TestAlert')
         self.assertEqual(message.signal_tree,
@@ -2375,7 +2375,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
                          ])
 
     def test_type_parameter_overrides_is_extended_sym(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
         db.add_sym_file('tests/files/sym/type-extended-cycle-dash-p.sym')
         message = db.get_message_by_name('CAN-Tx Query')
         self.assertTrue(message.is_extended_frame)
@@ -2600,10 +2600,10 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_load_bad_format(self):
         with self.assertRaises(UnsupportedDatabaseFormatError):
-            cantools.db.load(StringIO(''))
+            cantools.database.load(StringIO(''))
 
     def test_add_bad_kcd_string(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
 
         with self.assertRaises(ElementTree.ParseError) as cm:
             db.add_kcd_string('not xml')
@@ -2611,10 +2611,10 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(str(cm.exception), 'syntax error: line 1, column 0')
 
     def test_bus(self):
-        bus = cantools.db.Bus('foo')
+        bus = cantools.database.Bus('foo')
         self.assertEqual(repr(bus), "bus('foo', None)")
 
-        bus = cantools.db.Bus('foo', 'bar')
+        bus = cantools.database.Bus('foo', 'bar')
         self.assertEqual(repr(bus), "bus('foo', 'bar')")
 
     def test_num(self):
@@ -2626,7 +2626,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_timing(self):
         filename = 'tests/files/dbc/timing.dbc'
-        db = cantools.db.load_file(filename)
+        db = cantools.database.load_file(filename)
 
         # Message cycle time is 200, as given by BA_.
         message = db.get_message_by_frame_id(1)
@@ -2642,7 +2642,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assert_dbc_dump(db, filename)
 
     def test_multiplex(self):
-        db = cantools.db.load_file('tests/files/dbc/multiplex.dbc')
+        db = cantools.database.load_file('tests/files/dbc/multiplex.dbc')
 
         message_1 = db.messages[0]
         self.assertTrue(message_1.is_multiplexed())
@@ -2713,7 +2713,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assert_dbc_dump(db, 'tests/files/dbc/multiplex_dumped.dbc')
 
     def test_multiplex_choices(self):
-        db = cantools.db.load_file('tests/files/dbc/multiplex_choices.dbc',
+        db = cantools.database.load_file('tests/files/dbc/multiplex_choices.dbc',
                                    prune_choices=False)
 
         # With Multiplexor and BIT_L as strings.
@@ -2780,7 +2780,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assert_dbc_dump(db, 'tests/files/dbc/multiplex_choices_dumped.dbc')
 
     def test_multiplex_2(self):
-        db = cantools.db.load_file('tests/files/dbc/multiplex_2.dbc')
+        db = cantools.database.load_file('tests/files/dbc/multiplex_2.dbc')
 
         # Shared.
         message = db.messages[0]
@@ -2879,53 +2879,53 @@ class CanToolsDatabaseTest(unittest.TestCase):
         #            +-- S8            | 40..48
         #
         signals = [
-            cantools.db.Signal(name='S0',
+            cantools.database.Signal(name='S0',
                                start=0,
                                length=4,
                                is_multiplexer=True),
-            cantools.db.Signal(name='S1',
+            cantools.database.Signal(name='S1',
                                start=4,
                                length=4,
                                is_multiplexer=True,
                                multiplexer_ids=[0],
                                multiplexer_signal='S0'),
-            cantools.db.Signal(name='S2',
+            cantools.database.Signal(name='S2',
                                start=8,
                                length=8,
                                multiplexer_ids=[0],
                                multiplexer_signal='S1'),
-            cantools.db.Signal(name='S3',
+            cantools.database.Signal(name='S3',
                                start=16,
                                length=16,
                                multiplexer_ids=[0],
                                multiplexer_signal='S1'),
-            cantools.db.Signal(name='S4',
+            cantools.database.Signal(name='S4',
                                start=8,
                                length=24,
                                multiplexer_ids=[2],
                                multiplexer_signal='S1'),
-            cantools.db.Signal(name='S5',
+            cantools.database.Signal(name='S5',
                                start=4,
                                length=28,
                                multiplexer_ids=[1],
                                multiplexer_signal='S0'),
-            cantools.db.Signal(name='S6',
+            cantools.database.Signal(name='S6',
                                start=32,
                                length=8,
                                is_multiplexer=True),
-            cantools.db.Signal(name='S7',
+            cantools.database.Signal(name='S7',
                                start=40,
                                length=24,
                                multiplexer_ids=[1],
                                multiplexer_signal='S6'),
-            cantools.db.Signal(name='S8',
+            cantools.database.Signal(name='S8',
                                start=40,
                                length=8,
                                multiplexer_ids=[2],
                                multiplexer_signal='S6')
         ]
 
-        message = cantools.db.Message(frame_id=1,
+        message = cantools.database.Message(frame_id=1,
                                       name='M0',
                                       length=8,
                                       signals=signals)
@@ -3037,7 +3037,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         # Missing frame id in message comment, using load_string().
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_string('CM_ BO_ "Foo.";')
+            cantools.database.load_string('CM_ BO_ "Foo.";')
 
         self.assertEqual(
             str(cm.exception),
@@ -3047,7 +3047,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             "supported.\", CDD: \"syntax error: line 1, column 0\"")
 
     def test_get_node_by_name(self):
-        db = cantools.db.load_file('tests/files/kcd/the_homer.kcd')
+        db = cantools.database.load_file('tests/files/kcd/the_homer.kcd')
 
         self.assertIs(db.get_node_by_name('Motor alternative supplier'),
                       db.nodes[1])
@@ -3058,7 +3058,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(str(cm.exception), "'Missing'")
 
     def test_get_bus_by_name(self):
-        db = cantools.db.load_file('tests/files/kcd/the_homer.kcd')
+        db = cantools.database.load_file('tests/files/kcd/the_homer.kcd')
 
         self.assertIs(db.get_bus_by_name('Comfort'), db.buses[2])
 
@@ -3073,14 +3073,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
         filename_sym = 'tests/files/sym/jopp-6.0.sym'
 
         # Matching file contents and database format.
-        cantools.db.load_file(filename_dbc, database_format=None)
-        cantools.db.load_file(filename_dbc, database_format='dbc')
-        cantools.db.load_file(filename_kcd, database_format='kcd')
-        cantools.db.load_file(filename_sym, database_format='sym')
+        cantools.database.load_file(filename_dbc, database_format=None)
+        cantools.database.load_file(filename_dbc, database_format='dbc')
+        cantools.database.load_file(filename_kcd, database_format='kcd')
+        cantools.database.load_file(filename_sym, database_format='sym')
 
         # KCD database format, but file is DBC.
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_file(filename_dbc, database_format='kcd')
+            cantools.database.load_file(filename_dbc, database_format='kcd')
 
         self.assertEqual(
             str(cm.exception),
@@ -3088,7 +3088,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         # DBC database format, but file is KCD.
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_file(filename_kcd, database_format='dbc')
+            cantools.database.load_file(filename_kcd, database_format='dbc')
 
         self.assertEqual(
             str(cm.exception),
@@ -3096,7 +3096,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         # SYM database format, but file is KCD.
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_file(filename_kcd, database_format='sym')
+            cantools.database.load_file(filename_kcd, database_format='sym')
 
         self.assertEqual(
             str(cm.exception),
@@ -3104,7 +3104,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         # Unsupported database format.
         with self.assertRaises(ValueError) as cm:
-            cantools.db.load_file(filename_kcd, database_format='bad')
+            cantools.database.load_file(filename_kcd, database_format='bad')
 
         self.assertEqual(
             str(cm.exception),
@@ -3135,16 +3135,16 @@ class CanToolsDatabaseTest(unittest.TestCase):
         iterations = 10000
 
         signals = [
-            cantools.db.Signal('S0',  7, 4,  'big_endian'),
-            cantools.db.Signal('S1',  3, 4,  'big_endian'),
-            cantools.db.Signal('S2', 15, 4,  'big_endian'),
-            cantools.db.Signal('S3', 11, 8,  'big_endian'),
-            cantools.db.Signal('S4', 19, 1,  'big_endian'),
-            cantools.db.Signal('S5', 17, 17, 'big_endian'),
-            cantools.db.Signal('S6', 47, 15, 'big_endian')
+            cantools.database.Signal('S0',  7, 4,  'big_endian'),
+            cantools.database.Signal('S1',  3, 4,  'big_endian'),
+            cantools.database.Signal('S2', 15, 4,  'big_endian'),
+            cantools.database.Signal('S3', 11, 8,  'big_endian'),
+            cantools.database.Signal('S4', 19, 1,  'big_endian'),
+            cantools.database.Signal('S5', 17, 17, 'big_endian'),
+            cantools.database.Signal('S6', 47, 15, 'big_endian')
         ]
 
-        message = cantools.db.Message(frame_id=1,
+        message = cantools.database.Message(frame_id=1,
                                       name='M0',
                                       length=8,
                                       signals=signals)
@@ -3180,15 +3180,15 @@ class CanToolsDatabaseTest(unittest.TestCase):
         """
 
         signals = [
-            cantools.db.Signal('S1',  3, 4,  'big_endian'),
-            cantools.db.Signal('S2', 15, 4,  'big_endian'),
-            cantools.db.Signal('S3', 11, 8,  'big_endian'),
-            cantools.db.Signal('S4', 19, 1,  'big_endian'),
-            cantools.db.Signal('S5', 17, 17, 'big_endian'),
-            cantools.db.Signal('S6', 47, 15, 'big_endian')
+            cantools.database.Signal('S1',  3, 4,  'big_endian'),
+            cantools.database.Signal('S2', 15, 4,  'big_endian'),
+            cantools.database.Signal('S3', 11, 8,  'big_endian'),
+            cantools.database.Signal('S4', 19, 1,  'big_endian'),
+            cantools.database.Signal('S5', 17, 17, 'big_endian'),
+            cantools.database.Signal('S6', 47, 15, 'big_endian')
         ]
 
-        message = cantools.db.Message(frame_id=1,
+        message = cantools.database.Message(frame_id=1,
                                       name='M0',
                                       length=8,
                                       signals=signals,
@@ -3214,7 +3214,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.load_file('tests/files/dbc/multiplex_choices.dbc',
+        db = cantools.database.load_file('tests/files/dbc/multiplex_choices.dbc',
                                    prune_choices=True)
 
         decoded_message = {
@@ -3240,13 +3240,13 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         """
 
-        db = cantools.db.load_file('tests/files/dbc/multiplex_choices.dbc',
+        db = cantools.database.load_file('tests/files/dbc/multiplex_choices.dbc',
                                    prune_choices=False)
 
         message_1 = db.messages[0]
 
         # Encode.
-        with self.assertRaises(cantools.db.EncodeError) as cm:
+        with self.assertRaises(cantools.database.EncodeError) as cm:
             message_1.encode({'Multiplexor': 7})
 
         self.assertEqual(str(cm.exception),
@@ -3255,7 +3255,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
                          '{8, 16 or 24}, but got 7')
 
         # Decode.
-        with self.assertRaises(cantools.db.DecodeError) as cm:
+        with self.assertRaises(cantools.database.DecodeError) as cm:
             message_1.decode(b'\x1f\xff\x73\xfe\xff\xff\xff\xff')
 
         self.assertEqual(str(cm.exception),
@@ -3264,7 +3264,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         message_3 = db.messages[2]
 
         # Encode with single multiplexer id 8.
-        with self.assertRaises(cantools.db.EncodeError) as cm:
+        with self.assertRaises(cantools.database.EncodeError) as cm:
             message_3.encode({'Multiplexor': 7})
 
         self.assertEqual(str(cm.exception),
@@ -3273,15 +3273,15 @@ class CanToolsDatabaseTest(unittest.TestCase):
                          'one of {8}, but got 7')
 
         # Decode with single multiplexer id 8.
-        with self.assertRaises(cantools.db.DecodeError) as cm:
+        with self.assertRaises(cantools.database.DecodeError) as cm:
             message_3.decode(b'\x1f\xff\x73\xfe\xff\xff\xff\xff')
 
         self.assertEqual(str(cm.exception),
                          'expected multiplexer id 8, but got 7')
 
     def test_multiplex_dump(self):
-        db = cantools.db.load_file('tests/files/dbc/test_multiplex_dump.dbc')
-        dumped_db = cantools.db.load_string(db.as_dbc_string())
+        db = cantools.database.load_file('tests/files/dbc/test_multiplex_dump.dbc')
+        dumped_db = cantools.database.load_string(db.as_dbc_string())
         dumped_msg = dumped_db.get_message_by_frame_id(0x100)
 
         self.assertEqual(dumped_msg.signals[0].name, "MultiplexorSig")
@@ -3295,8 +3295,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(dumped_msg.signals[2].is_multiplexer, False)
 
     def test_multiplex_sym_dump(self):
-        db = cantools.db.load_file('tests/files/sym/test_multiplex_dump.sym')
-        dumped_db = cantools.db.load_string(db.as_sym_string())
+        db = cantools.database.load_file('tests/files/sym/test_multiplex_dump.sym')
+        dumped_db = cantools.database.load_string(db.as_sym_string())
 
         dumped_msg = dumped_db.get_message_by_frame_id(0x100)
         self.assertEqual(dumped_msg.signals[0].name, "MultiplexorSig")
@@ -3307,24 +3307,24 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(dumped_msg.signals[1].multiplexer_ids[0], 0x2a)
 
     def test_multiplex_sym_with_empty_signal_name_dump(self):
-        db = cantools.db.load_file('tests/files/sym/test_multiplex_dump.sym')
+        db = cantools.database.load_file('tests/files/sym/test_multiplex_dump.sym')
         # change the name of the multiplexer signal to empty to trigger the condition in function _dump_message
         db.messages[0].signals[0].name = ''
         with self.assertRaises(ValueError) as context:
-            cantools.db.load_string(db.as_sym_string())
+            cantools.database.load_string(db.as_sym_string())
 
         self.assertTrue(str(context.exception).endswith("The database is corrupt."))
 
     def test_string_attribute_definition_dump(self):
-        db = cantools.db.load_file('tests/files/dbc/test_multiplex_dump.dbc')
-        dumped_db = cantools.db.load_string(db.as_dbc_string())
+        db = cantools.database.load_file('tests/files/dbc/test_multiplex_dump.dbc')
+        dumped_db = cantools.database.load_string(db.as_dbc_string())
         attribute = dumped_db.dbc.attribute_definitions
 
         self.assertEqual(attribute['BusType'].type_name, "STRING")
 
     def test_extended_id_dump(self):
-        db = cantools.db.load_file('tests/files/dbc/test_extended_id_dump.dbc')
-        dumped_db = cantools.db.load_string(db.as_dbc_string())
+        db = cantools.database.load_file('tests/files/dbc/test_extended_id_dump.dbc')
+        dumped_db = cantools.database.load_string(db.as_dbc_string())
         reg_id_msg = dumped_db.get_message_by_frame_id(0x100)
         ext_id_msg = dumped_db.get_message_by_frame_id(0x1c2a2a2a)
 
@@ -3332,8 +3332,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(ext_id_msg.is_extended_frame, True)
 
     def test_extended_id_sym_dump(self):
-        db = cantools.db.load_file('tests/files/sym/test_extended_id_dump.sym')
-        dumped_db = cantools.db.load_string(db.as_sym_string())
+        db = cantools.database.load_file('tests/files/sym/test_extended_id_dump.sym')
+        dumped_db = cantools.database.load_string(db.as_sym_string())
         reg_id_msg = dumped_db.get_message_by_frame_id(0x100)
         ext_id_msg = dumped_db.get_message_by_frame_id(0x1c2a2a2a)
 
@@ -3341,7 +3341,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(ext_id_msg.is_extended_frame, True)
 
     def test_event_attributes(self):
-        db = cantools.db.load_file('tests/files/dbc/attribute_Event.dbc')
+        db = cantools.database.load_file('tests/files/dbc/attribute_Event.dbc')
 
         self.assertEqual(db.messages[0].send_type, 'Event')
         self.assertEqual(db.messages[0].frame_id, 1234)
@@ -3351,7 +3351,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         filename = 'tests/files/dbc/attributes.dbc'
 
         with open(filename) as fin:
-            db = cantools.db.load(fin)
+            db = cantools.database.load(fin)
 
         # Signal attributes.
         attributes = db.messages[0].signals[0].dbc.attributes
@@ -3479,7 +3479,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         filename = 'tests/files/dbc/big_numbers.dbc'
 
         with open(filename) as fin:
-            db = cantools.db.load(fin)
+            db = cantools.database.load(fin)
 
         # Node attributes.
         node = db.nodes[0]
@@ -3497,7 +3497,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_setters(self):
         with open('tests/files/dbc/attributes.dbc') as fin:
-            db = cantools.db.load(fin)
+            db = cantools.database.load(fin)
 
         # Calling the setters for coverage. Assertions are not
         # necessary here since functionality is trivial.
@@ -3529,7 +3529,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_refresh(self):
         with open('tests/files/dbc/attributes.dbc') as fin:
-            db = cantools.db.load(fin)
+            db = cantools.database.load(fin)
 
         message = db.get_message_by_frame_id(0x39, force_extended_id=True)
         self.assertEqual(message.name, 'TheMessage')
@@ -3556,13 +3556,13 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(cm.exception.args[0], 0x80000000 | 0x41)
 
     def test_missing_dbc_specifics(self):
-        db = cantools.db.Database()
+        db = cantools.database.Database()
 
-        node = cantools.db.Node('FakeNode', 'Comment')
+        node = cantools.database.Node('FakeNode', 'Comment')
         db.nodes.append(node)
 
-        signals = [cantools.db.Signal('C', 0, 8)]
-        message = cantools.db.Message(0x20, 'D', 8, signals)
+        signals = [cantools.database.Signal('C', 0, 8)]
+        message = cantools.database.Message(0x20, 'D', 8, signals)
         db.messages.append(message)
 
         # Test that dump executes without raising.
@@ -3596,15 +3596,15 @@ class CanToolsDatabaseTest(unittest.TestCase):
         ]
 
         for data0, data1 in datas:
-            signal_0 = cantools.db.Signal('S0',
+            signal_0 = cantools.database.Signal('S0',
                                           data0.start,
                                           data0.length,
                                           data0.byte_order)
-            signal_1 = cantools.db.Signal('S1',
+            signal_1 = cantools.database.Signal('S1',
                                           data1.start,
                                           data1.length,
                                           data1.byte_order)
-            cantools.db.Message(1,
+            cantools.database.Message(1,
                                 'M',
                                 7,
                                 [signal_0, signal_1],
@@ -3627,17 +3627,17 @@ class CanToolsDatabaseTest(unittest.TestCase):
         ]
 
         for data0, data1 in datas:
-            signal_0 = cantools.db.Signal('S0',
+            signal_0 = cantools.database.Signal('S0',
                                           data0.start,
                                           data0.length,
                                           data0.byte_order)
-            signal_1 = cantools.db.Signal('S1',
+            signal_1 = cantools.database.Signal('S1',
                                           data1.start,
                                           data1.length,
                                           data1.byte_order)
 
-            with self.assertRaises(cantools.db.Error) as cm:
-                cantools.db.Message(1,
+            with self.assertRaises(cantools.database.Error) as cm:
+                cantools.database.Message(1,
                                     'M',
                                     7,
                                     [signal_0, signal_1],
@@ -3657,13 +3657,13 @@ class CanToolsDatabaseTest(unittest.TestCase):
         ]
 
         for data in datas:
-            signal = cantools.db.Signal('S',
+            signal = cantools.database.Signal('S',
                                         data.start,
                                         data.length,
                                         data.byte_order)
 
-            with self.assertRaises(cantools.db.Error) as cm:
-                cantools.db.Message(1,
+            with self.assertRaises(cantools.database.Error) as cm:
+                cantools.database.Message(1,
                                     'M',
                                     8,
                                     [signal],
@@ -3675,46 +3675,46 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_strict_multiplexer(self):
         # Signals not overlapping.
         signals = [
-            cantools.db.Signal('S0',
+            cantools.database.Signal('S0',
                                7,
                                2,
                                'big_endian',
                                is_multiplexer=True),
-            cantools.db.Signal('S1',
+            cantools.database.Signal('S1',
                                5,
                                2,
                                'big_endian',
                                multiplexer_ids=[0],
                                multiplexer_signal='S0'),
-            cantools.db.Signal('S2',
+            cantools.database.Signal('S2',
                                5,
                                1,
                                'big_endian',
                                multiplexer_ids=[1],
                                multiplexer_signal='S0'),
-            cantools.db.Signal('S3',
+            cantools.database.Signal('S3',
                                3,
                                1,
                                'big_endian'),
-            cantools.db.Signal('S4',
+            cantools.database.Signal('S4',
                                2,
                                2,
                                'big_endian',
                                is_multiplexer=True),
-            cantools.db.Signal('S5',
+            cantools.database.Signal('S5',
                                0,
                                2,
                                'big_endian',
                                multiplexer_ids=[0],
                                multiplexer_signal='S4'),
-            cantools.db.Signal('S6',
+            cantools.database.Signal('S6',
                                0,
                                2,
                                'big_endian',
                                is_multiplexer=True,
                                multiplexer_ids=[1],
                                multiplexer_signal='S4'),
-            cantools.db.Signal('S7',
+            cantools.database.Signal('S7',
                                14,
                                1,
                                'big_endian',
@@ -3722,7 +3722,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
                                multiplexer_signal='S6')
         ]
 
-        cantools.db.Message(1,
+        cantools.database.Message(1,
                             'M',
                             7,
                             signals,
@@ -3732,28 +3732,28 @@ class CanToolsDatabaseTest(unittest.TestCase):
         datas = [
             (
                 [
-                    cantools.db.Signal('S0',
+                    cantools.database.Signal('S0',
                                        7,
                                        2,
                                        'big_endian',
                                        is_multiplexer=True,
                                        multiplexer_ids=None,
                                        multiplexer_signal=None),
-                    cantools.db.Signal('S1',
+                    cantools.database.Signal('S1',
                                        5,
                                        2,
                                        'big_endian',
                                        is_multiplexer=False,
                                        multiplexer_ids=[0],
                                        multiplexer_signal='S0'),
-                    cantools.db.Signal('S2',
+                    cantools.database.Signal('S2',
                                        5,
                                        1,
                                        'big_endian',
                                        is_multiplexer=False,
                                        multiplexer_ids=[1],
                                        multiplexer_signal='S0'),
-                    cantools.db.Signal('S3',
+                    cantools.database.Signal('S3',
                                        4,
                                        1,
                                        'big_endian',
@@ -3765,46 +3765,46 @@ class CanToolsDatabaseTest(unittest.TestCase):
             ),
             (
                 [
-                    cantools.db.Signal('S0',
+                    cantools.database.Signal('S0',
                                        7,
                                        2,
                                        'big_endian',
                                        is_multiplexer=True),
-                    cantools.db.Signal('S1',
+                    cantools.database.Signal('S1',
                                        5,
                                        2,
                                        'big_endian',
                                        multiplexer_ids=[0],
                                        multiplexer_signal='S0'),
-                    cantools.db.Signal('S2',
+                    cantools.database.Signal('S2',
                                        5,
                                        1,
                                        'big_endian',
                                        multiplexer_ids=[1],
                                        multiplexer_signal='S0'),
-                    cantools.db.Signal('S3',
+                    cantools.database.Signal('S3',
                                        3,
                                        1,
                                        'big_endian'),
-                    cantools.db.Signal('S4',
+                    cantools.database.Signal('S4',
                                        2,
                                        2,
                                        'big_endian',
                                        is_multiplexer=True),
-                    cantools.db.Signal('S5',
+                    cantools.database.Signal('S5',
                                        0,
                                        2,
                                        'big_endian',
                                        multiplexer_ids=[0],
                                        multiplexer_signal='S4'),
-                    cantools.db.Signal('S6',
+                    cantools.database.Signal('S6',
                                        0,
                                        2,
                                        'big_endian',
                                        is_multiplexer=True,
                                        multiplexer_ids=[1],
                                        multiplexer_signal='S4'),
-                    cantools.db.Signal('S7',
+                    cantools.database.Signal('S7',
                                        7,
                                        1,
                                        'big_endian',
@@ -3815,46 +3815,46 @@ class CanToolsDatabaseTest(unittest.TestCase):
             ),
             (
                 [
-                    cantools.db.Signal('S0',
+                    cantools.database.Signal('S0',
                                        7,
                                        2,
                                        'big_endian',
                                        is_multiplexer=True),
-                    cantools.db.Signal('S1',
+                    cantools.database.Signal('S1',
                                        5,
                                        2,
                                        'big_endian',
                                        multiplexer_ids=[0],
                                        multiplexer_signal='S0'),
-                    cantools.db.Signal('S2',
+                    cantools.database.Signal('S2',
                                        5,
                                        1,
                                        'big_endian',
                                        multiplexer_ids=[1],
                                        multiplexer_signal='S0'),
-                    cantools.db.Signal('S3',
+                    cantools.database.Signal('S3',
                                        3,
                                        1,
                                        'big_endian'),
-                    cantools.db.Signal('S4',
+                    cantools.database.Signal('S4',
                                        2,
                                        2,
                                        'big_endian',
                                        is_multiplexer=True),
-                    cantools.db.Signal('S5',
+                    cantools.database.Signal('S5',
                                        0,
                                        2,
                                        'big_endian',
                                        multiplexer_ids=[0],
                                        multiplexer_signal='S4'),
-                    cantools.db.Signal('S6',
+                    cantools.database.Signal('S6',
                                        1,
                                        2,
                                        'big_endian',
                                        is_multiplexer=True,
                                        multiplexer_ids=[1],
                                        multiplexer_signal='S4'),
-                    cantools.db.Signal('S7',
+                    cantools.database.Signal('S7',
                                        14,
                                        1,
                                        'big_endian',
@@ -3866,8 +3866,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
         ]
 
         for signals, expected_overlpping in datas:
-            with self.assertRaises(cantools.db.Error) as cm:
-                cantools.db.Message(1, 'M', 7, signals, strict=True)
+            with self.assertRaises(cantools.database.Error) as cm:
+                cantools.database.Message(1, 'M', 7, signals, strict=True)
 
             self.assertEqual(str(cm.exception), expected_overlpping)
 
@@ -4363,7 +4363,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_illegal_namespace(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_file('tests/files/arxml/system-illegal-namespace-4.2.arxml')
+            cantools.database.load_file('tests/files/arxml/system-illegal-namespace-4.2.arxml')
 
         self.assertEqual(
             str(cm.exception),
@@ -4371,7 +4371,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         root = ElementTree.parse('tests/files/arxml/system-illegal-namespace-4.2.arxml').getroot()
         with self.assertRaises(ValueError) as cm:
-            cantools.db.can.formats.arxml.SystemLoader(root, strict=False)
+            cantools.database.can.formats.arxml.SystemLoader(root, strict=False)
 
         self.assertEqual(
             str(cm.exception),
@@ -4379,7 +4379,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_illegal_root(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_file('tests/files/arxml/system-illegal-root-4.2.arxml')
+            cantools.database.load_file('tests/files/arxml/system-illegal-root-4.2.arxml')
 
         self.assertEqual(
             str(cm.exception),
@@ -4387,7 +4387,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         root = ElementTree.parse('tests/files/arxml/system-illegal-root-4.2.arxml').getroot()
         with self.assertRaises(ValueError) as cm:
-            cantools.db.can.formats.arxml.SystemLoader(root, strict=False)
+            cantools.database.can.formats.arxml.SystemLoader(root, strict=False)
 
         self.assertEqual(
             str(cm.exception),
@@ -4395,7 +4395,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_illegal_version(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_file('tests/files/arxml/system-illegal-version-4.2.2.1.0.arxml')
+            cantools.database.load_file('tests/files/arxml/system-illegal-version-4.2.2.1.0.arxml')
 
         self.assertEqual(
             str(cm.exception),
@@ -4403,7 +4403,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_arxml_version(self):
         root = ElementTree.parse('tests/files/arxml/system-4.2.arxml').getroot()
-        loader = cantools.db.can.formats.arxml.SystemLoader(root, strict=False)
+        loader = cantools.database.can.formats.arxml.SystemLoader(root, strict=False)
 
         self.assertEqual(loader.autosar_version_newer(3), True)
         self.assertEqual(loader.autosar_version_newer(4), True)
@@ -4416,10 +4416,10 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(loader.autosar_version_newer(4, 3), False)
 
     def test_DAI_namespace(self):
-        cantools.db.load_file('tests/files/arxml/system-DAI-3.1.2.arxml')
+        cantools.database.load_file('tests/files/arxml/system-DAI-3.1.2.arxml')
 
     def test_system_3_arxml(self):
-        db = cantools.db.load_file('tests/files/arxml/system-3.2.3.arxml')
+        db = cantools.database.load_file('tests/files/arxml/system-3.2.3.arxml')
 
         self.assertEqual(len(db.buses), 1)
         bus = db.buses[0]
@@ -4701,7 +4701,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_6.multiplexer_ids, None)
 
     def test_system_4_arxml(self):
-        db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
+        db = cantools.database.load_file('tests/files/arxml/system-4.2.arxml')
 
         self.assertEqual(len(db.buses), 1)
         bus = db.buses[0]
@@ -5232,14 +5232,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_system_arxml_traversal(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_file(
+            cantools.database.load_file(
                 'tests/files/arxml/system-dangling-reference-4.2.arxml')
         self.assertEqual(str(cm.exception),
                          'ARXML: \"Encountered dangling reference FRAME-REF ' \
                          'of type "CAN-FRAME": /PackageDoesNotExist/Message1"')
 
         root = ElementTree.parse('tests/files/arxml/system-4.2.arxml').getroot()
-        loader = cantools.db.can.formats.arxml.SystemLoader(root, strict=True)
+        loader = cantools.database.can.formats.arxml.SystemLoader(root, strict=True)
 
         # a base node must always be specified
         with self.assertRaises(ValueError) as cm:
@@ -5291,7 +5291,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(str(cm.exception), "['AR-PACKAGES', '*AR-PACKAGE'] does not resolve into a unique node")
 
     def test_no_compu_method_category_arxml(self):
-        db = cantools.db.load_file('tests/files/arxml/compu_method_no_category.arxml')
+        db = cantools.database.load_file('tests/files/arxml/compu_method_no_category.arxml')
 
         self.assertEqual(len(db.buses), 1)
         bus = db.buses[0]
@@ -5341,7 +5341,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_1.multiplexer_ids, None)
 
     def test_unused_bit_pattern(self):
-        db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
+        db = cantools.database.load_file('tests/files/arxml/system-4.2.arxml')
 
         message4 = db.get_message_by_name('Message4')
         input_dict = {
@@ -5377,7 +5377,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(encoded, encoded_ref)
 
     def test_system_arxml_float_values(self):
-        db = cantools.db.load_file('tests/files/arxml/system-float-values.arxml')
+        db = cantools.database.load_file('tests/files/arxml/system-float-values.arxml')
 
         self.assertEqual(len(db.buses), 1)
         bus = db.buses[0]
@@ -5448,7 +5448,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_system_missing_factor_arxml(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_file(
+            cantools.database.load_file(
                 'tests/files/arxml/system-missing-factor-4.2.arxml')
 
         self.assertEqual(
@@ -5457,7 +5457,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_system_missing_denominator_arxml(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_file(
+            cantools.database.load_file(
                 'tests/files/arxml/system-missing-denominator-4.2.arxml')
 
         self.assertEqual(
@@ -5465,7 +5465,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             'ARXML: "Expected 1 denominator value for linear scaling, but got 0."')
 
     def test_system_missing_rational_arxml(self):
-        db = cantools.db.load_file(
+        db = cantools.database.load_file(
             'tests/files/arxml/system-missing-rational-4.2.arxml')
 
         signal_1 = db.messages[0].signals[0]
@@ -5476,7 +5476,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_system_bad_root_tag(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
-            cantools.db.load_file(
+            cantools.database.load_file(
                 'tests/files/arxml/system-bad-root-tag-4.2.arxml')
 
         self.assertEqual(
@@ -5627,7 +5627,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_encode_mixed_signal(self):
         # cf issue #373
-        db = cantools.db.load_file('tests/files/arxml/system-4.2.arxml')
+        db = cantools.database.load_file('tests/files/arxml/system-4.2.arxml')
 
         decoded_message = {
             'message1_SeqCounter': 123,
@@ -5669,7 +5669,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_issue_168_upper_case_file_extension(self):
         filename = 'tests/files/dbc/issue_168.DBC'
-        db = cantools.db.load_file(filename)
+        db = cantools.database.load_file(filename)
 
         message = db.get_message_by_name('Foo')
         self.assertEqual(message.name, 'Foo')
@@ -6192,7 +6192,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_fd_detection(self):
         filename = "tests/files/dbc/fd_test.dbc"
-        db = cantools.db.load_file(filename)
+        db = cantools.database.load_file(filename)
 
         msgfdex = db.get_message_by_name('TestMsg_FDEx')
         self.assertEqual(True, msgfdex.is_fd)

--- a/tests/test_diagnostics_database.py
+++ b/tests/test_diagnostics_database.py
@@ -10,7 +10,7 @@ class CanToolsDiagnosticsDatabaseTest(unittest.TestCase):
     maxDiff = None
 
     def test_le_example_cdd(self):
-        db = cantools.db.load_file('tests/files/cdd/le-example.cdd',
+        db = cantools.database.load_file('tests/files/cdd/le-example.cdd',
                                    encoding='iso-8859-1')
         self.assertEqual(len(db.dids), 15)
         self.assertEqual([did.name for did in db.dids],
@@ -149,7 +149,7 @@ class CanToolsDiagnosticsDatabaseTest(unittest.TestCase):
         self.assertEqual(decoded, decoded_did)
 
     def test_be_example_cdd(self):
-        db = cantools.db.load_file('tests/files/cdd/example.cdd',
+        db = cantools.database.load_file('tests/files/cdd/example.cdd',
                                    encoding = 'iso-8859-1')
         self.assertEqual(len(db.dids), 15)
         self.assertEqual([did.name for did in db.dids],
@@ -288,7 +288,7 @@ class CanToolsDiagnosticsDatabaseTest(unittest.TestCase):
         self.assertEqual(decoded, decoded_did)
 
     def test_be_example_cdd_repr(self):
-        db = cantools.db.load_file('tests/files/cdd/example.cdd',
+        db = cantools.database.load_file('tests/files/cdd/example.cdd',
                                    encoding = 'iso-8859-1')
         self.assertEqual(
             repr(db),
@@ -381,7 +381,7 @@ class CanToolsDiagnosticsDatabaseTest(unittest.TestCase):
             "  data('_reserved', 7, 4, 'big_endian', 1, 0, 0, 255, 'None', None)\n")
 
     def test_le_example_cdd_repr(self):
-        db = cantools.db.load_file('tests/files/cdd/le-example.cdd',
+        db = cantools.database.load_file('tests/files/cdd/le-example.cdd',
                                    encoding = 'iso-8859-1')
         self.assertEqual(
             repr(db),
@@ -474,17 +474,17 @@ class CanToolsDiagnosticsDatabaseTest(unittest.TestCase):
             "  data('_reserved', 4, 4, 'little_endian', 1, 0, 0, 255, 'None', None)\n")
 
     def test_be_cdd_add(self):
-        db = cantools.db.diagnostics.Database()
+        db = cantools.database.diagnostics.Database()
         db.add_cdd_file('tests/files/cdd/example.cdd', encoding = 'iso-8859-1')
         self.assertEqual(len(db.dids), 15)
 
     def test_le_cdd_add(self):
-        db = cantools.db.diagnostics.Database()
+        db = cantools.database.diagnostics.Database()
         db.add_cdd_file('tests/files/cdd/le-example.cdd', encoding = 'iso-8859-1')
         self.assertEqual(len(db.dids), 15)
 
     def test_unknown_byteorder(self):
-        db = cantools.db.diagnostics.Database()
+        db = cantools.database.diagnostics.Database()
 
         with self.assertRaises(ParseError) as pe:
             db.add_cdd_file('tests/files/cdd/invalid-bo-example.cdd', encoding = 'iso-8859-1')
@@ -492,7 +492,7 @@ class CanToolsDiagnosticsDatabaseTest(unittest.TestCase):
         self.assertEqual(str(pe.exception), "Unknown byte order code: 4321")
 
     def test_datarefs(self):
-        db = cantools.db.load_file('tests/files/cdd/example-diddatarefs.cdd', encoding = 'iso-8859-1')
+        db = cantools.database.load_file('tests/files/cdd/example-diddatarefs.cdd', encoding = 'iso-8859-1')
         self.assertEqual(len(db.dids[-1].datas), 2)
 
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -9,7 +9,7 @@ from cantools.subparsers.dump import formatting
 class CanToolsDumpTest(unittest.TestCase):
 
     def test_the_homer(self):
-        db = cantools.db.load_file('tests/files/kcd/the_homer.kcd')
+        db = cantools.database.load_file('tests/files/kcd/the_homer.kcd')
 
         self.assertEqual(db.messages[1].signal_tree,
                          [
@@ -47,7 +47,7 @@ class CanToolsDumpTest(unittest.TestCase):
             '   +-- Handbrake')
 
     def test_multiplex(self):
-        db = cantools.db.load_file('tests/files/dbc/multiplex.dbc')
+        db = cantools.database.load_file('tests/files/dbc/multiplex.dbc')
 
         message_1 = db.messages[0]
 
@@ -98,7 +98,7 @@ class CanToolsDumpTest(unittest.TestCase):
             '           +-- BIT_F')
 
     def test_multiplex_choices(self):
-        db = cantools.db.load_file('tests/files/dbc/multiplex_choices.dbc')
+        db = cantools.database.load_file('tests/files/dbc/multiplex_choices.dbc')
 
         message_1 = db.messages[0]
 
@@ -166,53 +166,53 @@ class CanToolsDumpTest(unittest.TestCase):
         #            +-- S8            | 40..48
         #
         signals = [
-            cantools.db.Signal(name='S0',
+            cantools.database.Signal(name='S0',
                                start=0,
                                length=4,
                                is_multiplexer=True),
-            cantools.db.Signal(name='S1',
+            cantools.database.Signal(name='S1',
                                start=4,
                                length=4,
                                is_multiplexer=True,
                                multiplexer_ids=[0],
                                multiplexer_signal='S0'),
-            cantools.db.Signal(name='S2',
+            cantools.database.Signal(name='S2',
                                start=8,
                                length=8,
                                multiplexer_ids=[0],
                                multiplexer_signal='S1'),
-            cantools.db.Signal(name='S3',
+            cantools.database.Signal(name='S3',
                                start=16,
                                length=16,
                                multiplexer_ids=[0],
                                multiplexer_signal='S1'),
-            cantools.db.Signal(name='S4',
+            cantools.database.Signal(name='S4',
                                start=8,
                                length=24,
                                multiplexer_ids=[2],
                                multiplexer_signal='S1'),
-            cantools.db.Signal(name='S5',
+            cantools.database.Signal(name='S5',
                                start=4,
                                length=28,
                                multiplexer_ids=[1],
                                multiplexer_signal='S0'),
-            cantools.db.Signal(name='S6',
+            cantools.database.Signal(name='S6',
                                start=32,
                                length=8,
                                is_multiplexer=True),
-            cantools.db.Signal(name='S7',
+            cantools.database.Signal(name='S7',
                                start=40,
                                length=24,
                                multiplexer_ids=[1],
                                multiplexer_signal='S6'),
-            cantools.db.Signal(name='S8',
+            cantools.database.Signal(name='S8',
                                start=40,
                                length=8,
                                multiplexer_ids=[2],
                                multiplexer_signal='S6')
         ]
 
-        message = cantools.db.Message(frame_id=1,
+        message = cantools.database.Message(frame_id=1,
                                       name='M0',
                                       length=8,
                                       signals=signals)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -811,7 +811,7 @@ BREMSE_33(
  (2020-12-29 08:48:34.369165)  vcan0  00000000   [8]  06 00 00 00 00 00 00 00
 """
 
-        db = cantools.db.load_file(self.DBC_FILE_CHOICES)
+        db = cantools.database.load_file(self.DBC_FILE_CHOICES)
         choices = db.get_message_by_name("Foo").get_signal_by_name("Foo").choices
 
         xs  = self.parse_time(input_data, self.parse_absolute_time)
@@ -2178,7 +2178,7 @@ Failed to parse line: 'invalid syntax'
  (012.432106)  vcan0  00000000   [8]  00 00 00 00 00 00 00 00
 """
 
-        db = cantools.db.load_file(self.DBC_FILE_CHOICES)
+        db = cantools.database.load_file(self.DBC_FILE_CHOICES)
         choices = db.get_message_by_name("Foo").get_signal_by_name("Foo").choices
 
         xs = self.parse_time(input_data, self.parse_seconds)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -50,7 +50,7 @@ def setup_tester(dut_name,
                  on_message=None,
                  decode_choices=False,
                  scaling=False):
-    database = cantools.db.load_file('tests/files/kcd/tester.kcd')
+    database = cantools.database.load_file('tests/files/kcd/tester.kcd')
     can_bus = CanBus()
     tester = cantools.tester.Tester(dut_name,
                                     database,
@@ -278,7 +278,7 @@ class CanToolsTesterTest(unittest.TestCase):
 
         """
 
-        database = cantools.db.load_file('tests/files/kcd/tester.kcd')
+        database = cantools.database.load_file('tests/files/kcd/tester.kcd')
         can_bus = CanBus()
 
         with self.assertRaises(cantools.tester.Error) as cm:
@@ -292,7 +292,7 @@ class CanToolsTesterTest(unittest.TestCase):
 
         """
 
-        database = cantools.db.load_file('tests/files/kcd/tester.kcd')
+        database = cantools.database.load_file('tests/files/kcd/tester.kcd')
         can_bus = CanBus()
 
         with self.assertRaises(cantools.tester.Error) as cm:
@@ -306,7 +306,7 @@ class CanToolsTesterTest(unittest.TestCase):
 
         """
 
-        database = cantools.db.load_file('tests/files/dbc/foobar.dbc')
+        database = cantools.database.load_file('tests/files/dbc/foobar.dbc')
         can_bus = CanBus()
 
         with self.assertRaises(cantools.tester.Error) as cm:
@@ -320,7 +320,7 @@ class CanToolsTesterTest(unittest.TestCase):
 
         """
 
-        database = cantools.db.load_file('tests/files/dbc/issue_725.dbc')
+        database = cantools.database.load_file('tests/files/dbc/issue_725.dbc')
         can_bus = CanBus()
 
         with self.assertRaises(cantools.tester.Error) as cm:


### PR DESCRIPTION
I removed the star imports and added missing imports where tests required it.

I decided against removing `cantools.db` completely, after seeing how often it was used in our own tests.
Instead, a DeprecationWarning was added to warn against use of `cantools.db`