### PR TITLE
decode: don't print undecodable contained messages twice with --single-line

### DIFF
--- a/src/cantools/subparsers/__utils__.py
+++ b/src/cantools/subparsers/__utils__.py
@@ -67,7 +67,6 @@ def _format_container_single_line(message : Message,
         if isinstance(cm, Message):
             if isinstance(signals, bytes):
                 formatted_cm = f'{cm.name}: Undecodable data: {signals.hex(" ")}'
-                contained_list.append(formatted_cm)
             else:
                 formatted_cm_signals = format_signals(cm, signals)
                 formatted_cm = _format_message_single_line(cm.name, formatted_cm_signals)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -719,6 +719,29 @@ BATTERY_VT(
             actual_output = stdout.getvalue()
             self.assertEqual(actual_output, expected_output)
 
+    def test_decode_single_line_undecodable_contained_message(self):
+        argv = [
+            'cantools',
+            'decode',
+            '--single-line',
+            'tests/files/arxml/system-4.2.arxml'
+        ]
+
+        input_data = """\
+  vcan0  066   [8]  0A 0B 0C 04 E2 D8 7F D6
+"""
+
+        expected_output = """\
+  vcan0  066   [8]  0A 0B 0C 04 E2 D8 7F D6 :: OneToContainThemAll(message1: Undecodable data: e2 d8 7f d6)
+"""
+
+        stdout = StringIO()
+
+        with patch('sys.stdin', StringIO(input_data)), patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
+
     def test_dump(self):
         argv = [
             'cantools',


### PR DESCRIPTION
Piping a candump log through `cantools decode --single-line` against an ARXML with container PDUs, and any contained message that fails to decode comes out listed twice, which reads like the container really did carry two copies of it:

```
$ echo "  vcan0  066   [8]  0A 0B 0C 04 E2 D8 7F D6" | cantools decode --single-line tests/files/arxml/system-4.2.arxml
  vcan0  066   [8]  0A 0B 0C 04 E2 D8 7F D6 :: OneToContainThemAll(message1: Undecodable data: e2 d8 7f d6, message1: Undecodable data: e2 d8 7f d6)
```

Without `--single-line` the same frame prints it once. The test in here fails without the change.

Left the format itself alone - the multi-line version prefixes these with `header_id##hexdata ::` and the single-line one doesn't, but that looks deliberate so I've not touched it.
