### PR TITLE
DBC cleanup, part 7: avoid a magic dict for relation attributes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,5 +301,9 @@ autodoc_type_aliases = {
 # disable specific warnings
 nitpick_ignore = [
     ("py:class", "TypeAliasForwardRef"),
+    ("py:class", "Choices"),
+    ("py:class", "AttributeType"),
+    ("py:class", "AttributeDefinitionType"),
     ("py:class", "cantools.database.can.attribute_definition.AttributeValueTypeVar"),
+    ("py:class", "DbcRelationAttributes"),
 ]

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -87,6 +87,18 @@ class DbcAttributes:
     envvars: OrderedDict[str, DbcAttributeMap] = field(default_factory=OrderedDict)
 
 
+# The type of the object returned by _load_relation_attributes()
+@dataclass(slots=True, kw_only=True)
+class DbcRelationAttributes:
+    # BU_SG_REL_ attributes:
+    #     node_signal_relations[frame_id][signal_name][node_name][attribute_name] -> attribute_object
+    node_signal_relations: OrderedDict[int, OrderedDict[str, OrderedDict[str, DbcAttributeMap]]] = field(default_factory=OrderedDict)
+
+    # BU_BO_REL_ attributes:
+    #     node_message_relations[frame_id][node_name][attribute_name] -> attribute_object
+    node_message_relations: OrderedDict[int, OrderedDict[str, DbcAttributeMap]] = field(default_factory=OrderedDict)
+
+
 # The type of the object returned by _load_comments()
 @dataclass(slots=True, kw_only=True)
 class DbcComments:
@@ -976,30 +988,29 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
 def _dump_attributes_rel(database: InternalDatabase, sort_signals: type_sort_signals) -> str | list[str]:
     ba_rel: list[str] = []
 
-    if database.dbc is None:
+    if database.dbc is None or database.dbc.attributes_rel is None:
         return  ba_rel
 
     attributes_rel = database.dbc.attributes_rel
-    for frame_id, element in attributes_rel.items():
-        if 'signal' in element:
-            for signal_name, signal_lst in element['signal'].items():
-                for node_name, node_dict in signal_lst['node'].items():
-                    for attribute in node_dict.values():
-                        ba_rel.append(f'BA_REL_ "{attribute.definition.name}" '
-                                        f'BU_SG_REL_ '
-                                        f'{node_name} '
-                                        f'SG_ '
-                                        f'{frame_id} '
-                                        f'{signal_name} '
-                                        f'{attribute.formatted_value};')
-        elif 'node' in element:
-            for node_name, node_dict in element['node'].items():
-                for attribute in node_dict.values():
+    for frame_id, signal_map in attributes_rel.node_signal_relations.items():
+        for signal_name, node_map in signal_map.items():
+            for node_name, attribute_map in node_map.items():
+                for attribute in attribute_map.values():
                     ba_rel.append(f'BA_REL_ "{attribute.definition.name}" '
-                                    f'BU_BO_REL_ '
-                                    f'{node_name} '
-                                    f'{frame_id} '
-                                    f'{attribute.formatted_value};')
+                                  f'BU_SG_REL_ '
+                                  f'{node_name} '
+                                  f'SG_ '
+                                  f'{frame_id} '
+                                  f'{signal_name} '
+                                  f'{attribute.formatted_value};')
+    for frame_id, node_map in attributes_rel.node_message_relations.items():
+        for node_name, attribute_map in node_map.items():
+            for attribute in attribute_map.values():
+                ba_rel.append(f'BA_REL_ "{attribute.definition.name}" '
+                              f'BU_BO_REL_ '
+                              f'{node_name} '
+                              f'{frame_id} '
+                              f'{attribute.formatted_value};')
 
     return ba_rel
 
@@ -1276,10 +1287,9 @@ def _load_attributes(tokens, definitions):
 
 
 def _load_attributes_rel(tokens, definitions):
-    attributes_rel = OrderedDict()
+    attributes_rel = DbcRelationAttributes()
 
     def to_attribute_rel_object(attribute, value):
-
         definition = definitions[attribute[1]]
 
         if definition.type_name in ['INT', 'HEX', 'ENUM']:
@@ -1296,43 +1306,29 @@ def _load_attributes_rel(tokens, definitions):
         node = attribute_rel_tokens[3]
 
         if rel_type == 'BU_SG_REL_':
-
             frame_id_dbc = int(attribute_rel_tokens[5])
             signal = attribute_rel_tokens[6]
 
-            if frame_id_dbc not in attributes_rel:
-                attributes_rel[frame_id_dbc] = {}
+            if frame_id_dbc not in attributes_rel.node_signal_relations:
+                attributes_rel.node_signal_relations[frame_id_dbc] = OrderedDict()
+            if signal not in attributes_rel.node_signal_relations[frame_id_dbc]:
+                attributes_rel.node_signal_relations[frame_id_dbc][signal] = OrderedDict()
+            if node not in attributes_rel.node_signal_relations[frame_id_dbc][signal]:
+                attributes_rel.node_signal_relations[frame_id_dbc][signal][node] = OrderedDict()
 
