### PR TITLE
`plot`: make sure that parsing timestamps keeps working for python >= 3.15

### DIFF
--- a/examples/dbc_io/main.py
+++ b/examples/dbc_io/main.py
@@ -24,8 +24,8 @@ try:
     print("Input cycle time: ", message.cycle_time)
     message.cycle_time = 2000
     print("Output cycle time:", message.cycle_time)
-except KeyError as e:
-    raise e
+except KeyError:
+    raise
 
 # Manipulate the message frame id.
 print("Input frame id: ", hex(message.frame_id))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ lint.extend-select = [
     "W",    # pycodestyle Warning
 ]
 lint.ignore = [
+    "BLE001",  # Do not catch blind exception
     "E501",    # line too long
     "F541",    # f-string-missing-placeholders
     "PLR09",   # too-many-this, too-many-that

--- a/src/cantools/database/can/attribute_definition.py
+++ b/src/cantools/database/can/attribute_definition.py
@@ -14,8 +14,8 @@ class AttributeDefinition(Generic[AttributeValueTypeVar]):
                  default_value: AttributeValueTypeVar | None = None,
                  kind: str | None = None,
                  type_name: str | None = None,
-                 minimum: int | float | None = None,
-                 maximum: int | float | None = None,
+                 minimum: float | None = None,
+                 maximum: float | None = None,
                  choices: list[str] | None = None) -> None:
         self._name = name
         self._default_value: AttributeValueTypeVar | None = default_value
@@ -72,7 +72,7 @@ class AttributeDefinition(Generic[AttributeValueTypeVar]):
         return self._minimum
 
     @minimum.setter
-    def minimum(self, value: int | float | None) -> None:
+    def minimum(self, value: float | None) -> None:
         self._minimum = value
 
     @property
@@ -91,7 +91,7 @@ class AttributeDefinition(Generic[AttributeValueTypeVar]):
         return self._maximum
 
     @maximum.setter
-    def maximum(self, value: int | float | None) -> None:
+    def maximum(self, value: float | None) -> None:
         self._maximum = value
 
     @property

--- a/src/cantools/database/can/c_source.py
+++ b/src/cantools/database/can/c_source.py
@@ -886,7 +886,7 @@ def _format_range(cg_signal: "CodeGenSignal") -> str:
     minimum = cg_signal.signal.minimum
     maximum = cg_signal.signal.maximum
 
-    def phys_to_raw(x: int | float) -> int | float:
+    def phys_to_raw(x: float) -> int | float:
         raw_val = cg_signal.signal.scaled_to_raw(x)
         if cg_signal.signal.is_float:
             return float(raw_val)
@@ -1173,9 +1173,8 @@ def _format_unpack_code_level(cg_message: "CodeGenMessage",
                                        variable_lines,
                                        helper_kinds)
 
-    if body_lines:
-        if body_lines[-1] != '':
-            body_lines.append('')
+    if body_lines and body_lines[-1] != '':
+        body_lines.append('')
 
     if muxes_lines:
         muxes_lines.append('')
