### PR TITLE
Use new python-can functions in monitor.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "bitstruct>=8.16.1",
-    "python-can>=3.3.4",
+    "python-can>=4.6.0",
     "textparser>=0.21.1",
     "diskcache",
     "argparse_addons",

--- a/tests/test_logreader.py
+++ b/tests/test_logreader.py
@@ -1,5 +1,5 @@
-import io
 import datetime
+import io
 import unittest
 
 import pytest


### PR DESCRIPTION
Let python-can handle bus arguments.

This is a breaking change:

- some argument names are different (`-i` instead of `-b`, `-b` instead of `-B`)
- unknown arguments are no longer passed to bus instantiation, users should use the `--bus-kwargs` argument instead

Here is the new help text:

```
 cantools monitor --help
usage: cantools monitor [-h] [-s] [-e ENCODING] [-m FRAME_ID_MASK] [--prune] [--no-strict] [-c CHANNEL]
                        [-i {canalystii,cantact,etas,gs_usb,iscan,ixxat,kvaser,neousys,neovi,nican,nixnet,pcan,robotell,seeedstudio,serial,slcan,socketcan,socketcand,systec,udp_multicast,usb2can,vector,virtual}] [-b BITRATE]
                        [--fd] [--data-bitrate DATA_BITRATE] [--timing TIMING_ARG [TIMING_ARG ...]] [--filter {<can_id>:<can_mask>,<can_id>~<can_mask>} [{<can_id>:<can_mask>,<can_id>~<can_mask>} ...]]
                        [--bus-kwargs BUS_KWARG [BUS_KWARG ...]]
                        database

Monitor CAN bus traffic in a text based user interface.

positional arguments:
  database              Database file.

options:
  -h, --help            show this help message and exit
  -s, --single-line     Print the decoded message on a single line. (default: False)
  -e, --encoding ENCODING
                        File encoding. (default: None)
  -m, --frame-id-mask FRAME_ID_MASK
                        Only compare selected frame id bits to find the message in the database. By default the received and database frame ids must be equal for a match. (default: None)
  --prune               Refrain from shortening the names of named signal values. (default: False)
  --no-strict           Skip database consistency checks. (default: False)

bus arguments (python-can):
  -c, --channel CHANNEL
                        Most backend interfaces require some sort of channel. For example with the serial interface the channel might be a rfcomm device: "/dev/rfcomm0". With the socketcan interface valid channel examples
                        include: "can0", "vcan0".
  -i, --interface {canalystii,cantact,etas,gs_usb,iscan,ixxat,kvaser,neousys,neovi,nican,nixnet,pcan,robotell,seeedstudio,serial,slcan,socketcan,socketcand,systec,udp_multicast,usb2can,vector,virtual}
                        Specify the backend CAN interface to use. If left blank, fall back to reading from configuration files.
  -b, --bitrate BITRATE
                        Bitrate to use for the CAN bus.
  --fd                  Activate CAN-FD support
  --data-bitrate DATA_BITRATE
                        Bitrate to use for the data phase in case of CAN-FD.
  --timing TIMING_ARG [TIMING_ARG ...]
                        Configure bit rate and bit timing. For example, use `--timing f_clock=8_000_000 tseg1=5 tseg2=2 sjw=2 brp=2 nof_samples=1` for classical CAN or `--timing f_clock=80_000_000 nom_tseg1=119 nom_tseg2=40
                        nom_sjw=40 nom_brp=1 data_tseg1=29 data_tseg2=10 data_sjw=10 data_brp=1` for CAN FD. Check the python-can documentation to verify whether your CAN interface supports the `timing` argument.
  --filter {<can_id>:<can_mask>,<can_id>~<can_mask>} [{<can_id>:<can_mask>,<can_id>~<can_mask>} ...]
                        R|Space separated CAN filters for the given CAN interface: <can_id>:<can_mask> (matches when <received_can_id> & mask == can_id & mask) <can_id>~<can_mask> (matches when <received_can_id> & mask !=
                        can_id & mask) Fx to show only frames with ID 0x100 to 0x103 and 0x200 to 0x20F: python -m can.viewer --filter 100:7FC 200:7F0 Note that the ID and mask are always interpreted as hex values
  --bus-kwargs BUS_KWARG [BUS_KWARG ...]
                        Pass keyword arguments down to the instantiation of the bus class. For example, `-i vector -c 1 --bus-kwargs app_name=MyCanApp serial=1234` is equivalent to opening the bus with `can.Bus('vector',
                        channel=1, app_name='MyCanApp', serial=1234)
```