-            if 'signal' not in attributes_rel[frame_id_dbc]:
-                attributes_rel[frame_id_dbc]['signal'] = OrderedDict()
-
-            if signal not in attributes_rel[frame_id_dbc]['signal']:
-                attributes_rel[frame_id_dbc]['signal'][signal] = OrderedDict()
-
-            if 'node' not in attributes_rel[frame_id_dbc]['signal'][signal]:
-                attributes_rel[frame_id_dbc]['signal'][signal]['node'] = OrderedDict()
-
-            if node not in attributes_rel[frame_id_dbc]['signal'][signal]['node']:
-                attributes_rel[frame_id_dbc]['signal'][signal]['node'][node] = OrderedDict()
-
-            attributes_rel[frame_id_dbc]['signal'][signal]['node'][node][name] = to_attribute_rel_object(attribute_rel_tokens, attribute_rel_tokens[7])
+            attributes_rel.node_signal_relations[frame_id_dbc][signal][node][name] = \
+                to_attribute_rel_object(attribute_rel_tokens, attribute_rel_tokens[7])
 
         elif rel_type == 'BU_BO_REL_':
             frame_id_dbc = int(attribute_rel_tokens[4])
 
-            if frame_id_dbc not in attributes_rel:
-                attributes_rel[frame_id_dbc] = {}
+            if frame_id_dbc not in attributes_rel.node_message_relations:
+                attributes_rel.node_message_relations[frame_id_dbc] = OrderedDict()
+            if node not in attributes_rel.node_message_relations[frame_id_dbc]:
+                attributes_rel.node_message_relations[frame_id_dbc][node] = OrderedDict()
 
-            if 'node' not in attributes_rel[frame_id_dbc]:
-                attributes_rel[frame_id_dbc]['node'] = OrderedDict()
-
-            if node not in attributes_rel[frame_id_dbc]['node']:
-                attributes_rel[frame_id_dbc]['node'][node] = OrderedDict()
-
-            attributes_rel[frame_id_dbc]['node'][node][name] = to_attribute_rel_object(attribute_rel_tokens, attribute_rel_tokens[5])
-
-        else:
-            pass
+            attributes_rel.node_message_relations[frame_id_dbc][node][name] = \
+                to_attribute_rel_object(attribute_rel_tokens, attribute_rel_tokens[5])
 
     return attributes_rel
 
@@ -2021,23 +2017,21 @@ def update_signal_attribute_rel_names(database: InternalDatabase,
                                       message: Message,
                                       converter: LongNamesConverter,
                                       shorten_long_names: bool) -> None:
-    if database.dbc is None or not shorten_long_names:
+    if database.dbc is None or database.dbc.attributes_rel is None or not shorten_long_names:
         return
 
     frame_id = get_dbc_frame_id(message)
 
-    frame_rel = database.dbc.attributes_rel.get(frame_id, EMPTY_DICT)
-    signal_attributes_rel = frame_rel.get('signal')
+    signal_attributes_rel = database.dbc.attributes_rel.node_signal_relations.get(frame_id)
     if signal_attributes_rel is None:
         return
 
     updated_signal_attributes_rel = OrderedDict()
-
     for signal_name, value in signal_attributes_rel.items():
         signal_name = converter.long_to_short.get(signal_name, signal_name)
         updated_signal_attributes_rel[signal_name] = value
 
-    database.dbc.attributes_rel[frame_id]['signal'] = updated_signal_attributes_rel
+    database.dbc.attributes_rel.node_signal_relations[frame_id] = updated_signal_attributes_rel
 
 
 def make_signal_names_unique(database: InternalDatabase, shorten_long_names: bool) -> None:
@@ -2248,30 +2242,27 @@ def get_definitions_rel_dict(definitions, defaults):
 
 
 def update_signal_attribute_rel_names_after_load(messages: list[Message],
-                                                 attributes: typing.Any,
-                                                 attributes_rel: typing.Any) -> None:
+                                                 attributes: DbcAttributes,
+                                                 attributes_rel: DbcRelationAttributes) -> None:
     for message in messages:
         frame_id = get_dbc_frame_id(message)
 
-        frame_rel = attributes_rel.get(frame_id, EMPTY_DICT)
-        signal_attributes_rel = frame_rel.get('signal')
+        signal_attributes_rel = attributes_rel.node_signal_relations.get(frame_id)
         if signal_attributes_rel is None:
             continue
 
-        signal_attributes = attributes.signals.get(frame_id, EMPTY_DICT)
-
-        short_to_signal_name = {}
+        signal_attributes: OrderedDict[str, DbcAttributeMap] = attributes.signals.get(frame_id) or OrderedDict()
+        short_to_signal_name: dict[str, str] = {}
         for signal_name, value in signal_attributes.items():
             if 'SystemSignalLongSymbol' in value:
-                short_to_signal_name[signal_name] = value['SystemSignalLongSymbol'].value
+                short_to_signal_name[signal_name] = str(value['SystemSignalLongSymbol'].value)
 
