### PR TITLE
monitor: prevent CAN frame duplication on error

### DIFF
--- a/src/cantools/subparsers/monitor.py
+++ b/src/cantools/subparsers/monitor.py
@@ -560,6 +560,9 @@ class Monitor(can.Listener):
         return bool(matched_signals)
 
     def insort_filtered(self, name):
+        if name in self._filtered_sorted_message_names:
+            return
+
         if name in self._messages_with_error or self._message_matches_filter(name):
             bisect.insort(self._filtered_sorted_message_names,
                           name)


### PR DESCRIPTION
Fixes issue where malformed CAN message followed by correct one results in duplicate frames in the output.

Start monitor
```
$ cantools monitor -i socketcan ./tests/files/dbc/foobar.dbc
```

Send malformed CAN message
```
$ cansend vcan0 00012332#12
   0.000  Bar(undecoded, 3 bytes too short: 0x12)
```

Send correct CAN message, but see duplicated frames now
```
$ cansend vcan0 00012332#12345678
   25.249  Bar(
               Binary32: 1.7378244361449504e+34
           )
   25.249  Bar(
               Binary32: 1.7378244361449504e+34
           )
```