### PR TITLE
Add signal param to dump CLI tool.

### DIFF
--- a/src/cantools/subparsers/dump/__init__.py
+++ b/src/cantools/subparsers/dump/__init__.py
@@ -104,12 +104,12 @@ def _dump_can_message(message, with_comments=False, name_prefix='', WIDTH=None):
                               name_prefix=f'{message.name} :: ')
 
 
-def _dump_can_signal(dbase: CanDatabase, signal_name: str, with_comments: bool) -> None:
+def _dump_can_single_message(dbase: CanDatabase, message_name: str, with_comments: bool) -> None:
     WIDTH = 80
     try:
-        message = dbase.get_message_by_name(signal_name)
+        message = dbase.get_message_by_name(message_name)
     except KeyError:
-        raise KeyError(f'Unknown signal {signal_name}') from KeyError
+        raise KeyError(f'Unknown message {message_name}') from KeyError
 
     print('================================= Message =================================')
     _dump_can_message(message,
@@ -161,12 +161,12 @@ def _do_dump(args):
                                encoding=args.encoding,
                                prune_choices=args.prune,
                                strict=not args.no_strict)
-    signal_name = args.signal
+    message_name = args.message
     if isinstance(dbase, CanDatabase):
-        if signal_name is None:
-            _dump_can_database(dbase, args.with_comments)
+        if message_name is not None:
+            _dump_can_single_message(dbase, message_name, args.with_comments)
         else:
-            _dump_can_signal(dbase, signal_name, args.with_comments)
+            _dump_can_database(dbase, args.with_comments)
     elif isinstance(dbase, DiagnosticsDatabase):
         _dump_diagnostics_database(dbase)
     else:
@@ -197,6 +197,6 @@ def add_subparser(subparsers):
         action='store_true',
         help='Print the comments.')
     dump_parser.add_argument(
-        '-s', '--signal',
-        help='Print only the specified signal.')
+        '-m', '--message',
+        help='Print only the specified message.')
     dump_parser.set_defaults(func=_do_dump)

--- a/src/cantools/subparsers/dump/__init__.py
+++ b/src/cantools/subparsers/dump/__init__.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 from ... import database
+from ...database import Message
 from ...database.can.database import Database as CanDatabase
 from ...database.diagnostics.database import Database as DiagnosticsDatabase
 from ...database.utils import format_and
@@ -104,20 +105,7 @@ def _dump_can_message(message, with_comments=False, name_prefix='', WIDTH=None):
                               name_prefix=f'{message.name} :: ')
 
 
-def _dump_can_single_message(dbase: CanDatabase, message_name: str, with_comments: bool) -> None:
-    WIDTH = 80
-    try:
-        message = dbase.get_message_by_name(message_name)
-    except KeyError:
-        raise KeyError(f'Unknown message {message_name}') from KeyError
-
-    print('================================= Message =================================')
-    _dump_can_message(message,
-                      with_comments,
-                      WIDTH=WIDTH)
-
-
-def _dump_can_database(dbase, with_comments=False):
+def _dump_can_messages(msg_list: list[Message], with_comments: bool = False) -> None:
     WIDTH = 80
     try:
         WIDTH, _ = os.get_terminal_size()
@@ -128,7 +116,7 @@ def _dump_can_database(dbase, with_comments=False):
     print()
     print('  ' + 72 * '-')
 
-    for message in dbase.messages:
+    for message in msg_list:
         _dump_can_message(message,
                           with_comments=with_comments,
                           WIDTH=WIDTH)
@@ -163,10 +151,15 @@ def _do_dump(args):
                                strict=not args.no_strict)
     message_name = args.message
     if isinstance(dbase, CanDatabase):
-        if message_name is not None:
-            _dump_can_single_message(dbase, message_name, args.with_comments)
+        if message_name is None:
+            _dump_can_messages(dbase.messages, args.with_comments)
         else:
-            _dump_can_database(dbase, args.with_comments)
+            try:
+                message = dbase.get_message_by_name(message_name)
+            except KeyError:
+                raise KeyError(f'Unknown message {message_name}') from KeyError
+            _dump_can_messages([message], args.with_comments)
+
     elif isinstance(dbase, DiagnosticsDatabase):
         _dump_diagnostics_database(dbase)
     else:

--- a/src/cantools/subparsers/dump/__init__.py
+++ b/src/cantools/subparsers/dump/__init__.py
@@ -33,6 +33,7 @@ def _print_j1939_frame_id(message):
     print(f'      Destination:    {destination}')
     print(f'      Format:         {pdu_format}')
 
+
 def _dump_can_message(message, with_comments=False, name_prefix='', WIDTH=None):
     cycle_time = message.cycle_time
     signal_choices_string = formatting.signal_choices_string(message)
@@ -102,6 +103,20 @@ def _dump_can_message(message, with_comments=False, name_prefix='', WIDTH=None):
                               WIDTH=WIDTH,
                               name_prefix=f'{message.name} :: ')
 
+
+def _dump_can_signal(dbase: CanDatabase, signal_name: str, with_comments: bool) -> None:
+    WIDTH = 80
+    try:
+        message = dbase.get_message_by_name(signal_name)
+    except KeyError:
+        raise KeyError(f'Unknown signal {signal_name}') from KeyError
+
+    print('================================= Message =================================')
+    _dump_can_message(message,
+                      with_comments,
+                      WIDTH=WIDTH)
+
+
 def _dump_can_database(dbase, with_comments=False):
     WIDTH = 80
     try:
@@ -117,7 +132,6 @@ def _dump_can_database(dbase, with_comments=False):
         _dump_can_message(message,
                           with_comments=with_comments,
                           WIDTH=WIDTH)
-
 
 
 def _dump_diagnostics_database(dbase):
@@ -147,9 +161,12 @@ def _do_dump(args):
                                encoding=args.encoding,
                                prune_choices=args.prune,
                                strict=not args.no_strict)
-
+    signal_name = args.signal
     if isinstance(dbase, CanDatabase):
-        _dump_can_database(dbase, args.with_comments)
+        if signal_name is None:
+            _dump_can_database(dbase, args.with_comments)
+        else:
+            _dump_can_signal(dbase, signal_name, args.with_comments)
     elif isinstance(dbase, DiagnosticsDatabase):
         _dump_diagnostics_database(dbase)
     else:
@@ -175,5 +192,11 @@ def add_subparser(subparsers):
     dump_parser.add_argument(
         'database',
         help='Database file.')
-    dump_parser.add_argument('--with-comments', action='store_true', default=False)
+    dump_parser.add_argument(
+        '--with-comments',
+        action='store_true',
+        help='Print the comments.')
+    dump_parser.add_argument(
+        '-s', '--signal',
+        help='Print only the specified signal.')
     dump_parser.set_defaults(func=_do_dump)


### PR DESCRIPTION
I often use `cantools dump` to check one specific signal. To do so, I used to use `| less -p <mySignalName>`. 
Now you can use the `-s` or `--signal` flag.

Maybe there was a reason why this feature wasn't implemented earlier?