### PR TITLE
Fix crash on candump ERRORFRAME lines in logreader

### DIFF
--- a/src/cantools/logreader.py
+++ b/src/cantools/logreader.py
@@ -71,7 +71,12 @@ class BasePattern:
 
 class CandumpBasePattern(BasePattern):
 
-    def unpack(self, match_object: re.Match[str]) -> DataFrame:
+    def unpack(self, match_object: re.Match[str]) -> DataFrame | None:
+        if match_object.groupdict().get('error_frame'):
+            # Error frames carry no payload. Skip them, mirroring how
+            # PCANTracePatternV11 skips 'Error' rows.
+            return None
+
         channel = match_object.group('channel')
         frame_id = int(match_object.group('can_id'), 16)
         is_extended_frame = len(match_object.group('can_id')) > 3
@@ -97,9 +102,11 @@ class CandumpDefaultPattern(CandumpBasePattern):
     # vcan0  1F0   [8]  00 00 00 00 00 00 1B C1
     #candump vcan0 -a
     # vcan0  1F0   [8]  00 00 00 00 00 00 1B C1   '.......Á'
+    #candump vcan0 (with error frames enabled)
+    # vcan0  20000004   [8]  00 00 00 00 00 00 00 00   ERRORFRAME
     #(Ignore anything after the end of the data to work with candump's ASCII decoding)
     pattern = re.compile(
-        r'^\s*?(?P<channel>\S+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|[0-9A-F ]*).*?$')
+        r'^\s*?(?P<channel>\S+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|(?:[0-9A-F]{2} *)*)\s*(?P<error_frame>ERRORFRAME)?.*?$')
 
     def parse_timestamp(self, match_object: re.Match[str]) -> tuple[TimestampType, TimestampFormat]:
         timestamp = None
@@ -112,9 +119,11 @@ class CandumpTimestampedPattern(CandumpBasePattern):
     # (000.000000)  vcan0  0C8   [8]  F0 00 00 00 00 00 00 00
     #candump vcan0 -tz -a
     # (000.000000)  vcan0  0C8   [8]  31 30 30 2E 35 20 46 4D   '100.5 FM'
+    #candump vcan0 -tz (with error frames enabled)
+    # (000.000000)  vcan0  20000004   [8]  00 00 00 00 00 00 00 00   ERRORFRAME
     #(Ignore anything after the end of the data to work with candump's ASCII decoding)
     pattern = re.compile(
-        r'^\s*?\((?P<timestamp>[\d.]+)\)\s+(?P<channel>\S+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|[0-9A-F ]*).*?$')
+        r'^\s*?\((?P<timestamp>[\d.]+)\)\s+(?P<channel>\S+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|(?:[0-9A-F]{2} *)*)\s*(?P<error_frame>ERRORFRAME)?.*?$')
 
     def __init__(self, tz: TimezoneType) -> None:
         if tz == TZ_LOCAL:
@@ -166,9 +175,11 @@ class CandumpAbsoluteLogPattern(CandumpBasePattern):
     # (2020-12-19 12:04:45.485261)  vcan0  0C8   [8]  F0 00 00 00 00 00 00 00
     #candump vcan0 -tA -a
     # (2020-12-19 12:04:45.485261)  vcan0  0C8   [8]  31 30 30 2E 35 20 46 4D   '100.5 FM'
+    #candump vcan0 -tA (with error frames enabled)
+    # (2020-12-19 12:04:45.485261)  vcan0  20000004   [8]  00 00 00 00 00 00 00 00   ERRORFRAME
     #(Ignore anything after the end of the data to work with candump's ASCII decoding)
     pattern = re.compile(
-        r'^\s*?\((?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\)\s+(?P<channel>\S+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|[0-9A-F ]*).*?$')
+        r'^\s*?\((?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\)\s+(?P<channel>\S+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>remote request|(?:[0-9A-F]{2} *)*)\s*(?P<error_frame>ERRORFRAME)?.*?$')
 
     def parse_timestamp(self, match_object: re.Match[str]) -> tuple[TimestampType, TimestampFormat]:
         timestamp = datetime.datetime.strptime(match_object.group('timestamp'), "%Y-%m-%d %H:%M:%S.%f")  # noqa: DTZ007

--- a/tests/test_logreader.py
+++ b/tests/test_logreader.py
@@ -19,6 +19,28 @@ class TestLogreaderFormats(unittest.TestCase):
         outp = parser.parse("")
         self.assertIsNone(outp)
 
+    def test_candump_error_frame(self):
+        parser = cantools.logreader.Parser()
+
+        outp = parser.parse(
+            "  vcan0  20000004   [8]  00 00 00 00 00 00 00 00   ERRORFRAME")
+        self.assertIsNone(outp)
+
+    def test_candump_error_frame_timestamped(self):
+        parser = cantools.logreader.Parser()
+
+        outp = parser.parse(
+            " (000.000000)  vcan0  20000004   [8]  00 00 00 00 00 00 00 00   ERRORFRAME")
+        self.assertIsNone(outp)
+
+    def test_candump_error_frame_absolute(self):
+        parser = cantools.logreader.Parser()
+
+        outp = parser.parse(
+            " (2020-12-19 12:04:45.485261)  vcan0  20000004   [8]  "
+            "00 00 00 00 00 00 00 00   ERRORFRAME")
+        self.assertIsNone(outp)
+
     def test_candump(self):
         parser = cantools.logreader.Parser()
 
@@ -557,6 +579,17 @@ class TestLogreaderFormats(unittest.TestCase):
         self.assertEqual(outp.timestamp.microseconds, 336543)
 
 class TestLogreaderStreams(unittest.TestCase):
+    def test_candump_error_frame_in_stream(self):
+        parser = cantools.logreader.Parser(io.StringIO("""\
+  vcan0  0C8   [8]  F0 00 00 00 00 00 00 00
+  vcan0  20000004   [8]  00 00 00 00 00 00 00 00   ERRORFRAME
+  vcan0  064   [2]  F0 01
+"""))
+        frames = list(parser)
+        self.assertEqual(len(frames), 2)
+        self.assertEqual(frames[0].frame_id, 0xc8)
+        self.assertEqual(frames[1].frame_id, 0x64)
+
     def test_candump(self):
         testvec = io.StringIO("""\
   vcan0  0C8   [8]  F0 00 00 00 00 00 00 00


### PR DESCRIPTION
logreader crashed with binascii.Error: Odd-length string on candump error-frame lines because the data group [0-9A-F ]* consumed the leading E of ERRORFRAME. This killed candump | cantools decode pipelines with error frames enabled, since decode.py reads stdin through this parser.

Changes: the data group now matches complete byte pairs ((?:[0-9A-F]{2} *)*). ERRORFRAME cannot be consumed pair-wise because its second character is not hex. The marker is captured explicitly and CandumpBasePattern.unpack returns None for it, mirroring how PCANTracePatternV11 handles Error rows. groupdict().get() is used because CandumpDefaultLogPattern shares this unpack but has no error_frame group. Tests added for all three view patterns plus a stream test.

Behavior notes: cantools decode now prints error-frame lines verbatim (the keep_unknowns path) instead of dying, so no output is lost. A truncated odd-length data field (00 00 0) previously crashed; it now parses the complete pairs and ignores the dangling nibble.

Open question: skipping matches the PCAN precedent, but an is_error_frame flag on DataFrame would mirror python-can's Message. Happy to rework to that if preferred.