### PR TITLE
Clean up monitor script and remove deprecated functionality

### DIFF
--- a/src/cantools/subparsers/__utils__.py
+++ b/src/cantools/subparsers/__utils__.py
@@ -1,5 +1,4 @@
-import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 from cantools.database.errors import DecodeError
 
@@ -10,7 +9,6 @@ from ..typechecking import (
     ContainerDecodeResultType,
     ContainerUnpackResultType,
     SignalDictType,
-    TAdditionalCliArgs,
 )
 
 MULTI_LINE_FMT = '''
@@ -209,41 +207,3 @@ def format_multiplexed_name(message : Message,
             result.append(f'{signal.name}={value}')
 
     return ' :: '.join(result)
-
-
-def cast_from_string(string_val: str) -> str | int | float | bool:
-    """Perform trivial type conversion from :class:`str` values.
-
-    :param string_val:
-        the string, that shall be converted
-    """
-    if re.match(r"^[-+]?\d+$", string_val):
-        # value is integer
-        return int(string_val)
-
-    if re.match(r"^[-+]?\d*\.\d+(?:e[-+]?\d+)?$", string_val):
-        # value is float
-        return float(string_val)
-
-    if re.match(r"^(?:True|False)$", string_val, re.IGNORECASE):
-        # value is bool
-        return string_val.lower() == "true"
-
-    # value is string
-    return string_val
-
-
-def parse_additional_config(unknown_args: Sequence[str]) -> TAdditionalCliArgs:
-    for arg in unknown_args:
-        if not re.match(r"^--[a-zA-Z][a-zA-Z0-9\-]*=\S*?$", arg):
-            raise ValueError(f'Parsing argument {arg} failed, use --param=value'
-                             ' to pass additional args to CAN Bus.')
-
-    def _split_arg(_arg: str) -> tuple[str, str]:
-        left, right = _arg.split("=", 1)
-        return left.lstrip("-").replace("-", "_"), right
-
-    args: dict[str, str | int | float | bool] = {}
-    for key, string_val in map(_split_arg, unknown_args):
-        args[key] = cast_from_string(string_val)
-    return args

--- a/src/cantools/subparsers/monitor.py
+++ b/src/cantools/subparsers/monitor.py
@@ -3,9 +3,7 @@ import bisect
 import curses
 import queue
 import re
-import sys
 import time
-import warnings
 from enum import Enum
 from typing import Any
 
@@ -584,44 +582,14 @@ def _do_monitor(args):
         pass
 
 
-def _check_legacy_args() -> bool:
-    """Return True if legacy CAN bus arguments were given."""
-    args = sys.argv[1:]  # already a list of strings
-
-    # New style explicitly supported -> no legacy mode
-    if "-i" in args or "--interface" in args:
-        return False
-
-    # Special case: "-b" meaning change
-    if "-b" in args:
-        b_index = args.index("-b")
-        # Legacy if the value after -b is non-numeric (old bus type behavior)
-        if len(args) > b_index + 1 and not args[b_index + 1].isdigit():
-            return True
-
-    # Other explicit legacy indicators
-    if any(arg in args for arg in ("--bus-type", "--bit-rate", "-B")):
-        return True
-
-    return False
-
-
-def _warn_legacy_usage():
-    """Emit a warning if legacy args were detected."""
-    warnings.warn(
-        "You are using legacy CAN bus arguments (-b, --bus-type, -B, etc.). "
-        "These are deprecated and will be removed in a future release. "
-        "Please use the new bus argument format via `--interface` and related options.",
-        UserWarning,
-        stacklevel=2
-    )
-
-
 def add_subparser(subparsers):
     monitor_parser = subparsers.add_parser(
         'monitor',
         description='Monitor CAN bus traffic in a text based user interface.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    monitor_parser.add_argument(
+        'database',
+        help='Database file.')
     monitor_parser.add_argument(
         '-s', '--single-line',
         action='store_true',
@@ -646,34 +614,6 @@ def add_subparser(subparsers):
     monitor_parser.add_argument(
         '--filter-regex',
         help='Use given filter regex.')
+    can.cli.add_bus_arguments(monitor_parser, filter_arg=True, group_title="bus arguments (python-can)")
 
-    if _check_legacy_args():
-        _warn_legacy_usage()
-        monitor_parser.add_argument(
-            '-b', '--bus-type',
-            default='socketcan',
-            help='(Deprecated) Python CAN bus type.')
-        monitor_parser.add_argument(
-            '-c', '--channel',
-            default='vcan0',
-            help='(Deprecated) Python CAN bus channel.')
-        monitor_parser.add_argument(
-            '-B', '--bit-rate',
-            help='(Deprecated) Python CAN bus bit rate.')
-        monitor_parser.add_argument(
-            '-f', '--fd',
-            action='store_true',
-            help='(Deprecated) Python CAN CAN-FD bus.')
-        monitor_parser.add_argument(
-            'extra_args',
-            nargs=argparse.REMAINDER,
-            help="(Deprecated) Remaining arguments will be used for the interface. "
-                 "Example: `-c can0 -b socketcand --host=192.168.0.10 --port=29536` "
-                 "is equivalent to `Bus('can0', 'socketcand', host='192.168.0.10', port=29536)`")
-    else:
-        can.cli.add_bus_arguments(monitor_parser, filter_arg=True, group_title="bus arguments (python-can)")
-
-    monitor_parser.add_argument(
-        'database',
-        help='Database file.')
     monitor_parser.set_defaults(func=_do_monitor)

--- a/src/cantools/subparsers/monitor.py
+++ b/src/cantools/subparsers/monitor.py
@@ -17,7 +17,6 @@ from ..typechecking import SignalDictType
 from .__utils__ import (
     format_multiplexed_name,
     format_signals,
-    parse_additional_config,
 )
 
 
@@ -59,6 +58,8 @@ class Monitor(can.Listener):
         self._errors = 0
         self._basetime: float | None = None
         self._page_first_row = 0
+        bus = can.cli.create_bus_from_namespace(args)
+        self._notifier = can.Notifier(bus, [self])
 
         if self._filter is not None:
             self.compile_filter()
@@ -70,36 +71,6 @@ class Monitor(can.Listener):
         curses.init_pair(1, curses.COLOR_BLACK, curses.COLOR_GREEN)
         curses.init_pair(2, curses.COLOR_BLACK, curses.COLOR_CYAN)
         curses.init_pair(3, curses.COLOR_CYAN, curses.COLOR_BLACK)
-
-        if "bus_type" in args:
-            # TODO: this branch can be removed once legacy args are removed
-            bus = self.create_bus(args)
-        else:
-            bus = can.cli.create_bus_from_namespace(args)
-
-        self._notifier = can.Notifier(bus, [self])
-
-    def create_bus(self, args):
-        kwargs = {}
-
-        if args.bit_rate is not None:
-            kwargs['bitrate'] = int(args.bit_rate)
-
-        if args.fd:
-            kwargs['fd'] = True
-
-        if args.extra_args:
-            kwargs.update(parse_additional_config(args.extra_args))
-
-        try:
-            return can.Bus(interface=args.bus_type,
-                           channel=args.channel,
-                           **kwargs)
-        except Exception as exc:
-            raise Exception(
-                f"Failed to create CAN bus with bustype='{args.bus_type}' and "
-                f"channel='{args.channel}'."
-            ) from exc
 
     def run(self, max_num_keys_per_tick=-1):
         while True:

--- a/src/cantools/typechecking.py
+++ b/src/cantools/typechecking.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     Literal,
     NamedTuple,
-    TypeAlias,
     TypedDict,
     Union,
 )
@@ -56,5 +55,3 @@ DecodeResultType = SignalDictType | ContainerDecodeResultType
 EncodeInputType = SignalMappingType | ContainerEncodeInputType
 
 SecOCAuthenticatorFn = Callable[["Message", bytes, int], bytes]
-
-TAdditionalCliArgs: TypeAlias = dict[str, str | int | float | bool]

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -23,8 +23,7 @@ class Args(argparse.Namespace):
 
     def __init__(self,
                  database,
-                 single_line=False,
-                 legacy_args=False):
+                 single_line=False):
         kwargs = {
             "database": database,
             "encoding": None,
@@ -35,19 +34,10 @@ class Args(argparse.Namespace):
             "fd": False,
             "channel": 'vcan0',
             "filter_regex": '',
+            "interface": "socketcan",
+            "bitrate": None,
+            "bus_kwargs": [],
         }
-
-        if legacy_args:
-            # TODO: this branch can be removed once legacy args are removed
-            kwargs["bus_type"] = "socketcan"
-            kwargs["bit_rate"] = None
-            kwargs["extra_args"] = []
-        else:
-            kwargs["interface"] = "socketcan"
-            kwargs["bitrate"] = None
-            kwargs["bus_kwargs"] = []
-
-
         super().__init__(**kwargs)
 
 
@@ -2071,7 +2061,7 @@ class CanToolsMonitorTest(unittest.TestCase):
     @patch('curses.init_pair')
     @patch('curses.curs_set')
     @patch('curses.use_default_colors')
-    def test_extra_args_parsing(self,
+    def test_bus_kwargs_parsing(self,
                                 _use_default_colors,
                                 _curs_set,
                                 _init_pair,
@@ -2081,10 +2071,10 @@ class CanToolsMonitorTest(unittest.TestCase):
                                 _notifier):
         # Prepare mocks.
         stdscr = StdScr()
-        args = Args('tests/files/dbc/motohawk.dbc', legacy_args=True)
-        args.bus_type = 'socketcand'
+        args = Args('tests/files/dbc/motohawk.dbc')
+        args.interface = 'socketcand'
         args.channel = 'can0'
-        args.extra_args = ['--host=192.168.0.10', '--port=29536']
+        args.bus_kwargs = {'host': '192.168.0.10', 'port': 29536}
         color_pair.side_effect = lambda i: self.color_pair_side_effect[i]
         is_term_resized.return_value = False
 
@@ -2093,8 +2083,8 @@ class CanToolsMonitorTest(unittest.TestCase):
         monitor.run(1)
 
         # Check mocks.
-        self.assert_called(bus, [call(interface='socketcand', channel='can0',
-                                      host='192.168.0.10', port=29536)])
+        self.assert_called(bus, [call(single_handle=True, interface='socketcand', channel='can0',
+                                      host='192.168.0.10', port=29536, bitrate=None, fd=False)])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It's been about a year since https://github.com/cantools/cantools/pull/745 landed, and there's some extra cruft in `monitor.py` that can be removed to simplify it a bit. The changes in #732 can also be removed since python-can incorporates that functionality in `bus_kwargs`.

The change for user scripts would be from:
```
cantools monitor ... -c can0 -b socketcand --host=192.168.0.10 --port=29536
```
to:
```
cantools monitor ... -c can0 -i socketcand --bus_kwargs host=192.168.0.10 port=29536
```