-        updated_signal_attributes_rel = OrderedDict()
-
-        for signal_name, value in signal_attributes_rel.items():
+        updated_signal_attributes_rel: OrderedDict[str, OrderedDict[str, DbcAttributeMap]] = OrderedDict()
+        for signal_name, node_attrs in signal_attributes_rel.items():
             signal_name = short_to_signal_name.get(signal_name, signal_name)
-            updated_signal_attributes_rel[signal_name] = value
+            updated_signal_attributes_rel[signal_name] = node_attrs
 
-        attributes_rel[frame_id]['signal'] = updated_signal_attributes_rel
+        attributes_rel.node_signal_relations[frame_id] = updated_signal_attributes_rel
 
 
 def load_string(string: str, strict: bool = True,

--- a/src/cantools/database/can/formats/dbc_specifics.py
+++ b/src/cantools/database/can/formats/dbc_specifics.py
@@ -1,13 +1,19 @@
 # Store the specific DBC format properties of objects
 
+from __future__ import annotations
+
 from collections import OrderedDict
-from typing import Any
+from typing import TYPE_CHECKING
 
-from cantools.database.can.attribute import AttributeType
-from cantools.database.can.attribute_definition import AttributeDefinitionType
-from cantools.database.can.environment_variable import EnvironmentVariable
-from cantools.typechecking import Choices
+if TYPE_CHECKING:
+    from cantools.database.can.attribute import AttributeType
+    from cantools.database.can.attribute_definition import (
+        AttributeDefinitionType,
+    )
+    from cantools.database.can.environment_variable import EnvironmentVariable
+    from cantools.typechecking import Choices
 
+    from .dbc import DbcRelationAttributes
 
 class DbcSpecifics:
 
@@ -17,13 +23,13 @@ class DbcSpecifics:
                  attribute_definitions: OrderedDict[str, AttributeDefinitionType] | None = None,
                  environment_variables: OrderedDict[str, EnvironmentVariable] | None = None,
                  value_tables: OrderedDict[str, Choices] | None = None,
-                 attributes_rel: OrderedDict[int, dict[Any, Any]] | None =None,
+                 attributes_rel: DbcRelationAttributes | None = None,
                  attribute_definitions_rel: OrderedDict[str, AttributeDefinitionType] | None = None) -> None:
         self._attributes = attributes or OrderedDict()
         self._attribute_definitions = attribute_definitions or OrderedDict()
         self._environment_variables = environment_variables or OrderedDict()
         self._value_tables = value_tables or OrderedDict()
-        self._attributes_rel = attributes_rel or OrderedDict()
+        self._attributes_rel = attributes_rel
         self._attribute_definitions_rel = attribute_definitions_rel or OrderedDict()
 
     @property
@@ -62,7 +68,7 @@ class DbcSpecifics:
         return self._environment_variables
 
     @property
-    def attributes_rel(self) -> OrderedDict[int, dict[Any, Any]]:
+    def attributes_rel(self) -> DbcRelationAttributes | None:
         """The DBC specific attribute rel as dictionary..
 
         """

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6037,12 +6037,11 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_relation_attributes(self):
         filename = 'tests/files/dbc/attributes_relation.dbc'
         db = cantools.database.load_file(filename)
-        for frame in db.dbc.attributes_rel.values():
-            signal = frame.get("signal")
-            if "signal_1" in signal:
-                rel_attributes = signal["signal_1"]["node"]["ECU2"]
-                first_timeout_attr = rel_attributes["SigFirstTimeoutTime"]
-                timeout_attr = rel_attributes["SigTimeoutTime"]
+        for signal_map in db.dbc.attributes_rel.node_signal_relations.values():
+            if 'signal_1' in signal_map:
+                rel_attributes = signal_map['signal_1']['ECU2']
+                first_timeout_attr = rel_attributes['SigFirstTimeoutTime']
+                timeout_attr = rel_attributes['SigTimeoutTime']
                 self.assertEqual(first_timeout_attr.value, 24000)
                 self.assertEqual(timeout_attr.value, 6000)
                 break
@@ -6051,10 +6050,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_relation_message_attributes(self):
         filename = 'tests/files/dbc/BU_BO_REL_Message.dbc'
         db = cantools.database.load_file(filename)
-        for frame in db.dbc.attributes_rel.values():
-            node = frame.get("node")
-            rel_attributes = node["ECU1"]
-            msg_attr = rel_attributes["MsgProject"]
+        for node_map in db.dbc.attributes_rel.node_message_relations.values():
+            rel_attributes = node_map['ECU1']
+            msg_attr = rel_attributes['MsgProject']
             self.assertEqual(msg_attr.value, 2)
             break
         self.assert_dbc_dump(db, filename)


### PR DESCRIPTION
this does the same for relation attributes as what #813 did for comments and #816 did for attributes: replace the dictionary containing "magic" entries with by a dataclass.

after this PR, the "magical dictionaries" will fortunately have been dealt with...