### PR TITLE
Fix as_sym_string() dropping the {SIGNALS} block (UnboundLocalError + broken round-trip)

### DIFF
--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -865,7 +865,7 @@ def _dump_signals(database: InternalDatabase, sort_signals: Callable[[list[Signa
                 generated_signals.add(signal.name)
                 signal_dumps.append(_dump_signal(signal))
 
-    if signals:
+    if signal_dumps:
         return '{SIGNALS}\n' + '\n'.join(signal_dumps)
     else:
         return ''

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1962,6 +1962,39 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(db.messages), 1)
         self.assertEqual(db.messages[0].name, 'Symbol1')
 
+    def test_as_sym_string_empty_database(self):
+        # as_sym_string() on a database with no messages must not crash
+        # (regression: _dump_signals checked an unbound loop variable).
+        db = cantools.database.Database(messages=[])
+
+        sym = db.as_sym_string()
+        self.assertIn('FormatVersion', sym)
+        # ... and round-trips back to an empty database.
+        reloaded = cantools.database.load_string(sym, 'sym')
+        self.assertEqual(len(reloaded.messages), 0)
+
+    def test_as_sym_string_last_message_without_signals(self):
+        # When the last message has no signals, the {SIGNALS} block defining
+        # the earlier messages' signals must still be written; otherwise the
+        # emitted SYM references signals it never defines and cannot be re-read
+        # (regression: the guard used the loop variable, not the accumulator).
+        speed = Signal(name='Speed', start=0, length=8)
+        with_signals = Message(frame_id=0x100, name='HasSignals',
+                               length=8, signals=[speed])
+        without_signals = Message(frame_id=0x101, name='NoSignals',
+                                  length=8, signals=[])
+        db = cantools.database.Database(
+            messages=[with_signals, without_signals])
+
+        sym = db.as_sym_string()
+        self.assertIn('{SIGNALS}', sym)
+
+        reloaded = cantools.database.load_string(sym, 'sym')
+        by_name = {m.name: [s.name for s in m.signals]
+                   for m in reloaded.messages}
+        self.assertEqual(by_name['HasSignals'], ['Speed'])
+        self.assertEqual(by_name['NoSignals'], [])
+
     def test_signal_types_6_0_sym(self):
         db = cantools.database.load_file('tests/files/sym/signal-types-6.0.sym')
 


### PR DESCRIPTION
### The bug

`Database.as_sym_string()` (and `dump_file(..., 'sym')`) produces broken output via `_dump_signals`, with two manifestations from one root cause.

**A — crash on an empty database:**
```python
>>> import cantools
>>> cantools.database.Database(messages=[]).as_sym_string()
UnboundLocalError: cannot access local variable 'signals' where it is not associated with a value
```
(Also hit by bundled DBCs that parse to zero messages.)

**B — silently corrupt output (the serious one):** if the *last-iterated* message has no signals, the entire `{SIGNALS}` definition block is dropped — even when earlier messages have signals. The emitted SYM still references those signals in the message bodies, so cantools cannot re-read its own output:
```python
db = cantools.database.Database(messages=[
    Message(0x100, 'HasSignals', 8, signals=[Signal('Speed', 0, 8)]),
    Message(0x101, 'NoSignals',  8, signals=[]),
])
sym = db.as_sym_string()
'{SIGNALS}' in sym          # False  -> block dropped
cantools.database.load_string(sym, 'sym')   # KeyError: 'Speed'
```

### Why the expected behaviour is unambiguous

A writer must emit SYM that its own reader can parse (round-trip), and the sibling helper in the same file, `_dump_messages`, already guards correctly on the *accumulated* lists (`if send_messages:`, `if receive_messages:`, `if send_receive_messages:`). Only `_dump_signals` guards on the loop variable.

### Root cause

`src/cantools/database/can/formats/sym.py`, `_dump_signals`:

```python
signal_dumps = []
...
for message in database.messages:
    signals = ... message.signals          # loop-local
    for signal in signals:
        ... signal_dumps.append(_dump_signal(signal))

if signals:                                # BUG: should be `signal_dumps`
    return '{SIGNALS}\n' + '\n'.join(signal_dumps)
```

`signals` is bound only inside the loop, so it is undefined when there are no messages and otherwise equals the *last* message's signal list — neither reflects whether any signal was actually dumped. The accumulator is `signal_dumps`.

### The fix

One line: guard on the accumulator, matching `_dump_messages`:

```python
if signal_dumps:
```

### Tests

Two cases in `tests/test_database.py`: `test_as_sym_string_empty_database` (manifestation A) and `test_as_sym_string_last_message_without_signals` (manifestation B, asserting `{SIGNALS}` is present and that the SYM round-trips back to `HasSignals=['Speed']`, `NoSignals=[]`). Both fail on `master` (UnboundLocalError / `{SIGNALS}` not found) and pass with the fix; the full `tests/test_database.py` stays green (the only failure, `test_cache_env_var`, is a pre-existing diskcache-environment one that also fails on a clean tree).
