### PR TITLE
fix(database): broken caching when loading dbc file

### DIFF
--- a/src/cantools/database/__init__.py
+++ b/src/cantools/database/__init__.py
@@ -132,7 +132,7 @@ def load_file(filename: StringPathLike,
     db: Union[can.Database, diagnostics.Database]
 
     with diskcache.Cache(cache_dir) if cache_dir else nullcontext() as cache:
-        if cache:
+        if cache is not None:
             # do not cache if user-defined sort_signals function is provided
             # the key cannot be created if function is local or depends on context
             # pickle serializer will fail anyway
@@ -160,7 +160,7 @@ def load_file(filename: StringPathLike,
                     strict,
                     sort_signals)
 
-        if cache:
+        if cache is not None:
             cache[cache_key] = db
 
         return db


### PR DESCRIPTION
Caching DBC files has not been working for me for some time now. I debugged it and found that it is incorrectly checking whether the cache object was created correctly.
This is probably due to a change in diskcache.
The problem only occurs when the cache is empty or has been newly created. Then the original query generates false and therefore never caches.