### PR TITLE
feat: make disk cache an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "bitstruct>=8.16.1",
     "python-can>=4.6.0",
     "textparser>=0.21.1",
-    "diskcache",
     "argparse_addons",
     "crccheck",
 ]
@@ -36,6 +35,7 @@ dynamic = ["version"]
 # can be empty if no extra settings are needed, presence enables setuptools_scm
 
 [project.optional-dependencies]
+cache = ["diskcache"]
 dev = [
     "mypy",
     "pipx",

--- a/src/cantools/database/__init__.py
+++ b/src/cantools/database/__init__.py
@@ -140,6 +140,7 @@ def load_file(filename: StringPathLike,
         warnings.warn(
             "diskcache is not installed; caching is disabled. "
             "Install it with: pip install cantools[cache]",
+            UserWarning,
             stacklevel=2,
         )
         cache_dir = None

--- a/src/cantools/database/__init__.py
+++ b/src/cantools/database/__init__.py
@@ -2,10 +2,15 @@ __all__ = ["Bus", "Database", "DecodeError", "EncodeError", "Message",
            "Node", "Signal", "dump_file", "load", "load_file", "load_string"]
 
 import os
+import warnings
 from contextlib import nullcontext
 from typing import Any, TextIO
 
-import diskcache  # type: ignore
+try:
+    import diskcache  # type: ignore
+    _DISKCACHE_AVAILABLE = True
+except ImportError:
+    _DISKCACHE_AVAILABLE = False
 
 from ..typechecking import StringPathLike
 from . import can, diagnostics, utils
@@ -107,6 +112,9 @@ def load_file(filename: StringPathLike,
     cache will significantly reduce the load time when reloading the
     same file. The cache directory is automatically created if it does
     not exist. Remove the cache directory `cache_dir` to clear the cache.
+    Requires the optional ``diskcache`` package
+    (``pip install cantools[cache]``); if it is not installed, a
+    warning is issued and caching is disabled.
 
     See :func:`~cantools.database.load_string()` for descriptions of
     other arguments.
@@ -128,6 +136,13 @@ def load_file(filename: StringPathLike,
         filename)
 
     cache_dir = cache_dir or os.getenv("CANTOOLS_CACHE_DIR", None)
+    if cache_dir and not _DISKCACHE_AVAILABLE:
+        warnings.warn(
+            "diskcache is not installed; caching is disabled. "
+            "Install it with: pip install cantools[cache]",
+            stacklevel=2,
+        )
+        cache_dir = None
     cache_key: tuple[Any, ...] | None = None
     db: can.Database | diagnostics.Database
 

--- a/src/cantools/subparsers/monitor.py
+++ b/src/cantools/subparsers/monitor.py
@@ -397,7 +397,7 @@ class Monitor(can.Listener):
                     self._update_message_error(timestamp, name, data, f'{message.length - len(data)} bytes too short')
                     return MessageFormattingResult.DecodeError
 
-                decoded_signals = message.decode_simple(data,
+                decoded_signals = message.decode_simple(bytes(data),
                     decode_choices=True,
                     allow_truncated=True,
                     allow_excess=True

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6008,6 +6008,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             break
         self.assert_dbc_dump(db, filename)
 
+    @unittest.skipUnless(cantools.database._DISKCACHE_AVAILABLE, "diskcache not installed")
     def test_cache_prune_choices(self):
         filename = 'tests/files/dbc/socialledge.dbc'
         db = cantools.database.load_file(filename, prune_choices=False, cache_dir=self.cache_dir)
@@ -6018,6 +6019,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(sig.choices[1], 'DRIVER_HEARTBEAT_cmd_SYNC')
         self.assertEqual(sig.choices[2], 'DRIVER_HEARTBEAT_cmd_REBOOT')
 
+    @unittest.skipUnless(cantools.database._DISKCACHE_AVAILABLE, "diskcache not installed")
     @unittest.mock.patch.dict(os.environ, {'CANTOOLS_CACHE_DIR': 'tests/cache_dir'})
     def test_cache_env_var(self):
         cache_dir_path = Path(__file__).parent / "cache_dir"
@@ -6035,6 +6037,15 @@ class CanToolsDatabaseTest(unittest.TestCase):
         # cleanup
         if cache_dir_path.exists():
             shutil.rmtree(cache_dir_path)
+
+    def test_cache_warning_when_diskcache_unavailable(self):
+        with unittest.mock.patch.object(cantools.database, '_DISKCACHE_AVAILABLE', False):
+            with self.assertWarns(UserWarning) as cm:
+                cantools.database.load_file(
+                    'tests/files/dbc/motohawk.dbc',
+                    cache_dir=self.cache_dir,
+                )
+            self.assertIn('diskcache', str(cm.warning))
 
     def test_sort_signals_by_name(self):
         filename = 'tests/files/dbc/vehicle.dbc'

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6008,7 +6008,6 @@ class CanToolsDatabaseTest(unittest.TestCase):
             break
         self.assert_dbc_dump(db, filename)
 
-    @unittest.skipUnless(cantools.database._DISKCACHE_AVAILABLE, "diskcache not installed")
     def test_cache_prune_choices(self):
         filename = 'tests/files/dbc/socialledge.dbc'
         db = cantools.database.load_file(filename, prune_choices=False, cache_dir=self.cache_dir)
@@ -6019,7 +6018,6 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(sig.choices[1], 'DRIVER_HEARTBEAT_cmd_SYNC')
         self.assertEqual(sig.choices[2], 'DRIVER_HEARTBEAT_cmd_REBOOT')
 
-    @unittest.skipUnless(cantools.database._DISKCACHE_AVAILABLE, "diskcache not installed")
     @unittest.mock.patch.dict(os.environ, {'CANTOOLS_CACHE_DIR': 'tests/cache_dir'})
     def test_cache_env_var(self):
         cache_dir_path = Path(__file__).parent / "cache_dir"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6046,6 +6046,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
                     cache_dir=self.cache_dir,
                 )
             self.assertIn('diskcache', str(cm.warning))
+        self.assertFalse(os.path.exists(self.cache_dir))
 
     def test_sort_signals_by_name(self):
         filename = 'tests/files/dbc/vehicle.dbc'

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
 
 extras =
     plot
+    cache
 
 commands =
     pytest {posargs} --cov=cantools --cov-config=tox.ini --cov-report=xml --cov-report=term


### PR DESCRIPTION
Resolve #778 by making the `diskcache` dependency optional and enhancing user feedback when caching is requested but unavailable. It also updates the documentation and adds new tests to ensure correct behavior when `diskcache` is missing. 

Users of caching would now need to opt-in by enabling the 'cache' extra.

**Dependency management and optional caching:**
* Removes `diskcache` from the main dependencies in `pyproject.toml` and adds it as an optional dependency under a new `cache` group, so users must explicitly install it if they want caching support. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L29) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R38)
* Updates the import logic in `src/cantools/database/__init__.py` to gracefully handle the absence of `diskcache`, setting a flag (`_DISKCACHE_AVAILABLE`) accordingly.
* Modifies the `load_file` function to warn users if caching is requested but `diskcache` is not installed, and disables caching in this case. Documentation is also updated to explain the new behavior and installation instructions. [[1]](diffhunk://#diff-4c76de757094e38c56adbfbb273b6de7b534ebd5447aabb6e0d6971c58abf182R115-R117) [[2]](diffhunk://#diff-4c76de757094e38c56adbfbb273b6de7b534ebd5447aabb6e0d6971c58abf182R139-R146)

**Testing improvements:**
* Adds a new test to verify that a warning is issued when caching is requested but `diskcache` is unavailable.