### PR TITLE
monitor: remove the `-f` alias for `--filter-regex`

### DIFF
--- a/src/cantools/subparsers/monitor.py
+++ b/src/cantools/subparsers/monitor.py
@@ -644,7 +644,7 @@ def add_subparser(subparsers):
         action='store_true',
         help='Skip database consistency checks.')
     monitor_parser.add_argument(
-        '-f', '--filter-regex',
+        '--filter-regex',
         help='Use given filter regex.')
 
     if _check_legacy_args():


### PR DESCRIPTION
on my machine, this cause conflicts with the `--fd` option:

```
Traceback (most recent call last):
  File "cantools", line 6, in <module>
    sys.exit(_main())
             ~~~~~^^
  File "cantools/src/cantools/__init__.py", line 102, in _main
    _load_subparser(subparser_name, subparsers)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "cantools/src/cantools/__init__.py", line 67, in _load_subparser
    result.add_subparser(subparsers)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "cantools/src/cantools/subparsers/monitor.py", line 663, in add_subparser
    monitor_parser.add_argument(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        '-f', '--fd',
        ^^^^^^^^^^^^^
        action='store_true',
        ^^^^^^^^^^^^^^^^^^^^
        help='(Deprecated) Python CAN CAN-FD bus.')
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/argparse.py", line 1517, in add_argument
    return self._add_action(action)
           ~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/lib64/python3.13/argparse.py", line 1906, in _add_action
    self._optionals._add_action(action)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/lib64/python3.13/argparse.py", line 1724, in _add_action
    action = super(_ArgumentGroup, self)._add_action(action)
  File "/usr/lib64/python3.13/argparse.py", line 1531, in _add_action
    self._check_conflict(action)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/lib64/python3.13/argparse.py", line 1673, in _check_conflict
    conflict_handler(action, confl_optionals)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/argparse.py", line 1682, in _handle_conflict_error
    raise ArgumentError(action, message % conflict_string)
argparse.ArgumentError: argument -f/--fd: conflicting option string: -f
```