@@ -1212,10 +1211,10 @@ def _generate_struct(cg_message: "CodeGenMessage", bit_fields: bool) -> tuple[st
 
     if not members:
         members = [
-            '    /**\n'
+            ('    /**\n'
             '     * Dummy signal in empty message.\n'
             '     */\n'
-            '    uint8_t dummy;'
+            '    uint8_t dummy;')
         ]
 
     if cg_message.message.comment is None:
@@ -1283,17 +1282,13 @@ def _generate_is_in_range(cg_signal: "CodeGenSignal") -> str:
     if maximum is not None:
         maximum = cg_signal.signal.scaled_to_raw(maximum)
 
-    if minimum is None and cg_signal.minimum_can_raw_value is not None:
-        if cg_signal.minimum_ctype_value is None:
-            minimum = cg_signal.minimum_can_raw_value
-        elif cg_signal.minimum_can_raw_value > cg_signal.minimum_ctype_value:
-            minimum = cg_signal.minimum_can_raw_value
+    if (minimum is None and cg_signal.minimum_can_raw_value is not None) and \
+       (cg_signal.minimum_ctype_value is None or cg_signal.minimum_can_raw_value > cg_signal.minimum_ctype_value):
+        minimum = cg_signal.minimum_can_raw_value
 
-    if maximum is None and cg_signal.maximum_can_raw_value is not None:
-        if cg_signal.maximum_ctype_value is None:
-            maximum = cg_signal.maximum_can_raw_value
-        elif cg_signal.maximum_can_raw_value < cg_signal.maximum_ctype_value:
-            maximum = cg_signal.maximum_can_raw_value
+    if (maximum is None and cg_signal.maximum_can_raw_value is not None) and \
+       (cg_signal.maximum_ctype_value is None or cg_signal.maximum_can_raw_value < cg_signal.maximum_ctype_value):
+        maximum = cg_signal.maximum_can_raw_value
 
     suffix = cg_signal.type_suffix
     check = []

--- a/src/cantools/database/can/database.py
+++ b/src/cantools/database/can/database.py
@@ -570,7 +570,7 @@ class Database:
         elif isinstance(frame_id_or_name, str):
             message = self._name_to_message[frame_id_or_name]
         else:
-            raise ValueError(f"Invalid frame_id_or_name '{frame_id_or_name}'")
+            raise ValueError(f"Invalid frame_id_or_name '{frame_id_or_name}'") # noqa: TRY004
 
         return message.encode(data, scaling, padding, strict)
 
@@ -615,7 +615,7 @@ class Database:
         elif isinstance(frame_id_or_name, str):
             message = self._name_to_message[frame_id_or_name]
         else:
-            raise ValueError(f"Invalid frame_id_or_name '{frame_id_or_name}'")
+            raise ValueError(f"Invalid frame_id_or_name '{frame_id_or_name}'") # noqa: TRY004
 
         if message.is_container:
             if decode_containers:

--- a/src/cantools/database/can/environment_variable.py
+++ b/src/cantools/database/can/environment_variable.py
@@ -12,10 +12,10 @@ class EnvironmentVariable:
     def __init__(self,
                  name: str,
                  env_type: int,
-                 minimum: int | float,
-                 maximum: int | float,
+                 minimum: float,
+                 maximum: float,
                  unit: str,
-                 initial_value: int | float,
+                 initial_value: float,
                  env_id: int,
                  access_type: str,
                  access_node: str,
@@ -66,7 +66,7 @@ class EnvironmentVariable:
         return self._minimum
 
     @minimum.setter
-    def minimum(self, value: int | float) -> None:
+    def minimum(self, value: float) -> None:
         self._minimum = value
 
     @property
@@ -78,7 +78,7 @@ class EnvironmentVariable:
         return self._maximum
 
     @maximum.setter
-    def maximum(self, value: int | float) -> None:
+    def maximum(self, value: float) -> None:
         self._maximum = value
 
     @property
@@ -102,7 +102,7 @@ class EnvironmentVariable:
         return self._initial_value
 
     @initial_value.setter
-    def initial_value(self, value: int | float) -> None:
+    def initial_value(self, value: float) -> None:
         self._initial_value = value
 
     @property

--- a/src/cantools/database/can/formats/arxml/ecu_extract_loader.py
+++ b/src/cantools/database/can/formats/arxml/ecu_extract_loader.py
@@ -339,9 +339,8 @@ class EcuExtractLoader:
                 continue
 
             for reference, value in self.iter_reference_values(message):
-                if reference == expected_reference:
-                    if value == com_pdu_id_ref:
-                        return message
+                if reference == expected_reference and value == com_pdu_id_ref:
+                    return message
 
     def iter_parameter_values(self, param_conf_container):
         parameters = param_conf_container.find(PARAMETER_VALUES_XPATH,

--- a/src/cantools/database/can/formats/arxml/system_loader.py
+++ b/src/cantools/database/can/formats/arxml/system_loader.py
@@ -740,11 +740,11 @@ class SystemLoader:
         tx_behavior = \
             self._get_unique_arxml_child(can_frame_triggering,
                                          'CAN-FRAME-TX-BEHAVIOR')
-        if rx_behavior is not None and tx_behavior is not None:
-            if rx_behavior.text != tx_behavior.text:
-                LOGGER.warning(f'Frame "{name}" specifies different receive '
-                               f'and send behavior. This is currently '
-                               f'unsupported by cantools.')
+        if rx_behavior is not None and tx_behavior is not None and \
+           rx_behavior.text != tx_behavior.text:
+            LOGGER.warning(f'Frame "{name}" specifies different receive '
+                           f'and send behavior. This is currently '
+                           f'unsupported by cantools.')
 
         is_fd = \
             (rx_behavior is not None and rx_behavior.text == 'CAN-FD') or \
@@ -1201,9 +1201,7 @@ class SystemLoader:
             is_initial = \
                 self._get_unique_arxml_child(dynalt, 'INITIAL-DYNAMIC-PART')
             is_initial = \
-                True \
-                if is_initial is not None and is_initial.text == 'true' \
-                else False
+                bool(is_initial is not None and is_initial.text == 'true')
             if is_initial:
                 assert selector_signal.raw_initial is None
                 selector_signal.raw_initial = dynalt_selector_value

--- a/src/cantools/database/can/formats/arxml/utils.py
+++ b/src/cantools/database/can/formats/arxml/utils.py
@@ -14,7 +14,7 @@ def parse_number_string(in_string: str, allow_float: bool=False) \
     - Some ARXML editors seem to sometimes include a dot in integer
       numbers (e.g., they produce "123.0" instead of "123")
     """
-    ret: None | int | float = None
+    ret: int | float | None = None
     in_string = in_string.strip().lower()
 
     if len(in_string) > 0:

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -1014,9 +1014,8 @@ def _is_extended_mux_needed(messages: list[Message]) -> bool:
             return True
 
         for signal in message.signals:
-            if signal.multiplexer_ids:
-                if len(signal.multiplexer_ids) > 1:
-                    return True
+            if signal.multiplexer_ids and len(signal.multiplexer_ids) > 1:
+                return True
 
     return False
 
@@ -1565,9 +1564,9 @@ def _load_signals(tokens,
 
     def get_signal_spn(frame_id_dbc, name):
         signal_attributes = get_signal_attributes(frame_id_dbc, name)
-        if 'SPN' in signal_attributes:
-            if (value := signal_attributes['SPN'].value) is not None:
-                return value
+        if 'SPN' in signal_attributes and \
+           (value := signal_attributes['SPN'].value) is not None:
+            return value
 
         if definitions is not None and 'SPN' in definitions:
             return definitions['SPN'].default_value
@@ -1679,9 +1678,8 @@ def _load_messages(tokens,
                 result = send_type_attr.value
                 if send_type_def.choices and result is not None:
                     result = send_type_def.choices[int(result)]
-        if result is None:
-            if (tmp := send_type_def.default_value) is not None:
-                result = str(tmp)
+        if result is None and (tmp := send_type_def.default_value) is not None:
+            result = str(tmp)
 
         return result
 
@@ -1777,13 +1775,12 @@ def _load_messages(tokens,
         multiplexer_signal = None
 
         for signal in message[6]:
-            if len(signal[1]) == 2:
-                if signal[1][1].endswith('M'):
-                    if multiplexer_signal is None:
-                        multiplexer_signal = signal[1][0]
-                    else:
-                        multiplexer_signal = None
-                        break
+            if len(signal[1]) == 2 and signal[1][1].endswith('M'):
+                if multiplexer_signal is None:
+                    multiplexer_signal = signal[1][0]
+                else:
+                    multiplexer_signal = None
+                    break
 
         signals = _load_signals(message[6],
                                 comments,

--- a/src/cantools/database/can/formats/kcd.py
+++ b/src/cantools/database/can/formats/kcd.py
@@ -222,7 +222,7 @@ def _load_message_element(message, bus_name, nodes, strict, sort_signals):
 
     if length == 'auto':
         if signals:
-            last_signal = sorted(signals, key=start_bit)[-1]
+            last_signal = max(signals, key=start_bit)
             length = (start_bit(last_signal) + last_signal.length + 7) // 8
         else:
             length = 0

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -725,7 +725,7 @@ class Message:
     def _get_mux_number(self, decoded: SignalMappingType, signal_name: str) -> int:
         mux = decoded[signal_name]
 
-        if isinstance(mux, str) or isinstance(mux, NamedSignalValue):
+        if isinstance(mux, (str, NamedSignalValue)):
             signal = self.get_signal_by_name(signal_name)
             try:
                 mux = signal.conversion.choice_to_number(str(mux))
@@ -765,19 +765,17 @@ class Message:
                 # skip range check if raw value exists in value table
                 continue
 
-            if signal.minimum is not None:
-                if scaled_value < signal.minimum - abs(signal.conversion.scale)*1e-6:
+            if signal.minimum is not None and scaled_value < signal.minimum - abs(signal.conversion.scale)*1e-6:
                     raise EncodeError(
                         f'Expected signal "{signal.name}" value greater than '
                         f'or equal to {signal.minimum} in message "{self.name}", '
                         f'but got {scaled_value}.')
 
-            if signal.maximum is not None:
-                if scaled_value > signal.maximum + abs(signal.conversion.scale)*1e-6:
-                    raise EncodeError(
-                        f'Expected signal "{signal.name}" value smaller than '
-                        f'or equal to {signal.maximum} in message "{self.name}", '
-                        f'but got {scaled_value}.')
+            if signal.maximum is not None and scaled_value > signal.maximum + abs(signal.conversion.scale)*1e-6:
+                raise EncodeError(
+                    f'Expected signal "{signal.name}" value smaller than '
+                    f'or equal to {signal.maximum} in message "{self.name}", '
+                    f'but got {scaled_value}.')
 
     def _encode(self, node: Codec, data: SignalMappingType, scaling: bool) -> tuple[int, int, list[Signal]]:
         encoded = encode_data(data,

--- a/src/cantools/database/can/signal.py
+++ b/src/cantools/database/can/signal.py
@@ -50,8 +50,8 @@ class Signal:
         length: int,
         byte_order: ByteOrder = "little_endian",
         is_signed: bool = False,
-        raw_initial: int | float | None = None,
-        raw_invalid: int | float | None = None,
+        raw_initial: float | None = None,
+        raw_invalid: float | None = None,
         conversion: BaseConversion | None = None,
         minimum: float | None = None,
         maximum: float | None = None,
@@ -154,7 +154,7 @@ class Signal:
             self.comments = comment
 
     def raw_to_scaled(
-        self, raw_value: int | float, decode_choices: bool = True
+        self, raw_value: float, decode_choices: bool = True
     ) -> SignalValueType:
         """Convert an internal raw value according to the defined scaling or value table.
 
@@ -184,7 +184,7 @@ class Signal:
         return self.conversion.scale
 
     @scale.setter
-    def scale(self, value: int | float) -> None:
+    def scale(self, value: float) -> None:
         self.conversion = self.conversion.factory(
             scale=value,
             offset=self.conversion.offset,
@@ -198,7 +198,7 @@ class Signal:
         return self.conversion.offset
 
     @offset.setter
-    def offset(self, value: int | float) -> None:
+    def offset(self, value: float) -> None:
         self.conversion = self.conversion.factory(
             scale=self.conversion.scale,
             offset=value,

--- a/src/cantools/database/conversion.py
+++ b/src/cantools/database/conversion.py
@@ -245,7 +245,7 @@ class NamedSignalConversion(BaseConversion):
         raw_value: float,
         decode_choices: bool = True,
     ) -> SignalValueType:
-        if decode_choices and (choice := self.choices.get(raw_value)) is not None:  # type: ignore[arg-type]
+        if decode_choices and (choice := self.choices.get(int(raw_value))) is not None:
             return choice
         return self._conversion.raw_to_scaled(raw_value, False)
 

--- a/src/cantools/database/conversion.py
+++ b/src/cantools/database/conversion.py
@@ -67,7 +67,7 @@ class BaseConversion(ABC):
     @abstractmethod
     def raw_to_scaled(
         self,
-        raw_value: int | float,
+        raw_value: float,
         decode_choices: bool = True,
     ) -> SignalValueType:
         """Convert an internal raw value according to the defined scaling or value table.
@@ -95,7 +95,7 @@ class BaseConversion(ABC):
 
     @abstractmethod
     def numeric_scaled_to_raw(
-        self, scaled_value: int | float
+        self, scaled_value: float
     ) -> int | float:
         """Convert a numeric scaled value to the internal raw value.
 
@@ -124,7 +124,7 @@ class IdentityConversion(BaseConversion):
 
     def raw_to_scaled(
         self,
-        raw_value: int | float,
+        raw_value: float,
         decode_choices: bool = True,
     ) -> int | float:
         return raw_value
@@ -137,7 +137,7 @@ class IdentityConversion(BaseConversion):
         return self.numeric_scaled_to_raw(scaled_value)
 
     def numeric_scaled_to_raw(
-        self, scaled_value: int | float
+        self, scaled_value: float
     ) -> int | float:
         return scaled_value if self.is_float else round(scaled_value)
 
@@ -155,7 +155,7 @@ class LinearIntegerConversion(BaseConversion):
 
     def raw_to_scaled(
         self,
-        raw_value: int | float,
+        raw_value: float,
         decode_choices: bool = True,
     ) -> SignalValueType:
         return raw_value * self.scale + self.offset
@@ -168,7 +168,7 @@ class LinearIntegerConversion(BaseConversion):
         return self.numeric_scaled_to_raw(scaled_value)
 
     def numeric_scaled_to_raw(
-        self, scaled_value: int | float
+        self, scaled_value: float
     ) -> int | float:
         # try to avoid a loss of precision whenever possible
         _raw = scaled_value - self.offset
@@ -193,7 +193,7 @@ class LinearConversion(BaseConversion):
 
     def raw_to_scaled(
         self,
-        raw_value: int | float,
+        raw_value: float,
         decode_choices: bool = True,
     ) -> SignalValueType:
         return raw_value * self.scale + self.offset
@@ -206,7 +206,7 @@ class LinearConversion(BaseConversion):
         return self.numeric_scaled_to_raw(scaled_value)
 
     def numeric_scaled_to_raw(
-        self, scaled_value: int | float
+        self, scaled_value: float
     ) -> int | float:
         _raw = (scaled_value - self.offset) / self.scale
         return _raw if self.is_float else round(_raw)
@@ -242,7 +242,7 @@ class NamedSignalConversion(BaseConversion):
 
     def raw_to_scaled(
         self,
-        raw_value: int | float,
+        raw_value: float,
         decode_choices: bool = True,
     ) -> SignalValueType:
         if decode_choices and (choice := self.choices.get(raw_value)) is not None:  # type: ignore[arg-type]
@@ -263,7 +263,7 @@ class NamedSignalConversion(BaseConversion):
         raise TypeError
 
     def numeric_scaled_to_raw(
-        self, scaled_value: int | float
+        self, scaled_value: float
     ) -> int | float:
         return self._conversion.scaled_to_raw(scaled_value)
 
@@ -292,7 +292,7 @@ class NamedSignalConversion(BaseConversion):
         )
 
 
-def _is_integer(value: int | float) -> bool:
+def _is_integer(value: float) -> bool:
     if isinstance(value, int) or (hasattr(value, "is_integer") and value.is_integer()):
         return True
     elif isinstance(value, float):

--- a/src/cantools/database/diagnostics/data.py
+++ b/src/cantools/database/diagnostics/data.py
@@ -50,7 +50,7 @@ class Data:
         self.is_signed: bool = False
 
     def raw_to_scaled(
-        self, raw_value: int | float, decode_choices: bool = True
+        self, raw_value: float, decode_choices: bool = True
     ) -> SignalValueType:
         """Convert an internal raw value according to the defined scaling or value table.
 
@@ -87,7 +87,7 @@ class Data:
         return self.conversion.scale
 
     @scale.setter
-    def scale(self, value: int | float) -> None:
+    def scale(self, value: float) -> None:
         self.conversion = self.conversion.factory(
             scale=value,
             offset=self.conversion.offset,
@@ -101,7 +101,7 @@ class Data:
         return self.conversion.offset
 
     @offset.setter
-    def offset(self, value: int | float) -> None:
+    def offset(self, value: float) -> None:
         self.conversion = self.conversion.factory(
             scale=self.conversion.scale,
             offset=value,

--- a/src/cantools/database/namedsignalvalue.py
+++ b/src/cantools/database/namedsignalvalue.py
@@ -1,4 +1,3 @@
-from typing import Any
 
 
 class NamedSignalValue:
@@ -49,7 +48,7 @@ class NamedSignalValue:
     def __repr__(self) -> str:
         return f"'{self.name}'"
 
-    def __eq__(self, x: Any) -> bool:
+    def __eq__(self, x: object) -> bool:
         if isinstance(x, NamedSignalValue):
             return (
                 x.value == self.value

--- a/src/cantools/logreader.py
+++ b/src/cantools/logreader.py
@@ -49,7 +49,7 @@ class DataFrame:
         self.timestamp_format = timestamp_format
 
     def __repr__(self) -> str:
-        attrs = ', '.join(f'{a} = {getattr(self, a)!r}' for a in self.__dict__.keys())
+        attrs = ', '.join(f'{a} = {getattr(self, a)!r}' for a in self.__dict__)
         return f'{type(self).__name__}({attrs})'
 
 
@@ -171,7 +171,7 @@ class CandumpAbsoluteLogPattern(CandumpBasePattern):
         r'^\s*?\((?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\)\s+(?P<channel>\S+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|[0-9A-F ]*).*?$')
 
     def parse_timestamp(self, match_object: re.Match[str]) -> tuple[TimestampType, TimestampFormat]:
-        timestamp = datetime.datetime.strptime(match_object.group('timestamp'), "%Y-%m-%d %H:%M:%S.%f")
+        timestamp = datetime.datetime.strptime(match_object.group('timestamp'), "%Y-%m-%d %H:%M:%S.%f")  # noqa: DTZ007
         timestamp_format = TimestampFormat.ABSOLUTE
         return timestamp, timestamp_format
 

--- a/src/cantools/subparsers/__utils__.py
+++ b/src/cantools/subparsers/__utils__.py
@@ -30,8 +30,7 @@ def format_signals(message, decoded_signals):
         signal_name = signal.name
 
         if signal.unit is None or \
-           isinstance(value, NamedSignalValue) or \
-           isinstance(value, str):
+           isinstance(value, (NamedSignalValue, str)):
 
             formatted_signal = f'{signal_name}: {value}'
 

--- a/src/cantools/subparsers/dump/formatting.py
+++ b/src/cantools/subparsers/dump/formatting.py
@@ -221,9 +221,7 @@ def layout_string(message, signal_names=True):
             for i in range(0, 24, 3):
                 byte_triple = byte_line[i:i + 3]
 
-                if i == 0:
-                    line += '|'
-                elif byte_triple[0] in ' <>x':
+                if i == 0 or byte_triple[0] in ' <>x':
                     line += '|'
                 elif byte_triple[0] == 'X':
                     if prev_byte == 'X':

--- a/src/cantools/subparsers/list.py
+++ b/src/cantools/subparsers/list.py
@@ -9,7 +9,7 @@ from ..database.namedsignalvalue import NamedSignalValue
 from .dump.formatting import signal_tree_string
 
 
-def _format_val(val: float | int | str | NamedSignalValue | None,
+def _format_val(val: float | str | NamedSignalValue | None,
                 unit: str,
                 value_format_specifier: str) \
         -> str:

--- a/src/cantools/subparsers/monitor.py
+++ b/src/cantools/subparsers/monitor.py
@@ -97,11 +97,7 @@ class Monitor(can.Listener):
         self.draw_stats(0)
         self.draw_title(1)
 
-        lines = []
-
-        for name in self._filtered_sorted_message_names:
-            for line in self._formatted_messages[name]:
-                lines.append(line)
+        lines = [line for name in self._filtered_sorted_message_names for line in self._formatted_messages[name]]
 
         # Only render the visible screen. We only have (self._nrows - 3)
         # available rows to draw on, due to the persistent TUI features that

--- a/src/cantools/subparsers/plot.py
+++ b/src/cantools/subparsers/plot.py
@@ -226,7 +226,16 @@ class TimestampParser:
         ]:
             for p in patterns:
                 try:
-                    out = datetime.datetime.strptime(user_input, p)
+                    # HACK: ensure that an absolute year is specified
+                    # to make it work with python >= 3.15 (and get
+                    # around the deprecation warning for earlier
+                    # versions). We use 1904 because it is a leap year
+                    # and because it should be clear that this is not
+                    # the real year of the specified date.
+                    if '%Y' not in p and '%d' in p:
+                        out = datetime.datetime.strptime('1904 ' + user_input, '%Y ' + p)
+                    else:
+                        out = datetime.datetime.strptime(user_input, p)
                 except ValueError:
                     pass
                 else:

--- a/src/cantools/subparsers/plot.py
+++ b/src/cantools/subparsers/plot.py
@@ -233,9 +233,9 @@ class TimestampParser:
                     # and because it should be clear that this is not
                     # the real year of the specified date.
                     if '%Y' not in p and '%d' in p:
-                        out = datetime.datetime.strptime('1904 ' + user_input, '%Y ' + p)
+                        out = datetime.datetime.strptime('1904 ' + user_input, '%Y ' + p)  # noqa: DTZ007
                     else:
-                        out = datetime.datetime.strptime(user_input, p)
+                        out = datetime.datetime.strptime(user_input, p)  # noqa: DTZ007
                 except ValueError:
                     pass
                 else:
@@ -291,11 +291,11 @@ class TimestampParser:
             return linenumber
 
     def parse_absolute_timestamp(self, timestamp):
-        return datetime.datetime.strptime(timestamp, self.FORMAT_ABSOLUTE_TIMESTAMP)
+        return datetime.datetime.strptime(timestamp, self.FORMAT_ABSOLUTE_TIMESTAMP)  # noqa: DTZ007
 
     @staticmethod
     def parse_absolute_seconds(timestamp):
-        return datetime.datetime.fromtimestamp(float(timestamp))
+        return datetime.datetime.fromtimestamp(float(timestamp))  # noqa: DTZ006
 
     @staticmethod
     def parse_seconds(timestamp):
@@ -751,12 +751,9 @@ class Signals:
             # if the user bothers to type out the same regex twice
             # it is probably intended to be plotted twice
             return True
-        if '.' not in current_signal.reo.pattern:
-            # if the user bothers to type out a complete signal name without wildcards
-            # he/she probably means to plot this signal even if it has been plotted already
-            return True
-
-        return False
+        # if the user bothers to type out a complete signal name without wildcards
+        # he/she probably means to plot this signal even if it has been plotted already
+        return '.' not in current_signal.reo.pattern
 
     def get_signal_unit(self, signal_name):
         msg, signal = re.split(self.SEP_SG, signal_name)

--- a/src/cantools/tester.py
+++ b/src/cantools/tester.py
@@ -25,9 +25,8 @@ class DecodedMessage:
 
 class Messages(UserDict):
     def __setitem__(self, message_name, value):
-        if getattr(self, '_frozen', False):
-            if message_name not in self.data:
-                raise KeyError(message_name)
+        if getattr(self, '_frozen', False) and message_name not in self.data:
+            raise KeyError(message_name)
         self.data[message_name] = value
 
     def __missing__(self, key):
@@ -230,9 +229,8 @@ class Message(UserDict):
                     return
 
     def _filter_expected_message(self, message, signals):
-        if message.name == self.database.name:
-            if all(message.signals[name] == signals[name] for name in signals):
-                return message.signals
+        if message.name == self.database.name and all(message.signals[name] == signals[name] for name in signals):
+            return message.signals
 
     def send_periodic_start(self):
         if not self.enabled:

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -110,12 +110,10 @@ IO_DEBUG(
 
         stdout = StringIO()
 
-        with patch('sys.stdin', StringIO(input_data)):
-            with patch('sys.stdout', stdout):
-                with patch('sys.argv', argv):
-                    cantools._main()
-                    actual_output = stdout.getvalue()
-                    self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdin', StringIO(input_data)), patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_decode_timestamp_absolute(self):
         argv = [
@@ -154,12 +152,10 @@ IO_DEBUG(
 
         stdout = StringIO()
 
-        with patch('sys.stdin', StringIO(input_data)):
-            with patch('sys.stdout', stdout):
-                with patch('sys.argv', argv):
-                    cantools._main()
-                    actual_output = stdout.getvalue()
-                    self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdin', StringIO(input_data)), patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_decode_timestamp_zero(self):
         argv = [
@@ -198,12 +194,10 @@ IO_DEBUG(
 
         stdout = StringIO()
 
-        with patch('sys.stdin', StringIO(input_data)):
-            with patch('sys.stdout', stdout):
-                with patch('sys.argv', argv):
-                    cantools._main()
-                    actual_output = stdout.getvalue()
-                    self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdin', StringIO(input_data)), patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_decode_can_fd(self):
         argv = ['cantools', 'decode', 'tests/files/dbc/foobar.dbc']
@@ -221,12 +215,10 @@ CanFd(
 
         stdout = StringIO()
 
-        with patch('sys.stdin', StringIO(input_data)):
-            with patch('sys.stdout', stdout):
-                with patch('sys.argv', argv):
-                    cantools._main()
-                    actual_output = stdout.getvalue()
-                    self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdin', StringIO(input_data)), patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_decode_log_format(self):
         argv = [
@@ -289,12 +281,10 @@ IO_DEBUG(
 
         stdout = StringIO()
 
-        with patch('sys.stdin', StringIO(input_data)):
-            with patch('sys.stdout', stdout):
-                with patch('sys.argv', argv):
-                    cantools._main()
-                    actual_output = stdout.getvalue()
-                    self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdin', StringIO(input_data)), patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_single_line_decode(self):
         argv = [
@@ -325,12 +315,10 @@ IO_DEBUG(
 
         stdout = StringIO()
 
-        with patch('sys.stdin', StringIO(input_data)):
-            with patch('sys.stdout', stdout):
-                with patch('sys.argv', argv):
-                    cantools._main()
-                    actual_output = stdout.getvalue()
-                    self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdin', StringIO(input_data)), patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_single_line_decode_log_format(self):
         argv = [
@@ -361,12 +349,10 @@ IO_DEBUG(
 
         stdout = StringIO()
 
-        with patch('sys.stdin', StringIO(input_data)):
-            with patch('sys.stdout', stdout):
-                with patch('sys.argv', argv):
-                    cantools._main()
-                    actual_output = stdout.getvalue()
-                    self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdin', StringIO(input_data)), patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_decode_muxed_data(self):
         argv = [
@@ -635,12 +621,10 @@ BATTERY_VT(
 
         stdout = StringIO()
 
-        with patch('sys.stdin', StringIO(input_data)):
-            with patch('sys.stdout', stdout):
-                with patch('sys.argv', argv):
-                    cantools._main()
-                    actual_output = stdout.getvalue()
-                    self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdin', StringIO(input_data)), patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_decode_single_line_muxed_data(self):
         argv = [
@@ -730,12 +714,10 @@ BATTERY_VT(
 
         stdout = StringIO()
 
-        with patch('sys.stdin', StringIO(input_data)):
-            with patch('sys.stdout', stdout):
-                with patch('sys.argv', argv):
-                    cantools._main()
-                    actual_output = stdout.getvalue()
-                    self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdin', StringIO(input_data)), patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_dump(self):
         argv = [
@@ -800,11 +782,10 @@ BATTERY_VT(
 
         stdout = StringIO()
 
-        with patch('sys.stdout', stdout):
-            with patch('sys.argv', argv):
-                cantools._main()
-                actual_output = stdout.getvalue()
-                self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     @with_fake_screen_width(screen_width=80)
     def test_dump_with_comments(self):
@@ -873,11 +854,10 @@ BATTERY_VT(
 
         stdout = StringIO()
 
-        with patch('sys.stdout', stdout):
-            with patch('sys.argv', argv):
-                cantools._main()
-                actual_output = stdout.getvalue()
-                self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     @with_fake_screen_width(screen_width=80)
     def test_dump_with_comments_mux(self):
@@ -974,11 +954,10 @@ BATTERY_VT(
 
         stdout = StringIO()
 
-        with patch('sys.stdout', stdout):
-            with patch('sys.argv', argv):
-                cantools._main()
-                actual_output = stdout.getvalue()
-                self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_dump_no_sender(self):
         argv = [
@@ -1019,11 +998,10 @@ BATTERY_VT(
 
         stdout = StringIO()
 
-        with patch('sys.stdout', stdout):
-            with patch('sys.argv', argv):
-                cantools._main()
-                actual_output = stdout.getvalue()
-                self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_dump_signal_choices(self):
         argv = [
@@ -1098,11 +1076,10 @@ BATTERY_VT(
 
         stdout = StringIO()
 
-        with patch('sys.stdout', stdout):
-            with patch('sys.argv', argv):
-                cantools._main()
-                actual_output = stdout.getvalue()
-                self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_dump_j1939(self):
         argv = [
@@ -1203,11 +1180,10 @@ BATTERY_VT(
 
         stdout = StringIO()
 
-        with patch('sys.stdout', stdout):
-            with patch('sys.argv', argv):
-                cantools._main()
-                actual_output = stdout.getvalue()
-                self.assertEqual(actual_output, expected_output)
+        with patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
     def test_convert(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1251,13 +1227,12 @@ BATTERY_VT(
             'test_command_line_convert.foo'
         ]
 
-        with patch('sys.argv', argv):
-            with self.assertRaises(SystemExit) as cm:
-                cantools._main()
+        with patch('sys.argv', argv), self.assertRaises(SystemExit) as cm:
+            cantools._main()
 
             self.assertEqual(
-                str(cm.exception),
-                "error: Unsupported output database format 'foo'.")
+            str(cm.exception),
+            "error: Unsupported output database format 'foo'.")
 
     def test_generate_c_source(self):
         databases = [

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -40,14 +40,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
         if have.keys() != expect.keys():
             raise AssertionError(f'keys differ: {have} != {expect}')
 
-        for key in have.keys():
+        for key in have:
             self.assertEqual(str(have[key]), str(expect[key]))
 
     def assertEqualChoicesDict(self, have, expect):
         if have.keys() != expect.keys():
             raise AssertionError(f'keys differ: {have.keys()} != {expect.keys()}')
 
-        for key in have.keys():
+        for key in have:
             self.assertEqualChoicesDictHelper_(have[key], expect[key])
 
     def assert_dbc_dump(self, db, filename):
@@ -322,14 +322,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
             (
                 'CanFd',
                 {'Fie': 0x123456789abcdef, 'Fas': 0xdeadbeefdeadbeef},
-                b'\xef\xcd\xab\x89\x67\x45\x23\x01'
+                (b'\xef\xcd\xab\x89\x67\x45\x23\x01'
                 b'\xef\xbe\xad\xde\xef\xbe\xad\xde'
                 b'\x00\x00\x00\x00\x00\x00\x00\x00'
                 b'\x00\x00\x00\x00\x00\x00\x00\x00'
                 b'\x00\x00\x00\x00\x00\x00\x00\x00'
                 b'\x00\x00\x00\x00\x00\x00\x00\x00'
                 b'\x00\x00\x00\x00\x00\x00\x00\x00'
-                b'\x00\x00\x00\x00\x00\x00\x00\x00'
+                b'\x00\x00\x00\x00\x00\x00\x00\x00')
             )
         ]
 
@@ -362,14 +362,14 @@ class CanToolsDatabaseTest(unittest.TestCase):
             (
                 0x12333,
                 {'Fie': 0x123456789abcdef, 'Fas': 0xdeadbeefdeadbeef},
-                b'\xef\xcd\xab\x89\x67\x45\x23\x01'
+                (b'\xef\xcd\xab\x89\x67\x45\x23\x01'
                 b'\xef\xbe\xad\xde\xef\xbe\xad\xde'
                 b'\x00\x00\x00\x00\x00\x00\x00\x00'
                 b'\x00\x00\x00\x00\x00\x00\x00\x00'
                 b'\x00\x00\x00\x00\x00\x00\x00\x00'
                 b'\x00\x00\x00\x00\x00\x00\x00\x00'
                 b'\x00\x00\x00\x00\x00\x00\x00\x00'
-                b'\x00\x00\x00\x00\x00\x00\x00\x00'
+                b'\x00\x00\x00\x00\x00\x00\x00\x00')
             )
         ]
 
@@ -790,38 +790,38 @@ class CanToolsDatabaseTest(unittest.TestCase):
             (
                 'Message1',
                 0,
-                'Expected signal "Signal1" value greater than or equal to 1 in '
-                'message "Message1", but got 0.'
+                ('Expected signal "Signal1" value greater than or equal to 1 in '
+                'message "Message1", but got 0.')
             ),
             (
                 'Message1',
                 3,
-                'Expected signal "Signal1" value smaller than or equal to 2 in '
-                'message "Message1", but got 3.'
+                ('Expected signal "Signal1" value smaller than or equal to 2 in '
+                'message "Message1", but got 3.')
             ),
             (
                 'Message2',
                 0,
-                'Expected signal "Signal1" value greater than or equal to 1 in '
-                'message "Message2", but got 0.'
+                ('Expected signal "Signal1" value greater than or equal to 1 in '
+                'message "Message2", but got 0.')
             ),
             (
                 'Message3',
                 3,
-                'Expected signal "Signal1" value smaller than or equal to 2 in '
-                'message "Message3", but got 3.'
+                ('Expected signal "Signal1" value smaller than or equal to 2 in '
+                'message "Message3", but got 3.')
             ),
             (
                 'Message4',
                 1.9,
-                'Expected signal "Signal1" value greater than or equal to 2 in '
-                'message "Message4", but got 1.9.'
+                ('Expected signal "Signal1" value greater than or equal to 2 in '
+                'message "Message4", but got 1.9.')
             ),
             (
                 'Message4',
                 8.1,
-                'Expected signal "Signal1" value smaller than or equal to 8 in '
-                'message "Message4", but got 8.1.'
+                ('Expected signal "Signal1" value smaller than or equal to 8 in '
+                'message "Message4", but got 8.1.')
             )
         ]
 
@@ -6037,9 +6037,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_relation_attributes(self):
         filename = 'tests/files/dbc/attributes_relation.dbc'
         db = cantools.database.load_file(filename)
-        for _key, frame in db.dbc.attributes_rel.items():
+        for frame in db.dbc.attributes_rel.values():
             signal = frame.get("signal")
-            if "signal_1" in signal.keys():
+            if "signal_1" in signal:
                 rel_attributes = signal["signal_1"]["node"]["ECU2"]
                 first_timeout_attr = rel_attributes["SigFirstTimeoutTime"]
                 timeout_attr = rel_attributes["SigTimeoutTime"]
@@ -6051,7 +6051,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_relation_message_attributes(self):
         filename = 'tests/files/dbc/BU_BO_REL_Message.dbc'
         db = cantools.database.load_file(filename)
-        for _key, frame in db.dbc.attributes_rel.items():
+        for frame in db.dbc.attributes_rel.values():
             node = frame.get("node")
             rel_attributes = node["ECU1"]
             msg_attr = rel_attributes["MsgProject"]

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -72,7 +72,7 @@ class CanToolsMonitorTest(unittest.TestCase):
     def assert_called(self, mock, expected, verbose=False):
         try:
             self.assertEqual(mock.call_args_list, expected)
-        except AssertionError as e:
+        except AssertionError:
             if verbose:
                 nl = ",\n "
                 print(f"Assertion failed:")
@@ -80,7 +80,7 @@ class CanToolsMonitorTest(unittest.TestCase):
                 print(f"Got: {nl.join(str(x) for x in mock.call_args_list)}")
                 print("Traceback:")
                 traceback.print_stack()
-            raise e
+            raise
 
     @patch('can.Notifier')
     @patch('can.cli.create_bus_from_namespace')

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -68,7 +68,7 @@ class SubplotMock(mock.Mock):
                 self.__kw[key] = False
 
         if kw:
-            raise TypeError("{}() got unexpected keyword argument(s): {}".format(type(self).__name__, ', '.join(key for key in kw.keys())))
+            raise TypeError("{}() got unexpected keyword argument(s): {}".format(type(self).__name__, ', '.join(key for key in kw)))
 
         if parent:
             parent.attach_mock(self, 'subplot()')
@@ -164,11 +164,9 @@ class CanToolsPlotTest(unittest.TestCase):
             mock.call.show(),
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with PyplotMock() as plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
 
 
     def test_plot_ta(self):
@@ -186,7 +184,7 @@ class CanToolsPlotTest(unittest.TestCase):
 """
 
         xs = [x+1608822980 for x in (.872678, .873316, .873745, .874138, .874524, .874921, .875305, .875685, .876130)]
-        xs = [datetime.datetime.fromtimestamp(x) for x in xs]
+        xs = [datetime.datetime.fromtimestamp(x) for x in xs]  # noqa: DTZ006
         ys_fl = [20.328125, 22.109375, 21.671875, 20.78125,  20.390625, 18.109375, 14.4375,   10.609375, 3.78125 ]
         ys_fr = [20.21875,  22.328125, 22.21875,  21.21875,  20.390625, 18.0,      14.4375,   10.9375,   3.671875]
         ys_rl = [20.4375,   22.328125, 21.671875, 21.21875,  20.71875,  18.0,      14.328125, 10.5,      3.671875]
@@ -202,11 +200,9 @@ class CanToolsPlotTest(unittest.TestCase):
             mock.call.show(),
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with PyplotMock() as plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
 
 
     def test_plot_tz(self):
@@ -245,13 +241,11 @@ class CanToolsPlotTest(unittest.TestCase):
             mock.call.set_xlabel(self.XLABEL_tz),
         ]]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
-                    for i in range(len(expected_subplot_calls)):
-                        self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
 
     def test_plot_td(self):
@@ -285,11 +279,9 @@ class CanToolsPlotTest(unittest.TestCase):
             mock.call.show(),
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with PyplotMock() as plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
 
 
     def test_plot_l(self):
@@ -318,11 +310,9 @@ class CanToolsPlotTest(unittest.TestCase):
             mock.call.show(),
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with PyplotMock() as plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
 
 
     def test_plot_no_timestamps(self):
@@ -351,11 +341,9 @@ class CanToolsPlotTest(unittest.TestCase):
             mock.call.show(),
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with PyplotMock() as plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
 
     def test_plot_cantools_decode(self):
         argv = ['cantools', 'plot', self.DBC_FILE]
@@ -403,13 +391,10 @@ BREMSE_33(
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock() as plt:
-                        cantools._main()
-                        self.assertEqual(stdout.getvalue(), expected_output)
-                        self.assertListEqual(plt.mock_calls, expected_calls)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertEqual(stdout.getvalue(), expected_output)
+            self.assertListEqual(plt.mock_calls, expected_calls)
 
 
     # ------- test different file formats -------
@@ -440,11 +425,9 @@ BREMSE_33(
             mock.call.show(),
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with PyplotMock() as plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
 
 
     # ------- test signal command line argument(s) -------
@@ -484,13 +467,11 @@ BREMSE_33(
             ],
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
-                    for i in range(len(expected_subplot_calls)):
-                        self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_subplots(self):
         argv = ['cantools', 'plot', self.DBC_FILE, '--', 'BREMSE_33.*', '-', '--no-units', 'BREMSE_2.*']
@@ -543,13 +524,11 @@ BREMSE_33(
             ],
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
-                    for i in range(len(expected_subplot_calls)):
-                        self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_two_axes_with_auto_ylabels_and_one_legend(self):
         argv = ['cantools', 'plot', '--no-units', self.DBC_FILE, '*_33.*fl*:b', ',', '*_2.*fl*:r']
@@ -593,13 +572,11 @@ BREMSE_33(
             ],
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
-                    for i in range(len(expected_subplot_calls)):
-                        self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_color(self):
         argv = ['cantools', 'plot', self.DBC_FILE, '--', '--color', 'C0', '--ylabel', 'Bremse 33', '*_33.*fl*', ',', '--color', 'C1', '--ylabel', 'Bremse 2', '*_2.*fl*']
@@ -648,13 +625,11 @@ BREMSE_33(
             ],
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
-                    for i in range(len(expected_subplot_calls)):
-                        self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_autocolor(self):
         self.maxDiff = None
@@ -724,13 +699,11 @@ BREMSE_33(
             ],
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
-                    for i in range(len(expected_subplot_calls)):
-                        self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_format(self):
         col_33 = "b"
@@ -788,13 +761,11 @@ BREMSE_33(
             ],
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
-                    for i in range(len(expected_subplot_calls)):
-                        self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_choices_stem(self):
         argv = ['cantools', 'plot', '--no-units', self.DBC_FILE_CHOICES, 'Foo:|']
@@ -832,13 +803,11 @@ BREMSE_33(
             ],
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
-                    for i in range(len(expected_subplot_calls)):
-                        self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_no_decode_choices(self):
         argv = ['cantools', 'plot', '--no-decode-choices', self.DBC_FILE_CHOICES, 'Foo:|']
@@ -872,13 +841,11 @@ BREMSE_33(
             ],
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
-                    for i in range(len(expected_subplot_calls)):
-                        self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_case_sensitive(self):
         argv = ['cantools', 'plot', '--case-sensitive', self.DBC_FILE, '*fl*']
@@ -905,18 +872,15 @@ BREMSE_33(
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
 
-                        actual_output = stdout.getvalue()
-                        self.assertEqual(actual_output, expected_output)
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
 
     # ------- test error handling -------
@@ -937,11 +901,11 @@ invalid syntax
  (2020-12-29 11:33:28.295229)  vcan0  0000024A   [8]  CC 05 CC 05 E9 05 DB 05
 '''
         xs33 = [
-            datetime.datetime(2020, 12, 29, 11, 33, 24, 285921),
-            datetime.datetime(2020, 12, 29, 11, 33, 25, 288070),
-            datetime.datetime(2020, 12, 29, 11, 33, 26, 290617),
-            datetime.datetime(2020, 12, 29, 11, 33, 27, 292325),
-            datetime.datetime(2020, 12, 29, 11, 33, 28, 294690),
+            datetime.datetime(2020, 12, 29, 11, 33, 24, 285921),  # noqa: DTZ001
+            datetime.datetime(2020, 12, 29, 11, 33, 25, 288070),  # noqa: DTZ001
+            datetime.datetime(2020, 12, 29, 11, 33, 26, 290617),  # noqa: DTZ001
+            datetime.datetime(2020, 12, 29, 11, 33, 27, 292325),  # noqa: DTZ001
+            datetime.datetime(2020, 12, 29, 11, 33, 28, 294690),  # noqa: DTZ001
         ]
         xs33_ln = [1,4,6,8,11]
         whlspeed_fl_bremse2 = [20.421875, 20.578125, 20.78125, 22.078125, 23.1875]
@@ -983,18 +947,15 @@ Failed to parse line: 'invalid syntax'
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(data.input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
+        with mock.patch('sys.stdin', StringIO(data.input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
 
-                        actual_output = stdout.getvalue()
-                        self.assertLinesMatch(actual_output, expected_output)
+            actual_output = stdout.getvalue()
+            self.assertLinesMatch(actual_output, expected_output)
 
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
 
     # --ignore-*
@@ -1027,18 +988,15 @@ Failed to parse data of frame id 586 (0x24a): ...
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(data.input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
+        with mock.patch('sys.stdin', StringIO(data.input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
 
-                        actual_output = stdout.getvalue()
-                        self.assertLinesMatch(actual_output, expected_output)
+            actual_output = stdout.getvalue()
+            self.assertLinesMatch(actual_output, expected_output)
 
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_ignore_unknown_frameid(self):
         argv = ['cantools', 'plot', '--ignore-unknown-frames', self.DBC_FILE, '*33.*']
@@ -1068,18 +1026,15 @@ Failed to parse line: 'invalid syntax'
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(data.input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
+        with mock.patch('sys.stdin', StringIO(data.input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
 
-                        actual_output = stdout.getvalue()
-                        self.assertLinesMatch(actual_output, expected_output)
+            actual_output = stdout.getvalue()
+            self.assertLinesMatch(actual_output, expected_output)
 
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_ignore_invalid_data(self):
         argv = ['cantools', 'plot', '--ignore-invalid-data', self.DBC_FILE, '*33.*']
@@ -1110,18 +1065,15 @@ Failed to parse line: 'invalid syntax'
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(data.input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
+        with mock.patch('sys.stdin', StringIO(data.input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
 
-                        actual_output = stdout.getvalue()
-                        self.assertLinesMatch(actual_output, expected_output)
+            actual_output = stdout.getvalue()
+            self.assertLinesMatch(actual_output, expected_output)
 
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_quiet(self):
         argv = ['cantools', 'plot', '-q', self.DBC_FILE, '*33.*']
@@ -1148,18 +1100,15 @@ Failed to parse line: 'invalid syntax'
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(data.input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
+        with mock.patch('sys.stdin', StringIO(data.input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
 
-                        actual_output = stdout.getvalue()
-                        self.assertEqual(actual_output, expected_output)
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
 
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
 
     # --show-*
@@ -1197,18 +1146,15 @@ Failed to parse line: 'invalid syntax'
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(data.input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
+        with mock.patch('sys.stdin', StringIO(data.input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
 
-                        actual_output = stdout.getvalue()
-                        self.assertLinesMatch(actual_output, expected_output)
+            actual_output = stdout.getvalue()
+            self.assertLinesMatch(actual_output, expected_output)
 
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_show_unknown_frames(self):
         argv = ['cantools', 'plot', '--show-unknown-frames', self.DBC_FILE, '*33.*']
@@ -1245,18 +1191,15 @@ Failed to parse line: 'invalid syntax'
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(data.input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
+        with mock.patch('sys.stdin', StringIO(data.input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
 
-                        actual_output = stdout.getvalue()
-                        self.assertLinesMatch(actual_output, expected_output)
+            actual_output = stdout.getvalue()
+            self.assertLinesMatch(actual_output, expected_output)
 
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_show_invalid_syntax(self):
         argv = ['cantools', 'plot', '--show-invalid-syntax', self.DBC_FILE, '*33.*']
@@ -1293,18 +1236,15 @@ Failed to parse line: 'invalid syntax'
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(data.input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
+        with mock.patch('sys.stdin', StringIO(data.input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
 
-                        actual_output = stdout.getvalue()
-                        self.assertLinesMatch(actual_output, expected_output)
+            actual_output = stdout.getvalue()
+            self.assertLinesMatch(actual_output, expected_output)
 
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_show_all_errors(self):
         argv = ['cantools', 'plot', '-s', self.DBC_FILE, '*33.*']
@@ -1347,18 +1287,15 @@ Failed to parse line: 'invalid syntax'
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(data.input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
+        with mock.patch('sys.stdin', StringIO(data.input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
 
-                        actual_output = stdout.getvalue()
-                        self.assertLinesMatch(actual_output, expected_output)
+            actual_output = stdout.getvalue()
+            self.assertLinesMatch(actual_output, expected_output)
 
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
 
     # ------- test other command line options -------
@@ -1399,33 +1336,31 @@ Failed to parse line: 'invalid syntax'
             mock.call.show(),
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
-                    subplot = subplots[0]
-                    for i in range(len(whlspeed_0)):
-                        call = subplot.mock_calls[i]
-                        actual_xs = call[1][0]
-                        actual_ys = call[1][1]
-                        label = call[2]['label']
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            subplot = subplots[0]
+            for i in range(len(whlspeed_0)):
+                call = subplot.mock_calls[i]
+                actual_xs = call[1][0]
+                actual_ys = call[1][1]
+                label = call[2]['label']
 
-                        n0 = len(whlspeed_0[i])
-                        n1 = len(whlspeed_1[i])
-                        self.assertEqual(len(actual_xs), len(actual_ys), f"numbers of actual x and y values do not match for signal {label}")
-                        self.assertEqual(len(actual_xs), len(xs)+1, f"number of x values does not match for signal {label}")
-                        self.assertEqual(len(actual_ys), n0+n1+1, f"number of y values does not match for signal {label}")
+                n0 = len(whlspeed_0[i])
+                n1 = len(whlspeed_1[i])
+                self.assertEqual(len(actual_xs), len(actual_ys), f"numbers of actual x and y values do not match for signal {label}")
+                self.assertEqual(len(actual_xs), len(xs)+1, f"number of x values does not match for signal {label}")
+                self.assertEqual(len(actual_ys), n0+n1+1, f"number of y values does not match for signal {label}")
 
-                        for j in range(1, len(actual_xs)):
-                            self.assertLess(actual_xs[j-1], actual_xs[j], f"actual x values are not strictly increasing for signal {label}")
-                        self.assertEqual(actual_xs[:n0], xs[:n0], f"first half of x values does not match for signal {label}")
-                        self.assertEqual(actual_xs[-n1:], xs[-n1:], f"second half of x values does not match for signal {label}")
+                for j in range(1, len(actual_xs)):
+                    self.assertLess(actual_xs[j-1], actual_xs[j], f"actual x values are not strictly increasing for signal {label}")
+                self.assertEqual(actual_xs[:n0], xs[:n0], f"first half of x values does not match for signal {label}")
+                self.assertEqual(actual_xs[-n1:], xs[-n1:], f"second half of x values does not match for signal {label}")
 
-                        self.assertEqual(actual_ys[:n0], whlspeed_0[i], f"first half of y values does not match for signal {label}")
-                        self.assertEqual(actual_ys[n0], None, f"expected separating value is not at it's place for signal {label}")
-                        self.assertEqual(actual_ys[-n1:], whlspeed_1[i], f"second half of y values does not match for signal {label}")
-                        #self.assertEqual(actual_ys[-n1:], actual_ys[n1+1:], "this test is a duplicate of len == n0+n1+1")
+                self.assertEqual(actual_ys[:n0], whlspeed_0[i], f"first half of y values does not match for signal {label}")
+                self.assertEqual(actual_ys[n0], None, f"expected separating value is not at it's place for signal {label}")
+                self.assertEqual(actual_ys[-n1:], whlspeed_1[i], f"second half of y values does not match for signal {label}")
+                #self.assertEqual(actual_ys[-n1:], actual_ys[n1+1:], "this test is a duplicate of len == n0+n1+1")
 
     def test_break_time_none(self):
         argv = ['cantools', 'plot', '--break-time', '-1', self.DBC_FILE]
@@ -1470,13 +1405,11 @@ Failed to parse line: 'invalid syntax'
             ],
         ]
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                with plt:
-                    cantools._main()
-                    self.assertListEqual(plt.mock_calls, expected_calls)
-                    for i in range(len(expected_subplot_calls)):
-                        self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
 
     def test_output_file(self):
@@ -1514,13 +1447,10 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = f"Result written to {fn}\n"
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock() as plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            self.assertEqual(stdout.getvalue(), expected_output)
 
     def test_start_absolute_seconds(self):
         argv = ['cantools', 'plot', '--start', '20', self.DBC_FILE, '*FL']
@@ -1554,13 +1484,10 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock() as plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            self.assertEqual(stdout.getvalue(), expected_output)
 
     def test_stop_line_numbers(self):
         argv = ['cantools', 'plot', '--stop', '4', self.DBC_FILE, '*FL']
@@ -1592,13 +1519,10 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock() as plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            self.assertEqual(stdout.getvalue(), expected_output)
 
     def test_start_stop_relative(self):
         argv = ['cantools', 'plot', '--start', '86400', '--stop', '2 days', '--break-time', '-1', self.DBC_FILE, '*FL']
@@ -1631,13 +1555,10 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock(ignore_axes=True) as plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock(ignore_axes=True) as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            self.assertEqual(stdout.getvalue(), expected_output)
 
 
     def test_stop_is_based_on_start_and_xlabel_shows_start(self):
@@ -1671,13 +1592,10 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock() as plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            self.assertEqual(stdout.getvalue(), expected_output)
 
 
     # ------- subplot options -------
@@ -1717,15 +1635,12 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertEqual(stdout.getvalue(), expected_output)
 
     def test_title(self):
         argv = ['cantools', 'plot', self.DBC_FILE, '*fl', '--', '--title', 'Test']
@@ -1748,13 +1663,10 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock() as plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            self.assertEqual(stdout.getvalue(), expected_output)
 
     def test_xlabel(self):
         argv = ['cantools', 'plot', self.DBC_FILE, '--', '--xlabel', '', '*fl', '-', '*fl?*']
@@ -1797,15 +1709,12 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertEqual(stdout.getvalue(), expected_output)
 
     def test_ymin(self):
         argv = ['cantools', 'plot', self.DBC_FILE, '--', '--ymin', '0']
@@ -1837,13 +1746,10 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock() as plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            self.assertEqual(stdout.getvalue(), expected_output)
 
     def test_ymax(self):
         argv = ['cantools', 'plot', self.DBC_FILE, '--', '--ymin', '20', '--ymax', '40']
@@ -1875,13 +1781,10 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock() as plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            self.assertEqual(stdout.getvalue(), expected_output)
 
 
     # ------- global subplot options -------
@@ -1921,15 +1824,12 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertEqual(stdout.getvalue(), expected_output)
 
     def test_global_title(self):
         argv = ['cantools', 'plot', self.DBC_FILE, '*fl', '--title', 'Test']
@@ -1952,13 +1852,10 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock() as plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            self.assertEqual(stdout.getvalue(), expected_output)
 
     def test_global_xlabel(self):
         argv = ['cantools', 'plot', '--xlabel', '', self.DBC_FILE, '*fl', '-', '*fl?*']
@@ -2001,15 +1898,12 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+            self.assertEqual(stdout.getvalue(), expected_output)
 
     def test_global_ymin(self):
         argv = ['cantools', 'plot', self.DBC_FILE, '--ymin', '0']
@@ -2041,13 +1935,10 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock() as plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            self.assertEqual(stdout.getvalue(), expected_output)
 
     def test_global_ymax(self):
         argv = ['cantools', 'plot', self.DBC_FILE, '--ymin', '20', '--ymax', '40']
@@ -2079,13 +1970,10 @@ Failed to parse line: 'invalid syntax'
         stdout = StringIO()
         expected_output = ""
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with PyplotMock() as plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        self.assertEqual(stdout.getvalue(), expected_output)
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), PyplotMock() as plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            self.assertEqual(stdout.getvalue(), expected_output)
 
 
     # ------- other tests -------
@@ -2115,14 +2003,11 @@ Failed to parse line: 'invalid syntax'
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_do_not_replot(self):
         argv = ['cantools', 'plot', self.DBC_FILE, '*fl:-o', '*:o']
@@ -2159,14 +2044,11 @@ Failed to parse line: 'invalid syntax'
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
     def test_do_replot(self):
         argv = ['cantools', 'plot', self.DBC_FILE_CHOICES, "Foo:b-", "Foo:rd"]
@@ -2202,14 +2084,11 @@ Failed to parse line: 'invalid syntax'
 
         stdout = StringIO()
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.stdout', stdout):
-                with mock.patch('sys.argv', argv):
-                    with plt:
-                        cantools._main()
-                        self.assertListEqual(plt.mock_calls, expected_calls)
-                        for i in range(len(expected_subplot_calls)):
-                            self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv), plt:
+            cantools._main()
+            self.assertListEqual(plt.mock_calls, expected_calls)
+            for i in range(len(expected_subplot_calls)):
+                self.assertListEqual(subplots[i].mock_calls, expected_subplot_calls[i], msg=f"calls don't match for subplot {i}")
 
 
     # ------- auxiliary functions -------
@@ -2228,10 +2107,10 @@ Failed to parse line: 'invalid syntax'
         return out
 
     def parse_absolute_time(self, timestamp):
-        return datetime.datetime.strptime(timestamp, self.FORMAT_ABSOLUTE_TIMESTAMP)
+        return datetime.datetime.strptime(timestamp, self.FORMAT_ABSOLUTE_TIMESTAMP)  # noqa: DTZ007
 
     def parse_absolute_seconds(self, timestamp):
-        return datetime.datetime.fromtimestamp(float(timestamp))
+        return datetime.datetime.fromtimestamp(float(timestamp))  # noqa: DTZ006
 
     def parse_seconds(self, timestamp):
         return float(timestamp)

--- a/tests/test_plot_unittests.py
+++ b/tests/test_plot_unittests.py
@@ -76,7 +76,7 @@ class CanToolsPlotUnittests(unittest.TestCase):
     def parse_time(self, s):
         for pattern in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S.%f"):
             try:
-                return datetime.datetime.strptime(s, pattern)
+                return datetime.datetime.strptime(s, pattern)  # noqa: DTZ007
             except ValueError:
                 pass
         raise ValueError('Failed to parse time {s}')

--- a/tests/test_plot_without_mock.py
+++ b/tests/test_plot_without_mock.py
@@ -35,9 +35,8 @@ class CanToolsPlotTest(unittest.TestCase):
  (009.014779)  vcan0  00000343   [8]  CB 02 BC 02 B5 02 D2 02
 """
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                cantools._main()
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv):
+            cantools._main()
 
         self.assertTrue(os.path.exists(self.FN_OUT))
         os.remove(self.FN_OUT)
@@ -60,9 +59,8 @@ class CanToolsPlotTest(unittest.TestCase):
  (009.014779)  vcan0  00000343   [8]  CB 02 BC 02 B5 02 D2 02
 """
 
-        with mock.patch('sys.stdin', StringIO(input_data)):
-            with mock.patch('sys.argv', argv):
-                cantools._main()
+        with mock.patch('sys.stdin', StringIO(input_data)), mock.patch('sys.argv', argv):
+            cantools._main()
 
         self.assertTrue(os.path.exists(self.FN_OUT))
         os.remove(self.FN_OUT)
@@ -76,9 +74,8 @@ class CanToolsPlotTest(unittest.TestCase):
         expected += "".join(f"\n- {s}" for s in plt.style.available)
         expected += "\n"
 
-        with mock.patch('sys.stdout', stdout):
-            with mock.patch('sys.argv', argv):
-                cantools._main()
+        with mock.patch('sys.stdout', stdout), mock.patch('sys.argv', argv):
+            cantools._main()
 
         self.assertEqual(stdout.getvalue(), expected)
 


### PR DESCRIPTION
The following warning is produced when running the unit tests on the current master version:

```
  src/cantools/subparsers/plot.py:229: DeprecationWarning: Parsing dates involving a day of month without a year specified is ambiguious
  and fails to parse leap day. The default behavior will change in Python 3.15
  to either always raise an exception or to use a different default year (TBD).
  To avoid trouble, add a specific year to the input & format.
  See https://github.com/python/cpython/issues/70647.
    out = datetime.datetime.strptime(user_input, p)
```

this patch works around this by using 1904 as the year for formats which do not specify one.