### PR TITLE
DBC cleanup, part1 (v2)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,4 +301,5 @@ autodoc_type_aliases = {
 # disable specific warnings
 nitpick_ignore = [
     ("py:class", "TypeAliasForwardRef"),
+    ("py:class", "cantools.database.can.attribute_definition.AttributeValueTypeVar"),
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,8 +43,7 @@ Functions and classes
 .. autoclass:: cantools.database.can.attribute_definition.AttributeDefinition
     :members:
 
-.. autoclass:: cantools.database.can.attribute_definition.AttributeValueType
-    :members:
+.. autodata:: cantools.database.can.attribute_definition.AttributeValueTypeVar
 
 .. autoclass:: cantools.database.can.attribute.Attribute
     :members:

--- a/src/cantools/database/can/attribute.py
+++ b/src/cantools/database/can/attribute.py
@@ -35,6 +35,16 @@ class Attribute(Generic[AttributeValueType]):
         self._value = value
 
     @property
+    def formatted_value(self) -> str:
+        """The value of the attribute as it appears in the DBC file
+
+        """
+        if self.definition.type_name == "STRING":
+            return f'"{self._value}"'
+
+        return f'{self._value}'
+
+    @property
     def definition(self) -> AttributeDefinition[AttributeValueType]:
         """The attribute definition.
 

--- a/src/cantools/database/can/attribute.py
+++ b/src/cantools/database/can/attribute.py
@@ -1,18 +1,18 @@
 from typing import Generic
 
-from .attribute_definition import AttributeDefinition, AttributeValueType
+from .attribute_definition import AttributeDefinition, AttributeValueTypeVar
 
 
-class Attribute(Generic[AttributeValueType]):
+class Attribute(Generic[AttributeValueTypeVar]):
     """An attribute that can be associated with nodes/messages/signals.
 
     """
 
     def __init__(self,
-                 value: AttributeValueType,
-                 definition: AttributeDefinition[AttributeValueType]) -> None:
-        self._value: AttributeValueType = value
-        self._definition: AttributeDefinition[AttributeValueType] = definition
+                 value: AttributeValueTypeVar,
+                 definition: AttributeDefinition[AttributeValueTypeVar]) -> None:
+        self._value: AttributeValueTypeVar = value
+        self._definition: AttributeDefinition[AttributeValueTypeVar] = definition
 
     @property
     def name(self) -> str:
@@ -23,7 +23,7 @@ class Attribute(Generic[AttributeValueType]):
         return self._definition.name
 
     @property
-    def value(self) -> AttributeValueType:
+    def value(self) -> AttributeValueTypeVar:
         """The value that this attribute has.
 
         """
@@ -31,7 +31,7 @@ class Attribute(Generic[AttributeValueType]):
         return self._value
 
     @value.setter
-    def value(self, value: AttributeValueType) -> None:
+    def value(self, value: AttributeValueTypeVar) -> None:
         self._value = value
 
     @property
@@ -45,7 +45,7 @@ class Attribute(Generic[AttributeValueType]):
         return f'{self._value}'
 
     @property
-    def definition(self) -> AttributeDefinition[AttributeValueType]:
+    def definition(self) -> AttributeDefinition[AttributeValueTypeVar]:
         """The attribute definition.
 
         """

--- a/src/cantools/database/can/attribute_definition.py
+++ b/src/cantools/database/can/attribute_definition.py
@@ -1,8 +1,9 @@
 from typing import Generic, TypeVar
 
-AttributeValueType = TypeVar('AttributeValueType', str, int, float)
+AttributeValue = str | int | float
+AttributeValueTypeVar = TypeVar('AttributeValueTypeVar', str, int, float)
 
-class AttributeDefinition(Generic[AttributeValueType]):
+class AttributeDefinition(Generic[AttributeValueTypeVar]):
     """A definition of an attribute that can be associated with attributes
     in nodes/messages/signals.
 
@@ -10,14 +11,14 @@ class AttributeDefinition(Generic[AttributeValueType]):
 
     def __init__(self,
                  name: str,
-                 default_value: AttributeValueType | None = None,
+                 default_value: AttributeValueTypeVar | None = None,
                  kind: str | None = None,
                  type_name: str | None = None,
                  minimum: int | float | None = None,
                  maximum: int | float | None = None,
                  choices: list[str] | None = None) -> None:
         self._name = name
-        self._default_value: AttributeValueType | None = default_value
+        self._default_value: AttributeValueTypeVar | None = default_value
         self._kind = kind
         self._type_name = type_name
         self._minimum = minimum
@@ -33,7 +34,7 @@ class AttributeDefinition(Generic[AttributeValueType]):
         return self._name
 
     @property
-    def default_value(self) -> AttributeValueType | None:
+    def default_value(self) -> AttributeValueTypeVar | None:
         """The default value that this attribute has, or ``None`` if
         unavailable.
 
@@ -42,7 +43,7 @@ class AttributeDefinition(Generic[AttributeValueType]):
         return self._default_value
 
     @default_value.setter
-    def default_value(self, value: AttributeValueType | None) -> None:
+    def default_value(self, value: AttributeValueTypeVar | None) -> None:
         self._default_value = value
 
     @property

--- a/src/cantools/database/can/attribute_definition.py
+++ b/src/cantools/database/can/attribute_definition.py
@@ -75,6 +75,13 @@ class AttributeDefinition(Generic[AttributeValueType]):
         self._minimum = value
 
     @property
+    def formatted_minimum(self) -> str:
+        """The defined minimum value of the attribute definition as it appears in the DBC file
+
+        """
+        return '' if self._minimum is None else f' {self._minimum}'
+
+    @property
     def maximum(self) -> int | float | None:
         """The maximum value of the attribute, or ``None`` if unavailable.
 
@@ -85,6 +92,13 @@ class AttributeDefinition(Generic[AttributeValueType]):
     @maximum.setter
     def maximum(self, value: int | float | None) -> None:
         self._maximum = value
+
+    @property
+    def formatted_maximum(self) -> str:
+        """The defined maximum value of the attribute definition as it appears in the DBC file
+
+        """
+        return '' if self._maximum is None else f' {self._maximum}'
 
     @property
     def choices(self) -> list[str]:

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -737,7 +737,7 @@ def _dump_attribute_definition_defaults(database: InternalDatabase) -> list[str]
 
     for definition in definitions.values():
         if definition.default_value is not None:
-            if definition.type_name in ["STRING", "ENUM"]:
+            if definition.type_name in ['STRING', 'ENUM']:
                 fmt = 'BA_DEF_DEF_  "{name}" "{value}";'
             else:
                 fmt = 'BA_DEF_DEF_  "{name}" {value};'
@@ -758,7 +758,7 @@ def _dump_attribute_definition_defaults_rel(database: InternalDatabase) -> list[
 
     for definition in definitions.values():
         if definition.default_value is not None:
-            if definition.type_name in ["STRING", "ENUM"]:
+            if definition.type_name in ['STRING', 'ENUM']:
                 fmt = 'BA_DEF_DEF_REL_ "{name}" "{value}";'
             else:
                 fmt = 'BA_DEF_DEF_REL_ "{name}" {value};'
@@ -792,7 +792,7 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
         assert baudrate_attr_def is not None
         database.dbc.attributes['Baudrate'] = Attribute[int](
                     value=int(baudrate),
-                    definition=typing.cast("AttributeDefinition[int]", baudrate_attr_def),
+                    definition=typing.cast('AttributeDefinition[int]', baudrate_attr_def),
                 )
 
     for attribute in database.dbc.attributes.values():
@@ -817,12 +817,12 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
         # the cycle time specified by the message object
         msg_cycle_time = message.cycle_time or 0
 
-        gen_msg_cycle_time_def = database.dbc.attribute_definitions.get("GenMsgCycleTime")
+        gen_msg_cycle_time_def = database.dbc.attribute_definitions.get('GenMsgCycleTime')
 
         if gen_msg_cycle_time_def is not None and msg_cycle_time != gen_msg_cycle_time_def.default_value:
             msg_attributes['GenMsgCycleTime'] = Attribute(
                 value=msg_cycle_time,
-                definition=typing.cast("AttributeDefinition[int]", gen_msg_cycle_time_def),
+                definition=typing.cast('AttributeDefinition[int]', gen_msg_cycle_time_def),
             )
         elif 'GenMsgCycleTime' in msg_attributes:
             del msg_attributes['GenMsgCycleTime']
@@ -830,7 +830,7 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
         # if bus is CAN FD, set VFrameFormat
         v_frame_format_def = None
         if database.dbc is not None:
-            v_frame_format_def = database.dbc.attribute_definitions.get("VFrameFormat")
+            v_frame_format_def = database.dbc.attribute_definitions.get('VFrameFormat')
         if v_frame_format_def is not None:
             if message.protocol == 'j1939':
                 v_frame_format_str = 'J1939PG'
@@ -925,7 +925,7 @@ def _dump_attributes_rel(database: InternalDatabase, sort_signals: type_sort_sig
 
     attributes_rel = database.dbc.attributes_rel
     for frame_id, element in attributes_rel.items():
-        if "signal" in element:
+        if 'signal' in element:
             for signal_name, signal_lst in element['signal'].items():
                 for node_name, node_dict in signal_lst['node'].items():
                     for attribute in node_dict.values():
@@ -936,7 +936,7 @@ def _dump_attributes_rel(database: InternalDatabase, sort_signals: type_sort_sig
                                         f'{frame_id} '
                                         f'{signal_name} '
                                         f'{attribute.formatted_value};')
-        elif "node" in element:
+        elif 'node' in element:
             for node_name, node_dict in element['node'].items():
                 for attribute in node_dict.values():
                     ba_rel.append(f'BA_REL_ "{attribute.definition.name}" '
@@ -1238,7 +1238,7 @@ def _load_attributes_rel(tokens, definitions):
         rel_type = attribute[2]
         node = attribute[3]
 
-        if rel_type == "BU_SG_REL_":
+        if rel_type == 'BU_SG_REL_':
 
             frame_id_dbc = int(attribute[5])
             signal = attribute[6]
@@ -1260,7 +1260,7 @@ def _load_attributes_rel(tokens, definitions):
 
             attributes_rel[frame_id_dbc]['signal'][signal]['node'][node][name] = to_object(attribute, attribute[7])
 
-        elif rel_type == "BU_BO_REL_":
+        elif rel_type == 'BU_BO_REL_':
             frame_id_dbc = int(attribute[4])
 
             if frame_id_dbc not in attributes_rel:
@@ -1623,11 +1623,11 @@ def _get_enum_vframeformat_attribute(attribute: AttributeDefinitionType) -> Attr
     """
 
     if attribute.type_name != 'INT':
-        return typing.cast("AttributeDefinition[str]", attribute)
+        return typing.cast('AttributeDefinition[str]', attribute)
 
-    typed_attribute = typing.cast("AttributeDefinition[int]", attribute)
+    typed_attribute = typing.cast('AttributeDefinition[int]', attribute)
     default_value = typed_attribute.default_value
-    assert default_value is not None, "Default value for VFrameFormat attribute must be defined if the attribute is defined as an INT."
+    assert default_value is not None, 'Default value for VFrameFormat attribute must be defined if the attribute is defined as an INT.'
     enum_attribute = deepcopy(ATTRIBUTE_DEFINITION_VFRAMEFORMAT)
     enum_attribute.default_value = enum_attribute.choices[default_value]
 
@@ -1770,7 +1770,7 @@ def _load_messages(tokens,
         is_extended_frame = bool(frame_id_dbc & 0x80000000)
         frame_format = get_frame_format(frame_id_dbc)
         if frame_format is not None:
-            is_fd = frame_format.endswith("CAN_FD")
+            is_fd = frame_format.endswith('CAN_FD')
         else:
             is_fd = False
 
@@ -1879,25 +1879,25 @@ def get_attribute_definition(database: InternalDatabase, name: str, default: Att
 
 
 def get_long_envvar_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
-    return typing.cast("AttributeDefinition[str]", get_attribute_definition(database,
+    return typing.cast('AttributeDefinition[str]', get_attribute_definition(database,
                                     'SystemEnvVarLongSymbol',
                                     ATTRIBUTE_DEFINITION_LONG_ENVVAR_NAME))
 
 
 def get_long_node_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
-    return typing.cast("AttributeDefinition[str]", get_attribute_definition(database,
+    return typing.cast('AttributeDefinition[str]', get_attribute_definition(database,
                                     'SystemNodeLongSymbol',
                                     ATTRIBUTE_DEFINITION_LONG_NODE_NAME))
 
 
 def get_long_message_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
-    return typing.cast("AttributeDefinition[str]", get_attribute_definition(database,
+    return typing.cast('AttributeDefinition[str]', get_attribute_definition(database,
                                     'SystemMessageLongSymbol',
                                     ATTRIBUTE_DEFINITION_LONG_MESSAGE_NAME))
 
 
 def get_long_signal_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
-    return typing.cast("AttributeDefinition[str]", get_attribute_definition(database,
+    return typing.cast('AttributeDefinition[str]', get_attribute_definition(database,
                                     'SystemSignalLongSymbol',
                                     ATTRIBUTE_DEFINITION_LONG_SIGNAL_NAME))
 
@@ -2132,11 +2132,11 @@ def dump_string(database: InternalDatabase,
                           cm='\r\n'.join(cm),
                           signal_types='\r\n'.join(signal_types),
                           ba_def='\r\n'.join(ba_def),
-                          ba_def_rel="".join([elem+"\r\n" for elem in ba_def_rel]),
+                          ba_def_rel=''.join([elem+'\r\n' for elem in ba_def_rel]),
                           ba_def_def='\r\n'.join(ba_def_def),
-                          ba_def_def_rel="".join([elem+"\r\n" for elem in ba_def_def_rel]),
+                          ba_def_def_rel=''.join([elem+'\r\n' for elem in ba_def_def_rel]),
                           ba='\r\n'.join(ba),
-                          ba_rel="".join([elem+"\r\n" for elem in ba_rel]),
+                          ba_rel=''.join([elem+'\r\n' for elem in ba_rel]),
                           val='\r\n'.join(val),
                           sig_group='\r\n'.join(sig_group),
                           sig_mux_values='\r\n'.join(sig_mux_values))
@@ -2165,7 +2165,7 @@ def get_definitions_dict(definitions: typing.Any, defaults: typing.Any) -> Order
         values = item[4][0]
 
         if len(values) > 0:
-            if definition.type_name == "ENUM":
+            if definition.type_name == 'ENUM':
                 definition.choices = values
             elif definition.type_name in ['INT', 'FLOAT', 'HEX']:
                 definition.minimum = convert_value(definition, values[0])
@@ -2205,7 +2205,7 @@ def get_definitions_rel_dict(definitions, defaults):
         values = item[4]
 
         if len(values) > 0:
-            if definition.type_name == "ENUM":
+            if definition.type_name == 'ENUM':
                 definition.choices = values[0]
             elif definition.type_name in ['INT', 'FLOAT', 'HEX']:
                 definition.minimum = convert_value(definition, values[0][0])

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -10,6 +10,7 @@ from textparser import (
     Any,
     AnyUntil,
     DelimitedList,
+    Grammar,
     OneOrMore,
     OneOrMoreDict,
     Optional,
@@ -306,7 +307,7 @@ class DbcParser(Parser):
 
         return tokens
 
-    def grammar(self):
+    def grammar(self) -> Grammar:
         version = Sequence('VERSION', 'STRING')
 
         ns = Sequence('NS_', ':', AnyUntil(Sequence(Any(), ':')))
@@ -407,28 +408,26 @@ class DbcParser(Parser):
         signal_group = Sequence(
             'SIG_GROUP_', 'NUMBER', 'WORD', 'NUMBER', ':', ZeroOrMore('WORD'), ';')
 
-        return OneOrMoreDict(
-            choice(
-                message,
-                comment,
-                attribute_definition,
-                value_table,
-                choice_,
-                attribute,
-                attribute_rel_sg,
-                attribute_rel_bo,
-                attribute_definition_rel,
-                attribute_definition_default,
-                attribute_definition_default_rel,
-                signal_group,
-                signal_type,
-                signal_multiplexer_values,
-                message_add_sender,
-                environment_variable,
-                nodes,
-                ns,
-                bs,
-                version))
+        return Grammar(OneOrMoreDict(choice(message,
+                                            comment,
+                                            attribute_definition,
+                                            value_table,
+                                            choice_,
+                                            attribute,
+                                            attribute_rel_sg,
+                                            attribute_rel_bo,
+                                            attribute_definition_rel,
+                                            attribute_definition_default,
+                                            attribute_definition_default_rel,
+                                            signal_group,
+                                            signal_type,
+                                            signal_multiplexer_values,
+                                            message_add_sender,
+                                            environment_variable,
+                                            nodes,
+                                            ns,
+                                            bs,
+                                            version)))
 
 
 class LongNamesConverter:

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -202,22 +202,6 @@ def to_int(value: typing.Any) -> int:
 def to_float(value: typing.Any) -> float:
     return float(Decimal(value))
 
-def _get_value(definition: AttributeDefinitionType, value: int | float | None) -> str:
-        return '' if definition.minimum is None else f' {value}'
-
-def _get_minimum(definition: AttributeDefinitionType) -> str:
-    return _get_value(definition, definition.minimum)
-
-def _get_maximum(definition: AttributeDefinitionType) -> str:
-    return _get_value(definition, definition.maximum)
-
-def _get_attribute_value(attribute: AttributeType) -> str | int | float:
-        result = attribute.value
-
-        if attribute.definition.type_name == "STRING":
-            result = f'"{attribute.value}"'
-
-        return result
 
 class DbcParser(Parser):
 
@@ -706,7 +690,7 @@ def _dump_attribute_definitions(database: InternalDatabase) -> list[str]:
                 f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name}  {choices};')
         elif definition.type_name in ['INT', 'FLOAT', 'HEX']:
             ba_def.append(
-                f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name}{_get_minimum(definition)}{_get_maximum(definition)};')
+                f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name}{definition.formatted_minimum}{definition.formatted_maximum};')
         elif definition.type_name == 'STRING':
             ba_def.append(
                 f'BA_DEF_ {get_kind(definition)} "{definition.name}" {definition.type_name} ;')
@@ -730,7 +714,7 @@ def _dump_attribute_definitions_rel(database: InternalDatabase) -> list[str]:
                 f'BA_DEF_REL_ {definition.kind}  "{definition.name}" {definition.type_name}  {choices};')
         elif definition.type_name in ['INT', 'FLOAT', 'HEX']:
             ba_def_rel.append(
-                f'BA_DEF_REL_ {definition.kind}  "{definition.name}" {definition.type_name}{_get_minimum(definition)}{_get_maximum(definition)};')
+                f'BA_DEF_REL_ {definition.kind}  "{definition.name}" {definition.type_name}{definition.formatted_minimum}{definition.formatted_maximum};')
         elif definition.type_name == 'STRING':
             ba_def_rel.append(
                 f'BA_DEF_REL_ {definition.kind}  "{definition.name}" {definition.type_name} ;')
@@ -897,25 +881,25 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
     for typ, attribute_to_dump, node_to_dump, message_to_dump, signal_to_dump, envvar_to_dump in attributes:
         if typ == 'dbc':
             ba.append(f'BA_ "{attribute_to_dump.definition.name}" '
-                      f'{_get_attribute_value(attribute_to_dump)};')
+                      f'{attribute_to_dump.formatted_value};')
         elif typ == 'envvar':
             assert envvar_to_dump is not None
             ba.append(f'BA_ "{attribute_to_dump.definition.name}" '
                       f'{attribute_to_dump.definition.kind} '
                       f'{envvar_to_dump.name} '
-                      f'{_get_attribute_value(attribute_to_dump)};')
+                      f'{attribute_to_dump.formatted_value};')
         elif typ == 'node':
             assert node_to_dump is not None
             ba.append(f'BA_ "{attribute_to_dump.definition.name}" '
                       f'{attribute_to_dump.definition.kind} '
                       f'{node_to_dump.name} '
-                      f'{_get_attribute_value(attribute_to_dump)};')
+                      f'{attribute_to_dump.formatted_value};')
         elif typ == 'message':
             assert message_to_dump is not None
             ba.append(f'BA_ "{attribute_to_dump.definition.name}" '
                       f'{attribute_to_dump.definition.kind} '
                       f'{get_dbc_frame_id(message_to_dump)} '
-                      f'{_get_attribute_value(attribute_to_dump)};')
+                      f'{attribute_to_dump.formatted_value};')
         elif typ == 'signal':
             assert signal_to_dump is not None
             assert message_to_dump is not None
@@ -923,7 +907,7 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
                       f'{attribute_to_dump.definition.kind} '
                       f'{get_dbc_frame_id(message_to_dump)} '
                       f'{signal_to_dump.name} '
-                      f'{_get_attribute_value(attribute_to_dump)};')
+                      f'{attribute_to_dump.formatted_value};')
 
     return ba
 
@@ -946,7 +930,7 @@ def _dump_attributes_rel(database: InternalDatabase, sort_signals: type_sort_sig
                                         f'SG_ '
                                         f'{frame_id} '
                                         f'{signal_name} '
-                                        f'{_get_attribute_value(attribute)};')
+                                        f'{attribute.formatted_value};')
         elif "node" in element:
             for node_name, node_dict in element['node'].items():
                 for attribute in node_dict.values():
@@ -954,7 +938,7 @@ def _dump_attributes_rel(database: InternalDatabase, sort_signals: type_sort_sig
                                     f'BU_BO_REL_ '
                                     f'{node_name} '
                                     f'{frame_id} '
-                                    f'{_get_attribute_value(attribute)};')
+                                    f'{attribute.formatted_value};')
 
     return ba_rel
 

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -41,6 +41,7 @@ from ..attribute import Attribute, AttributeType
 from ..attribute_definition import (
     AttributeDefinition,
     AttributeDefinitionType,
+    AttributeValueType,
 )
 from ..bus import Bus
 from ..environment_variable import EnvironmentVariable
@@ -50,9 +51,6 @@ from ..signal import Signal
 from ..signal_group import SignalGroup
 from .dbc_specifics import DbcSpecifics
 from .utils import num
-
-# Attribute value types produced during parsing (before they become Attribute objects)
-AttributeValue = str | int | float
 
 DBC_FMT = (
     'VERSION "{version}"\r\n'
@@ -200,12 +198,12 @@ ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE = AttributeDefinition(
     maximum=100000000000)
 
 
-def to_int(value: AttributeValue) -> int:
+def to_int(value: AttributeValueType) -> int:
     if isinstance(value, str):
         return int(Decimal(value))
     return int(value)
 
-def to_float(value: AttributeValue) -> float:
+def to_float(value: AttributeValueType) -> float:
     if isinstance(value, str):
         return float(Decimal(value))
     return float(value)

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -41,7 +41,7 @@ from ..attribute import Attribute, AttributeType
 from ..attribute_definition import (
     AttributeDefinition,
     AttributeDefinitionType,
-    AttributeValueType,
+    AttributeValue,
 )
 from ..bus import Bus
 from ..environment_variable import EnvironmentVariable
@@ -198,12 +198,12 @@ ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE = AttributeDefinition(
     maximum=100000000000)
 
 
-def to_int(value: AttributeValueType) -> int:
+def to_int(value: AttributeValue) -> int:
     if isinstance(value, str):
         return int(Decimal(value))
     return int(value)
 
-def to_float(value: AttributeValueType) -> float:
+def to_float(value: AttributeValue) -> float:
     if isinstance(value, str):
         return float(Decimal(value))
     return float(value)

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -50,6 +50,9 @@ from ..signal_group import SignalGroup
 from .dbc_specifics import DbcSpecifics
 from .utils import num
 
+# Attribute value types produced during parsing (before they become Attribute objects)
+AttributeValue = str | int | float
+
 DBC_FMT = (
     'VERSION "{version}"\r\n'
     '\r\n'
@@ -196,12 +199,15 @@ ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE = AttributeDefinition(
     maximum=100000000000)
 
 
-def to_int(value: typing.Any) -> int:
-    return int(Decimal(value))
+def to_int(value: AttributeValue) -> int:
+    if isinstance(value, str):
+        return int(Decimal(value))
+    return int(value)
 
-def to_float(value: typing.Any) -> float:
-    return float(Decimal(value))
-
+def to_float(value: AttributeValue) -> float:
+    if isinstance(value, str):
+        return float(Decimal(value))
+    return float(value)
 
 class DbcParser(Parser):
 


### PR DESCRIPTION
this is the "new" first part of the DBC cleanup PR series after I moved renaming `Attribute` to `DbcAttribute` to the end. (A lot of "fun" with merge conflicts was involved.) This PR makes the `_get_{value,minimum,maximum}()` helper functions class members of `AttributeDefinition`, changes `DbcParser.grammar()` return a `Grammar` object and changes all strings in `dbc.py` which use double quotes to single-quote strings for consistency.