### PR TITLE
Fix restrictive ifname pattern in logreader.CandumpPattern

### DIFF
--- a/src/cantools/logreader.py
+++ b/src/cantools/logreader.py
@@ -99,7 +99,7 @@ class CandumpDefaultPattern(CandumpBasePattern):
     # vcan0  1F0   [8]  00 00 00 00 00 00 1B C1   '.......Á'
     #(Ignore anything after the end of the data to work with candump's ASCII decoding)
     pattern = re.compile(
-        r'^\s*?(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|[0-9A-F ]*).*?$')
+        r'^\s*?(?P<channel>\S+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|[0-9A-F ]*).*?$')
 
     def parse_timestamp(self, match_object: re.Match[str]) -> tuple[TimestampType, TimestampFormat]:
         timestamp = None
@@ -114,7 +114,7 @@ class CandumpTimestampedPattern(CandumpBasePattern):
     # (000.000000)  vcan0  0C8   [8]  31 30 30 2E 35 20 46 4D   '100.5 FM'
     #(Ignore anything after the end of the data to work with candump's ASCII decoding)
     pattern = re.compile(
-        r'^\s*?\((?P<timestamp>[\d.]+)\)\s+(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|[0-9A-F ]*).*?$')
+        r'^\s*?\((?P<timestamp>[\d.]+)\)\s+(?P<channel>\S+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|[0-9A-F ]*).*?$')
 
     def __init__(self, tz: TimezoneType) -> None:
         if tz == TZ_LOCAL:
@@ -143,7 +143,7 @@ class CandumpDefaultLogPattern(CandumpBasePattern):
     # (1579857014.345944) can2 486#82967A6B006B07F8
     # (1613656104.501098) can2 14C##16A0FFE00606E022400000000000000A0FFFF00FFFF25000600000000000000FE
     pattern = re.compile(
-        r'^\s*?\((?P<timestamp>[\d.]+?)\)\s+?(?P<channel>[a-zA-Z0-9]+)\s+?(?P<can_id>[0-9A-F]+?)#(#[0-9A-F])?(?P<can_data>R|([0-9A-Fa-f]{2})*)(\s+[RT])?$')
+        r'^\s*?\((?P<timestamp>[\d.]+?)\)\s+?(?P<channel>\S+)\s+?(?P<can_id>[0-9A-F]+?)#(#[0-9A-F])?(?P<can_data>R|([0-9A-Fa-f]{2})*)(\s+[RT])?$')
 
     def __init__(self, tz: TimezoneType) -> None:
         if tz == TZ_LOCAL:
@@ -168,7 +168,7 @@ class CandumpAbsoluteLogPattern(CandumpBasePattern):
     # (2020-12-19 12:04:45.485261)  vcan0  0C8   [8]  31 30 30 2E 35 20 46 4D   '100.5 FM'
     #(Ignore anything after the end of the data to work with candump's ASCII decoding)
     pattern = re.compile(
-        r'^\s*?\((?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\)\s+(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|[0-9A-F ]*).*?$')
+        r'^\s*?\((?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\)\s+(?P<channel>\S+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|[0-9A-F ]*).*?$')
 
     def parse_timestamp(self, match_object: re.Match[str]) -> tuple[TimestampType, TimestampFormat]:
         timestamp = datetime.datetime.strptime(match_object.group('timestamp'), "%Y-%m-%d %H:%M:%S.%f")

--- a/tests/test_logreader.py
+++ b/tests/test_logreader.py
@@ -73,6 +73,16 @@ class TestLogreaderFormats(unittest.TestCase):
         self.assertEqual(outp.is_remote_frame, True)
         self.assertEqual(outp.timestamp_format, cantools.logreader.TimestampFormat.MISSING)
 
+        outp = parser.parse("  vcan-0  123   [8]  00 01 02 03 04 05 06 07")
+        self.assertEqual(outp.channel, 'vcan-0')
+        self.assertEqual(outp.frame_id, 0x123)
+        self.assertEqual(outp.data, bytes(range(8)))
+
+        outp = parser.parse("  vcan.0  123   [8]  00 01 02 03 04 05 06 07")
+        self.assertEqual(outp.channel, 'vcan.0')
+        self.assertEqual(outp.frame_id, 0x123)
+        self.assertEqual(outp.data, bytes(range(8)))
+
     def test_timestamped_candump(self):
         parser = cantools.logreader.Parser()
 
@@ -203,6 +213,30 @@ class TestLogreaderFormats(unittest.TestCase):
         self.assertEqual(outp.timestamp.second, 24)
         self.assertEqual(outp.timestamp.microsecond, 501098)
         #self.assertEqual(outp.timestamp.tzinfo, utc_plus(0))  # bug in freezegun: tzlocal() != datetime.timezone.utc
+
+        outp = parser.parse("(1780715436.846782) vcan-0 123#0001020304050607")
+        self.assertEqual(outp.channel, 'vcan-0')
+        self.assertEqual(outp.frame_id, 0x123)
+        self.assertEqual(outp.data, bytes(range(8)))
+        self.assertEqual(outp.timestamp.year, 2026)
+        self.assertEqual(outp.timestamp.month, 6)
+        self.assertEqual(outp.timestamp.day, 6)
+        self.assertEqual(outp.timestamp.hour, 3)
+        self.assertEqual(outp.timestamp.minute, 10)
+        self.assertEqual(outp.timestamp.second, 36)
+        self.assertEqual(outp.timestamp.microsecond, 846782)
+
+        outp = parser.parse("(1780715439.417805) vcan.0 123#0001020304050607")
+        self.assertEqual(outp.channel, 'vcan.0')
+        self.assertEqual(outp.frame_id, 0x123)
+        self.assertEqual(outp.data, bytes(range(8)))
+        self.assertEqual(outp.timestamp.year, 2026)
+        self.assertEqual(outp.timestamp.month, 6)
+        self.assertEqual(outp.timestamp.day, 6)
+        self.assertEqual(outp.timestamp.hour, 3)
+        self.assertEqual(outp.timestamp.minute, 10)
+        self.assertEqual(outp.timestamp.second, 39)
+        self.assertEqual(outp.timestamp.microsecond, 417805)
 
         with freeze_time(tz_offset=2):
             outp = parser.parse("(1752918539.271062) vcan0 00000123#1234567890ABCDEF")


### PR DESCRIPTION
[net/core/dev.c:dev_valid_name](https://github.com/torvalds/linux/blob/8e65320d91cdc3b241d4b94855c88459b91abf66/net/core/dev.c#L1325) only limits interface names to "must be valid file name and not contain spaces", so e.g. "can-123" is a valid interface name.

    $ sudo ip link add vcan.0 type vcan
    $ sudo ip link set dev vcan.0 up
    $ cansend vcan.0 123#0001020304050607
    $ candump vcan.0
      vcan.0  123   [8]  00 01 02 03 04 05 06 07

Fixes #519

---

I went with "non-blank", which is slightly less restrictive, but I figured that it wasn't worth trying to match the semantics exactly (since we don't do things like compare against IFNAMSIZ etc.)