### PR TITLE
DBC cleanup, part 9: add comprehensive type hints

### DIFF
--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -1254,13 +1254,13 @@ def _load_attribute_definitions(tokens: DbcTokens) -> list[MatchObject]:
 
 
 def _load_attribute_definition_defaults(tokens: DbcTokens) -> DbcAttributeDefaults:
-    defaults: DbcAttributeDefaults = OrderedDict()
+    attribute_definition_defaults: DbcAttributeDefaults = OrderedDict()
 
-    for _default_attr in tokens.get('BA_DEF_DEF_', []):
-        default_attr = dbc_assert_type(_default_attr, list)
-        defaults[dbc_assert_type(default_attr[1], str)] = typing.cast('AttributeValue', default_attr[2])
+    for _attribute_definition_default_tokens in tokens.get('BA_DEF_DEF_', []):
+        attribute_definition_default_tokens = dbc_assert_type(_attribute_definition_default_tokens, list)
+        attribute_definition_defaults[dbc_assert_type(attribute_definition_default_tokens[1], str)] = typing.cast('AttributeValue', attribute_definition_default_tokens[2])
 
-    return defaults
+    return attribute_definition_defaults
 
 
 def _load_relation_attribute_definitions(tokens: DbcTokens) -> list[MatchObject]:
@@ -1268,13 +1268,13 @@ def _load_relation_attribute_definitions(tokens: DbcTokens) -> list[MatchObject]
 
 
 def _load_relation_attribute_definition_defaults(tokens: DbcTokens) -> DbcAttributeDefaults:
-    defaults: DbcAttributeDefaults = OrderedDict()
+    relation_attribute_definition_defaults: DbcAttributeDefaults = OrderedDict()
 
-    for _default_attr in tokens.get('BA_DEF_DEF_REL_', []):
-        default_attr = dbc_assert_type(_default_attr, list)
-        defaults[dbc_assert_type(default_attr[1], str)] = typing.cast('AttributeValue', default_attr[2])
+    for _relation_attribute_definition_default_tokens in tokens.get('BA_DEF_DEF_REL_', []):
+        relation_attribute_definition_default_tokens = dbc_assert_type(_relation_attribute_definition_default_tokens, list)
+        relation_attribute_definition_defaults[dbc_assert_type(relation_attribute_definition_default_tokens[1], str)] = typing.cast('AttributeValue', relation_attribute_definition_default_tokens[2])
 
-    return defaults
+    return relation_attribute_definition_defaults
 
 
 def _load_attributes(tokens: DbcTokens, definitions: OrderedDict[str, AttributeDefinitionType]) -> DbcAttributes:
@@ -1404,10 +1404,10 @@ def _load_value_tables(tokens: DbcTokens) -> OrderedDict[str, Choices]:
 
     value_tables: OrderedDict[str, Choices] = OrderedDict()
 
-    for _value_table in tokens.get('VAL_TABLE_', []):
-        value_table = dbc_assert_type(_value_table, list)
-        name = dbc_assert_type(value_table[1], str)
-        number_text_pairs = dbc_assert_type(value_table[2], list)
+    for _value_table_tokens in tokens.get('VAL_TABLE_', []):
+        value_table_tokens = dbc_assert_type(_value_table_tokens, list)
+        name = dbc_assert_type(value_table_tokens[1], str)
+        number_text_pairs = dbc_assert_type(value_table_tokens[2], list)
         value_tables[name] = OrderedDict((int(number), NamedSignalValue(int(number), text))
                                          for number, text in number_text_pairs)
 
@@ -1464,11 +1464,11 @@ def _load_message_senders(tokens: DbcTokens, attributes: DbcAttributes) -> defau
 
     message_senders: defaultdict[int, list[str]] = defaultdict(list)
 
-    for _senders in tokens.get('BO_TX_BU_', []):
-        senders = dbc_assert_type(_senders, list)
-        frame_id = int(dbc_assert_type(senders[1], str))
+    for _sender_tokens in tokens.get('BO_TX_BU_', []):
+        sender_tokens = dbc_assert_type(_sender_tokens, list)
+        frame_id = int(dbc_assert_type(sender_tokens[1], str))
         message_senders[frame_id] += [
-            _get_node_long_name(attributes, sender) for sender in dbc_assert_type(senders[3], list)
+            _get_node_long_name(attributes, sender) for sender in dbc_assert_type(sender_tokens[3], list)
         ]
 
     return message_senders
@@ -1481,11 +1481,11 @@ def _load_signal_types(tokens: DbcTokens) -> defaultdict[int, dict[str, int]]:
 
     signal_types: defaultdict[int, dict[str, int]] = defaultdict(dict)
 
-    for _signal_type in tokens.get('SIG_VALTYPE_', []):
-        signal_type = dbc_assert_type(_signal_type, list)
-        frame_id = int(dbc_assert_type(signal_type[1], str))
-        signal_name = dbc_assert_type(signal_type[2], str)
-        signal_types[frame_id][signal_name] = int(dbc_assert_type(signal_type[4], str))
+    for _signal_type_tokens in tokens.get('SIG_VALTYPE_', []):
+        signal_type_tokens = dbc_assert_type(_signal_type_tokens, list)
+        frame_id = int(dbc_assert_type(signal_type_tokens[1], str))
+        signal_name = dbc_assert_type(signal_type_tokens[2], str)
+        signal_types[frame_id][signal_name] = int(dbc_assert_type(signal_type_tokens[4], str))
 
     return signal_types
 
@@ -1497,14 +1497,14 @@ def _load_signal_multiplexer_values(tokens: DbcTokens) -> MuxValues:
 
     signal_multiplexer_values: MuxValues = defaultdict(dict)
 
-    for _signal_multiplexer_value in tokens.get('SG_MUL_VAL_', []):
-        signal_multiplexer_value = dbc_assert_type(_signal_multiplexer_value, list)
-        frame_id = int(dbc_assert_type(signal_multiplexer_value[1], str))
-        signal_name = dbc_assert_type(signal_multiplexer_value[2], str)
-        multiplexer_signal_name = dbc_assert_type(signal_multiplexer_value[3], str)
+    for _signal_multiplexer_value_tokens in tokens.get('SG_MUL_VAL_', []):
+        signal_multiplexer_value_tokens = dbc_assert_type(_signal_multiplexer_value_tokens, list)
+        frame_id = int(dbc_assert_type(signal_multiplexer_value_tokens[1], str))
+        signal_name = dbc_assert_type(signal_multiplexer_value_tokens[2], str)
+        multiplexer_signal_name = dbc_assert_type(signal_multiplexer_value_tokens[3], str)
         multiplexer_ids: list[int] = []
 
-        for lower_str, upper_str in dbc_assert_type(signal_multiplexer_value[4], list):
+        for lower_str, upper_str in dbc_assert_type(signal_multiplexer_value_tokens[4], list):
             lower = int(lower_str)
             upper = int(upper_str[1:])
             # TODO: Probably store ranges as tuples to not run out of
@@ -1545,12 +1545,12 @@ def _load_signal_groups(tokens: DbcTokens, attributes: DbcAttributes) -> default
 
         return signal_short_name
 
-    for _signal_group in tokens.get('SIG_GROUP_',[]):
-        signal_group = dbc_assert_type(_signal_group, list)
-        frame_id = int(dbc_assert_type(signal_group[1], str))
-        signal_names = [get_signal_long_name(frame_id, sn) for sn in dbc_assert_type(signal_group[5], list)]
-        signal_groups[frame_id].append(SignalGroup(name=dbc_assert_type(signal_group[2], str),
-                                                   repetitions=int(dbc_assert_type(signal_group[3], str)),
+    for _signal_group_tokens in tokens.get('SIG_GROUP_',[]):
+        signal_group_tokens = dbc_assert_type(_signal_group_tokens, list)
+        frame_id = int(dbc_assert_type(signal_group_tokens[1], str))
+        signal_names = [get_signal_long_name(frame_id, sn) for sn in dbc_assert_type(signal_group_tokens[5], list)]
+        signal_groups[frame_id].append(SignalGroup(name=dbc_assert_type(signal_group_tokens[2], str),
+                                                   repetitions=int(dbc_assert_type(signal_group_tokens[3], str)),
                                                    signal_names=signal_names))
 
     return signal_groups

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -6,12 +6,14 @@ from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from dataclasses import dataclass, field
 from decimal import Decimal
+from typing import TypeVar
 
 from textparser import (
     Any,
     AnyUntil,
     DelimitedList,
     Grammar,
+    MatchObject,
     OneOrMore,
     OneOrMoreDict,
     Optional,
@@ -25,8 +27,10 @@ from textparser import (
 )
 
 from cantools.database.can.internal_database import InternalDatabase
+from cantools.typechecking import Choices
 
 from ...conversion import BaseConversion
+from ...errors import ParseError
 from ...namedsignalvalue import NamedSignalValue
 from ...utils import (
     SORT_SIGNALS_DEFAULT,
@@ -58,6 +62,13 @@ if typing.TYPE_CHECKING:
     from types import MappingProxyType
 
 EMPTY_DICT = typing.cast("MappingProxyType[typing.Any, typing.Any]", {})
+
+# Type alias for the parsed token dict produced by DbcParser.parse()
+DbcTokens = dict[str, list[MatchObject]]
+
+# A list of tokens as produced by textparser's
+# Sequence/ZeroOrMore/OneOrMoreDict patterns.
+TokenList = list[MatchObject]
 
 # attribute_name -> attribute_object
 DbcAttributeMap = OrderedDict[str, AttributeType]
@@ -124,6 +135,34 @@ class DbcComments:
     #     signals[message_arbitration_id][signal_name] -> signal_comment
     signals: dict[int, dict[str, str]] = field(default_factory=dict)
 
+# Signal multiplexer values:
+#   mux_values_dict[frame_id][mux_signal_name][signal_name] -> list[mux_id]
+MuxSignalValues = dict[str, dict[str, list[int]]]
+MuxValues = dict[int, MuxSignalValues]
+
+# Attribute definition defaults from BA_DEF_DEF_ tokens:
+#   attrib_default_dict[attribute_name] -> attribute_value
+DbcAttributeDefaults = OrderedDict[str, AttributeValue]
+
+# Value tables:
+#   value_tables_dict[value_table_name] -> { choice_int_value: choice_string_value }
+ValueTables = OrderedDict[str, Choices]
+
+# Choices dict:
+#   choices[frame_id][signal_name] -> { choice_int_value: choice_string_value }
+ChoicesDict = defaultdict[int, dict[str, Choices]]
+
+_T = TypeVar('_T')
+def dbc_assert_type(x: object, t: type[_T]) -> _T:
+    """Ensure that object `x` is of type `t`
+
+    Return `x` if this is the case, else raise a `ParseError`.
+    """
+    if not isinstance(x, t):
+        raise ParseError(
+            f'Expected {t.__name__}, got {type(x).__name__}: {x!r}')
+    return x
+
 DBC_FMT = (
     'VERSION "{version}"\r\n'
     '\r\n'
@@ -181,7 +220,6 @@ DBC_FMT = (
     '{sig_group}\r\n'
     '{sig_mux_values}\r\n'
 )
-
 
 # Signal types.
 SIGNAL_TYPE_FLOAT = 1
@@ -261,7 +299,7 @@ ATTRIBUTE_DEFINITION_GENMSGCYCLETIME = AttributeDefinition(
     minimum=0,
     maximum=2**16-1)
 
-ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE = AttributeDefinition(
+ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE = AttributeDefinition[float](
     name='GenSigStartValue',
     default_value=0.0,
     kind='SG_',
@@ -282,7 +320,7 @@ def to_float(value: AttributeValue) -> float:
 
 class DbcParser(Parser):
 
-    def tokenize(self, string):
+    def tokenize(self, string: str) -> list[Token]:
         keywords = {
             'BA_',
             'BA_DEF_',
@@ -355,7 +393,7 @@ class DbcParser(Parser):
         tokens, token_regex = tokenize_init(token_specs)
 
         for mo in re.finditer(token_regex, string, re.DOTALL):
-            kind = mo.lastgroup
+            kind: str = mo.lastgroup  # type: ignore[assignment]
 
             if kind == 'SKIP':
                 pass
@@ -535,13 +573,13 @@ def get_dbc_name(name: str) -> str:
     return name
 
 
-def _get_node_long_name(attributes, node_short_name):
+def _get_node_long_name(attributes: DbcAttributes, node_short_name: str) -> str:
     attrib = attributes.nodes.get(node_short_name, EMPTY_DICT).get('SystemNodeLongSymbol')
     if attrib is not None:
         return str(attrib.value)
     return node_short_name
 
-def _get_envvar_long_name(attributes, envvar_short_name):
+def _get_envvar_long_name(attributes: DbcAttributes, envvar_short_name: str) -> str:
     attrib = attributes.envvars.get(envvar_short_name, EMPTY_DICT).get('SystemEnvVarLongSymbol')
     if attrib is not None:
         return str(attrib.value)
@@ -858,11 +896,13 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
         baudrate = database.buses[0].baudrate
     if baudrate is not None:
         baudrate_attribute_definition = database.dbc.attribute_definitions.get('Baudrate')
-        assert baudrate_attribute_definition is not None
+        if baudrate_attribute_definition is None:
+            raise ParseError('Database defines a baudrate but no definition for '
+                             'the corresponding attribute')
         database.dbc.attributes['Baudrate'] = Attribute[int](
-                    value=int(baudrate),
-                    definition=typing.cast('AttributeDefinition[int]', baudrate_attribute_definition),
-                )
+            value=int(baudrate),
+            definition=typing.cast('AttributeDefinition[int]', baudrate_attribute_definition))
+
 
     for attribute in database.dbc.attributes.values():
         attributes.append(('dbc', attribute, None, None, None, None))
@@ -891,7 +931,7 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
         if gen_msg_cycle_time_def is not None and msg_cycle_time != gen_msg_cycle_time_def.default_value:
             msg_attributes['GenMsgCycleTime'] = Attribute(
                 value=msg_cycle_time,
-                definition=typing.cast('AttributeDefinition[int]', gen_msg_cycle_time_def),
+                definition=dbc_assert_type(gen_msg_cycle_time_def, AttributeDefinition),
             )
         elif 'GenMsgCycleTime' in msg_attributes:
             del msg_attributes['GenMsgCycleTime']
@@ -941,8 +981,8 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
             if signal.raw_initial is None and 'GenSigStartValue' in sig_attributes:
                 del sig_attributes['GenSigStartValue']
             elif signal.raw_initial is not None:
-                sig_attributes['GenSigStartValue'] = Attribute(
-                    value=signal.raw_initial,
+                sig_attributes['GenSigStartValue'] = Attribute[float](
+                    value=float(signal.raw_initial),
                     definition=ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE)
 
             # output all signal attributes
@@ -957,26 +997,39 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
             attribute_lines.append(f'BA_ "{attribute_to_dump.definition.name}" '
                                    f'{attribute_to_dump.formatted_value};')
         elif attribute_kind == 'envvar':
-            assert envvar_to_dump is not None
+            if envvar_to_dump is None:
+                raise ParseError(
+                    f'Need to dump environment variable, but none has been specified')
             attribute_lines.append(f'BA_ "{attribute_to_dump.definition.name}" '
                                    f'{attribute_to_dump.definition.kind} '
                                    f'{envvar_to_dump.name} '
                                    f'{attribute_to_dump.formatted_value};')
+
         elif attribute_kind == 'node':
-            assert node_to_dump is not None
+            if node_to_dump is None:
+                raise ParseError(
+                    'Need to dump node, but none has been specified')
             attribute_lines.append(f'BA_ "{attribute_to_dump.definition.name}" '
                                    f'{attribute_to_dump.definition.kind} '
                                    f'{node_to_dump.name} '
                                    f'{attribute_to_dump.formatted_value};')
+
         elif attribute_kind == 'message':
-            assert message_to_dump is not None
+            if message_to_dump is None:
+                raise ParseError(
+                    'Need to dump message, but none has been specified')
             attribute_lines.append(f'BA_ "{attribute_to_dump.definition.name}" '
                                    f'{attribute_to_dump.definition.kind} '
                                    f'{get_dbc_frame_id(message_to_dump)} '
                                    f'{attribute_to_dump.formatted_value};')
+
         elif attribute_kind == 'signal':
-            assert signal_to_dump is not None
-            assert message_to_dump is not None
+            if message_to_dump is None:
+                raise ParseError(
+                    'Need to dump message, but none has been specified')
+            if signal_to_dump is None:
+                raise ParseError(
+                    'Need to dump signal, but none has been specified')
             attribute_lines.append(f'BA_ "{attribute_to_dump.definition.name}" '
                                    f'{attribute_to_dump.definition.kind} '
                                    f'{get_dbc_frame_id(message_to_dump)} '
@@ -986,7 +1039,7 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
     return attribute_lines
 
 
-def _dump_relation_attributes(database: InternalDatabase, sort_signals: type_sort_signals) -> str | list[str]:
+def _dump_relation_attributes(database: InternalDatabase, sort_signals: type_sort_signals) -> list[str]:
     relation_attribute_lines: list[str] = []
 
     if database.dbc is None or database.dbc.relation_attributes is None:
@@ -1155,111 +1208,118 @@ def _dump_environment_variables(database: InternalDatabase) -> list[str]:
     return envvar_lines
 
 
-def _load_comments(tokens):
+def _load_comments(tokens: DbcTokens) -> DbcComments:
     comments = DbcComments()
 
-    for comment_tokens in tokens.get('CM_', []):
+    for _comment_tokens in tokens.get('CM_', []):
+        comment_tokens = dbc_assert_type(_comment_tokens, list)
         if not isinstance(comment_tokens[1], list):
             # the CM_ token is a string, i.e., it is a bus comment. We
             # implement CANdb++ behavior and concatenate all bus
             # comments.
             if comments.bus is None:
                 comments.bus = ''
-            comments.bus += comment_tokens[1]
+            comments.bus += dbc_assert_type(comment_tokens[1], str)
             continue
 
-        item = comment_tokens[1]
-        kind = item[0]
+        item: TokenList = comment_tokens[1]
+        kind = dbc_assert_type(item[0], str)
 
         if kind == 'SG_':
             # signal comment
-            frame_id = int(item[1])
-            signal_name = item[2]
+            frame_id = int(dbc_assert_type(item[1], str))
+            signal_name = dbc_assert_type(item[2], str)
             if frame_id not in comments.signals:
                 comments.signals[frame_id] = {}
             message_signal_comments = comments.signals[frame_id]
-            message_signal_comments[signal_name] = item[3]
+            message_signal_comments[signal_name] = dbc_assert_type(item[3], str)
         elif kind == 'BO_':
             # message comment
-            frame_id = int(item[1])
-            comments.messages[frame_id] = item[2]
+            frame_id = int(dbc_assert_type(item[1], str))
+            comments.messages[frame_id] = dbc_assert_type(item[2], str)
         elif kind == 'BU_':
             # node comment
-            node_name = item[1]
-            comments.nodes[node_name] = item[2]
+            node_name = dbc_assert_type(item[1], str)
+            comments.nodes[node_name] = dbc_assert_type(item[2], str)
         elif kind == 'EV_':
             # environment variable comment
-            envvar_name = item[1]
-            comments.envvars[envvar_name] = item[2]
+            envvar_name = dbc_assert_type(item[1], str)
+            comments.envvars[envvar_name] = dbc_assert_type(item[2], str)
 
     return comments
 
 
-def _load_attribute_definitions(tokens):
+def _load_attribute_definitions(tokens: DbcTokens) -> list[MatchObject]:
     return tokens.get('BA_DEF_', [])
 
 
-def _load_attribute_definition_defaults(tokens):
-    defaults = OrderedDict()
+def _load_attribute_definition_defaults(tokens: DbcTokens) -> DbcAttributeDefaults:
+    defaults: DbcAttributeDefaults = OrderedDict()
 
-    for default_attr in tokens.get('BA_DEF_DEF_', []):
-        defaults[default_attr[1]] = default_attr[2]
+    for _default_attr in tokens.get('BA_DEF_DEF_', []):
+        default_attr = dbc_assert_type(_default_attr, list)
+        defaults[dbc_assert_type(default_attr[1], str)] = typing.cast('AttributeValue', default_attr[2])
 
     return defaults
 
 
-def _load_relation_attribute_definitions(tokens):
+def _load_relation_attribute_definitions(tokens: DbcTokens) -> list[MatchObject]:
     return tokens.get('BA_DEF_REL_', [])
 
 
-def _load_relation_attribute_definition_defaults(tokens):
-    defaults = OrderedDict()
+def _load_relation_attribute_definition_defaults(tokens: DbcTokens) -> DbcAttributeDefaults:
+    defaults: DbcAttributeDefaults = OrderedDict()
 
-    for default_attr in tokens.get('BA_DEF_DEF_REL_', []):
-        defaults[default_attr[1]] = default_attr[2]
+    for _default_attr in tokens.get('BA_DEF_DEF_REL_', []):
+        default_attr = dbc_assert_type(_default_attr, list)
+        defaults[dbc_assert_type(default_attr[1], str)] = typing.cast('AttributeValue', default_attr[2])
 
     return defaults
 
 
-def _load_attributes(tokens, definitions):
+def _load_attributes(tokens: DbcTokens, definitions: OrderedDict[str, AttributeDefinitionType]) -> DbcAttributes:
     attributes = DbcAttributes()
 
-    def to_attribute_object(attribute_tokens):
-        raw_value = attribute_tokens[3]
-        definition = definitions[attribute_tokens[1]]
+    def to_attribute_object(attribute_tokens: TokenList) -> AttributeType:
+        raw_value = dbc_assert_type(attribute_tokens[3], str)
+        definition = definitions[dbc_assert_type(attribute_tokens[1], str)]
 
         if definition.type_name in ['INT', 'HEX', 'ENUM']:
             return Attribute[int](value=to_int(raw_value),
-                                  definition=definition)
+                                  definition=typing.cast('AttributeDefinition[int]', definition))
         elif definition.type_name == 'FLOAT':
             return Attribute[float](value=to_float(raw_value),
-                                    definition=definition)
+                                    definition=typing.cast('AttributeDefinition[float]', definition))
 
         return Attribute[str](value=raw_value,
-                              definition=definition)
+                              definition=typing.cast('AttributeDefinition[str]', definition))
 
-    for attribute_tokens in tokens.get('BA_', []):
-        attribute_name = attribute_tokens[1]
+    for _attribute_tokens in tokens.get('BA_', []):
+        attribute_tokens = dbc_assert_type(_attribute_tokens, list)
+        attribute_name = dbc_assert_type(attribute_tokens[1], str)
 
+        if not isinstance(attribute_tokens[2], list):
+            raise ParseError('Second token of attribute must be a list, '
+                             f'got {type(attribute_tokens[2]).__name__}')
         if len(attribute_tokens[2]) > 0:
-            attribute_items = attribute_tokens[2][0]
-            attribute_kind = attribute_items[0]
+            attribute_items = dbc_assert_type(dbc_assert_type(attribute_tokens[2], list)[0], list)
+            attribute_kind = dbc_assert_type(attribute_items[0], str)
 
             if attribute_kind == 'SG_':
-                frame_id_dbc = int(attribute_items[1])
+                frame_id_dbc = int(dbc_assert_type(attribute_items[1], str))
 
                 if frame_id_dbc not in attributes.signals:
                     attributes.signals[frame_id_dbc] = OrderedDict()
                 message_signal_attrs = attributes.signals[frame_id_dbc]
 
-                signal_name = attribute_items[2]
+                signal_name = dbc_assert_type(attribute_items[2], str)
                 if signal_name not in message_signal_attrs:
                     message_signal_attrs[signal_name] = OrderedDict()
                 signal_attrs = message_signal_attrs[signal_name]
 
                 signal_attrs[attribute_name] = to_attribute_object(attribute_tokens)
             elif attribute_kind == 'BO_':
-                frame_id_dbc = int(attribute_items[1])
+                frame_id_dbc = int(dbc_assert_type(attribute_items[1], str))
 
                 if frame_id_dbc not in attributes.messages:
                     attributes.messages[frame_id_dbc] = OrderedDict()
@@ -1267,13 +1327,13 @@ def _load_attributes(tokens, definitions):
 
                 message_attrs[attribute_name] = to_attribute_object(attribute_tokens)
             elif attribute_kind == 'BU_':
-                node_name = attribute_items[1]
+                node_name = dbc_assert_type(attribute_items[1], str)
 
                 if node_name not in attributes.nodes:
                     attributes.nodes[node_name] = OrderedDict()
                 attributes.nodes[node_name][attribute_name] = to_attribute_object(attribute_tokens)
             elif attribute_kind == 'EV_':
-                envvar_name = attribute_items[1]
+                envvar_name = dbc_assert_type(attribute_items[1], str)
 
                 if envvar_name not in attributes.envvars:
                     attributes.envvars[envvar_name] = OrderedDict()
@@ -1287,28 +1347,31 @@ def _load_attributes(tokens, definitions):
     return attributes
 
 
-def _load_relation_attributes(tokens, definitions):
+def _load_relation_attributes(tokens: DbcTokens, definitions: OrderedDict[str, AttributeDefinitionType]) -> DbcRelationAttributes:
     relation_attributes = DbcRelationAttributes()
 
-    def to_relation_attribute_object(attribute, value):
-        definition = definitions[attribute[1]]
+    def to_relation_attribute_object(attribute_tokens: TokenList, value: AttributeValue) -> AttributeType:
+        definition = definitions[dbc_assert_type(attribute_tokens[1], str)]
 
         if definition.type_name in ['INT', 'HEX', 'ENUM']:
-            value = to_int(value)
+            return Attribute[int](value=to_int(value),
+                                  definition=typing.cast('AttributeDefinition[int]', definition))
         elif definition.type_name == 'FLOAT':
-            value = to_float(value)
+            return Attribute[float](value=to_float(value),
+                                    definition=typing.cast('AttributeDefinition[float]', definition))
+        else:
+            return Attribute[str](str(value),
+                                  definition=typing.cast('AttributeDefinition[str]', definition))
 
-        return Attribute(value=value,
-                         definition=definition)
-
-    for relation_attribute_tokens in tokens.get('BA_REL_', []):
-        attribute_name = relation_attribute_tokens[1]
-        relation_type = relation_attribute_tokens[2]
-        node_name = relation_attribute_tokens[3]
+    for _relation_attribute_tokens in tokens.get('BA_REL_', []):
+        relation_attribute_tokens = dbc_assert_type(_relation_attribute_tokens, list)
+        attribute_name = dbc_assert_type(relation_attribute_tokens[1], str)
+        relation_type = dbc_assert_type(relation_attribute_tokens[2], str)
+        node_name = dbc_assert_type(relation_attribute_tokens[3], str)
 
         if relation_type == 'BU_SG_REL_':
-            frame_id_dbc = int(relation_attribute_tokens[5])
-            signal_name = relation_attribute_tokens[6]
+            frame_id_dbc = int(dbc_assert_type(relation_attribute_tokens[5], str))
+            signal_name = dbc_assert_type(relation_attribute_tokens[6], str)
 
             if frame_id_dbc not in relation_attributes.node_signal_relations:
                 relation_attributes.node_signal_relations[frame_id_dbc] = OrderedDict()
@@ -1318,10 +1381,10 @@ def _load_relation_attributes(tokens, definitions):
                 relation_attributes.node_signal_relations[frame_id_dbc][signal_name][node_name] = OrderedDict()
 
             relation_attributes.node_signal_relations[frame_id_dbc][signal_name][node_name][attribute_name] = \
-                to_relation_attribute_object(relation_attribute_tokens, relation_attribute_tokens[7])
+                to_relation_attribute_object(relation_attribute_tokens, dbc_assert_type(relation_attribute_tokens[7], str))
 
         elif relation_type == 'BU_BO_REL_':
-            frame_id_dbc = int(relation_attribute_tokens[4])
+            frame_id_dbc = int(dbc_assert_type(relation_attribute_tokens[4], str))
 
             if frame_id_dbc not in relation_attributes.node_message_relations:
                 relation_attributes.node_message_relations[frame_id_dbc] = OrderedDict()
@@ -1329,185 +1392,203 @@ def _load_relation_attributes(tokens, definitions):
                 relation_attributes.node_message_relations[frame_id_dbc][node_name] = OrderedDict()
 
             relation_attributes.node_message_relations[frame_id_dbc][node_name][attribute_name] = \
-                to_relation_attribute_object(relation_attribute_tokens, relation_attribute_tokens[5])
+                to_relation_attribute_object(relation_attribute_tokens, dbc_assert_type(relation_attribute_tokens[5], str))
 
     return relation_attributes
 
 
-def _load_value_tables(tokens):
+def _load_value_tables(tokens: DbcTokens) -> OrderedDict[str, Choices]:
     """Load value tables, that is, choice definitions.
 
     """
 
-    value_tables = OrderedDict()
+    value_tables: OrderedDict[str, Choices] = OrderedDict()
 
-    for value_table in tokens.get('VAL_TABLE_', []):
-        name = value_table[1]
-        choices = {int(number): NamedSignalValue(int(number), text) for number, text in value_table[2]}
-        value_tables[name] = choices
+    for _value_table in tokens.get('VAL_TABLE_', []):
+        value_table = dbc_assert_type(_value_table, list)
+        name = dbc_assert_type(value_table[1], str)
+        number_text_pairs = dbc_assert_type(value_table[2], list)
+        value_tables[name] = OrderedDict((int(number), NamedSignalValue(int(number), text))
+                                         for number, text in number_text_pairs)
 
     return value_tables
 
 
-def _load_environment_variables(tokens, comments, attributes, attribute_definitions):
-    environment_variables = OrderedDict()
+def _load_environment_variables(tokens: DbcTokens, comments: DbcComments, attributes: DbcAttributes, attribute_definitions: OrderedDict[str, AttributeDefinitionType]) -> OrderedDict[str, EnvironmentVariable]:
+    environment_variables: OrderedDict[str, EnvironmentVariable] = OrderedDict()
 
-    for envvar_tokens in tokens.get('EV_', []):
-        short_name = envvar_tokens[1]
+    for _envvar_tokens in tokens.get('EV_', []):
+        envvar_tokens = dbc_assert_type(_envvar_tokens, list)
+        short_name = dbc_assert_type(envvar_tokens[1], str)
         long_name = _get_envvar_long_name(attributes, short_name)
         environment_variables[long_name] = EnvironmentVariable(
             name=long_name,
-            env_type=int(envvar_tokens[3]),
-            minimum=num(envvar_tokens[5]),
-            maximum=num(envvar_tokens[7]),
-            unit=envvar_tokens[9],
-            initial_value=num(envvar_tokens[10]),
-            env_id=int(envvar_tokens[11]),
-            access_type=envvar_tokens[12],
-            access_node=envvar_tokens[13],
+            env_type=int(dbc_assert_type(envvar_tokens[3], str)),
+            minimum=num(dbc_assert_type(envvar_tokens[5], str)),
+            maximum=num(dbc_assert_type(envvar_tokens[7], str)),
+            unit=dbc_assert_type(envvar_tokens[9], str),
+            initial_value=num(dbc_assert_type(envvar_tokens[10], str)),
+            env_id=int(dbc_assert_type(envvar_tokens[11], str)),
+            access_type=dbc_assert_type(envvar_tokens[12], str),
+            access_node=dbc_assert_type(envvar_tokens[13], str),
             comment=comments.envvars.get(short_name),
             dbc_specifics=DbcSpecifics(attributes=attributes.envvars.get(short_name),
                                        attribute_definitions=attribute_definitions))
 
     return environment_variables
 
-def _load_choices(tokens):
-    choices = defaultdict(dict)
+def _load_choices(tokens: DbcTokens) -> ChoicesDict:
+    choices: ChoicesDict = defaultdict(dict)
 
-    for choice_tokens in tokens.get('VAL_', []):
-        if len(choice_tokens[1]) == 0:
+    for _choice_tokens in tokens.get('VAL_', []):
+        choice_tokens = dbc_assert_type(_choice_tokens, list)
+        frame_id_list = dbc_assert_type(choice_tokens[1], list)
+        if len(frame_id_list) == 0:
             continue
 
-        od = OrderedDict((int(v[0]), NamedSignalValue(int(v[0]), v[1])) for v in choice_tokens[3])
+        pairs = dbc_assert_type(choice_tokens[3], list)
+        od: Choices = OrderedDict((int(v[0]), NamedSignalValue(int(v[0]), v[1])) for v in pairs)
 
         if len(od) == 0:
             continue
 
-        frame_id = int(choice_tokens[1][0])
-        choices[frame_id][choice_tokens[2]] = od
+        frame_id = int(frame_id_list[0])
+        choices[frame_id][dbc_assert_type(choice_tokens[2], str)] = od
 
     return choices
 
-def _load_message_senders(tokens, attributes):
+def _load_message_senders(tokens: DbcTokens, attributes: DbcAttributes) -> defaultdict[int, list[str]]:
     """Load additional message senders.
 
     """
 
-    message_senders = defaultdict(list)
+    message_senders: defaultdict[int, list[str]] = defaultdict(list)
 
-    for senders in tokens.get('BO_TX_BU_', []):
-        frame_id = int(senders[1])
+    for _senders in tokens.get('BO_TX_BU_', []):
+        senders = dbc_assert_type(_senders, list)
+        frame_id = int(dbc_assert_type(senders[1], str))
         message_senders[frame_id] += [
-            _get_node_long_name(attributes, sender) for sender in senders[3]
+            _get_node_long_name(attributes, sender) for sender in dbc_assert_type(senders[3], list)
         ]
 
     return message_senders
 
 
-def _load_signal_types(tokens):
+def _load_signal_types(tokens: DbcTokens) -> defaultdict[int, dict[str, int]]:
     """Load signal types.
 
     """
 
-    signal_types = defaultdict(dict)
+    signal_types: defaultdict[int, dict[str, int]] = defaultdict(dict)
 
-    for signal_type in tokens.get('SIG_VALTYPE_', []):
-        frame_id = int(signal_type[1])
-        signal_name = signal_type[2]
-        signal_types[frame_id][signal_name] = int(signal_type[4])
+    for _signal_type in tokens.get('SIG_VALTYPE_', []):
+        signal_type = dbc_assert_type(_signal_type, list)
+        frame_id = int(dbc_assert_type(signal_type[1], str))
+        signal_name = dbc_assert_type(signal_type[2], str)
+        signal_types[frame_id][signal_name] = int(dbc_assert_type(signal_type[4], str))
 
     return signal_types
 
 
-def _load_signal_multiplexer_values(tokens):
+def _load_signal_multiplexer_values(tokens: DbcTokens) -> MuxValues:
     """Load additional signal multiplexer values.
 
     """
 
-    signal_multiplexer_values = defaultdict(dict)
+    signal_multiplexer_values: MuxValues = defaultdict(dict)
 
-    for signal_multiplexer_value in tokens.get('SG_MUL_VAL_', []):
-        frame_id = int(signal_multiplexer_value[1])
-        signal_name = signal_multiplexer_value[2]
-        multiplexer_signal = signal_multiplexer_value[3]
-        multiplexer_ids = []
+    for _signal_multiplexer_value in tokens.get('SG_MUL_VAL_', []):
+        signal_multiplexer_value = dbc_assert_type(_signal_multiplexer_value, list)
+        frame_id = int(dbc_assert_type(signal_multiplexer_value[1], str))
+        signal_name = dbc_assert_type(signal_multiplexer_value[2], str)
+        multiplexer_signal_name = dbc_assert_type(signal_multiplexer_value[3], str)
+        multiplexer_ids: list[int] = []
 
-        for lower, upper in signal_multiplexer_value[4]:
-            lower = int(lower)
-            upper = int(upper[1:])
+        for lower_str, upper_str in dbc_assert_type(signal_multiplexer_value[4], list):
+            lower = int(lower_str)
+            upper = int(upper_str[1:])
             # TODO: Probably store ranges as tuples to not run out of
             #       memory on huge ranges.
             multiplexer_ids.extend(range(lower, upper + 1))
 
-        if multiplexer_signal not in signal_multiplexer_values[frame_id]:
-            signal_multiplexer_values[frame_id][multiplexer_signal] = {}
-
-        multiplexer_signal = signal_multiplexer_values[frame_id][multiplexer_signal]
+        multiplexer_signal = signal_multiplexer_values[frame_id].setdefault(multiplexer_signal_name, {})
         multiplexer_signal[signal_name] = multiplexer_ids
 
     return signal_multiplexer_values
 
 
-def _load_signal_groups(tokens, attributes):
+def _load_signal_groups(tokens: DbcTokens, attributes: DbcAttributes) -> defaultdict[int, list[SignalGroup]]:
     """Load signal groups.
 
     """
 
-    signal_groups = defaultdict(list)
+    signal_groups: defaultdict[int, list[SignalGroup]] = defaultdict(list)
 
-
-    def get_signal_attributes(frame_id_dbc, signal_short_name):
+    def get_signal_attributes(frame_id_dbc: int, signal_short_name: str) -> DbcAttributeMap:
         """Get attributes for given signal.
 
         """
 
-        return attributes.signals.get(frame_id_dbc, EMPTY_DICT).get(signal_short_name, EMPTY_DICT)
+        message_signal_attribs: dict[str, DbcAttributeMap]|None = attributes.signals.get(frame_id_dbc)
+        if message_signal_attribs is None:
+            return OrderedDict()
 
-    def get_signal_long_name(frame_id_dbc, signal_short_name):
+        if (signal_attribs := message_signal_attribs.get(signal_short_name)) is not None:
+            return signal_attribs
+
+        return OrderedDict()
+
+    def get_signal_long_name(frame_id_dbc: int, signal_short_name: str) -> str:
         signal_attributes = get_signal_attributes(frame_id_dbc, signal_short_name)
         if (attrib := signal_attributes.get('SystemSignalLongSymbol')) is not None:
             return str(attrib.value)
 
         return signal_short_name
 
-    for signal_group in tokens.get('SIG_GROUP_',[]):
-        frame_id = int(signal_group[1])
-        signal_names = [get_signal_long_name(frame_id, signal_short_name) for signal_short_name in signal_group[5]]
-        signal_groups[frame_id].append(SignalGroup(name=signal_group[2],
-                                                   repetitions=int(signal_group[3]),
+    for _signal_group in tokens.get('SIG_GROUP_',[]):
+        signal_group = dbc_assert_type(_signal_group, list)
+        frame_id = int(dbc_assert_type(signal_group[1], str))
+        signal_names = [get_signal_long_name(frame_id, sn) for sn in dbc_assert_type(signal_group[5], list)]
+        signal_groups[frame_id].append(SignalGroup(name=dbc_assert_type(signal_group[2], str),
+                                                   repetitions=int(dbc_assert_type(signal_group[3], str)),
                                                    signal_names=signal_names))
 
     return signal_groups
 
 
-def _load_signals(tokens,
-                  comments,
-                  attributes,
-                  definitions,
-                  choices,
-                  signal_types,
-                  signal_multiplexer_values,
-                  frame_id_dbc,
-                  multiplexer_signal):
-    signal_to_multiplexer = {}
+def _load_signals(tokens: list[MatchObject],
+                  comments: DbcComments,
+                  attributes: DbcAttributes,
+                  definitions: OrderedDict[str, AttributeDefinitionType] | None,
+                  choices: ChoicesDict,
+                  signal_types: dict[int, dict[str, int]],
+                  signal_multiplexer_values: MuxValues,
+                  frame_id_dbc: int,
+                  multiplexer_signal: str | None) -> list[Signal]:
+    multiplexer_of_signal: dict[str, str] = {}
 
-    frame_mux_values = signal_multiplexer_values.get(frame_id_dbc, EMPTY_DICT)
+    frame_mux_values: MuxSignalValues|None = signal_multiplexer_values.get(frame_id_dbc)
+    if frame_mux_values is None:
+        frame_mux_values = MuxSignalValues()
+
     for multiplexer_name, items in frame_mux_values.items():
         for name in items:
-            signal_to_multiplexer[name] = multiplexer_name
-    signal_multiplexer_values = frame_mux_values
+            multiplexer_of_signal[name] = multiplexer_name
 
-    def get_signal_attributes(frame_id_dbc, signal_name):
+    def get_signal_attributes(frame_id_dbc: int, signal_short_name: str) -> DbcAttributeMap:
         """Get attributes for given signal.
 
         """
-        if (msg_sig_attribs := attributes.signals.get(frame_id_dbc)) is not None and \
-           (sig_attribs := msg_sig_attribs.get(signal_name)) is not None:
-            return sig_attribs
+        message_signal_attribs: dict[str, DbcAttributeMap]|None = attributes.signals.get(frame_id_dbc)
+        if message_signal_attribs is None:
+            return OrderedDict()
 
-        return EMPTY_DICT
+        if (signal_attribs := message_signal_attribs.get(signal_short_name)) is not None:
+            return signal_attribs
 
-    def get_signal_comment(frame_id_dbc, signal_name):
+        return OrderedDict()
+
+    def get_signal_comment(frame_id_dbc: int, signal_name: str) -> str | None:
         """Get comment for given signal.
 
         """
@@ -1515,35 +1596,49 @@ def _load_signals(tokens,
         if message_signal_comments is None:
             return None
         return message_signal_comments.get(signal_name)
-
-    def get_signal_choices(frame_id_dbc, signal):
+    def get_signal_choices(frame_id_dbc: int, signal_name: str) -> Choices | None:
         """Get choices for given signal.
 
         """
+        message_choices = choices.get(frame_id_dbc)
+        if message_choices is None:
+            return None
 
-        return choices.get(frame_id_dbc, EMPTY_DICT).get(signal)
+        return message_choices.get(signal_name)
 
-    def get_signal_is_multiplexer(signal):
-        if len(signal[1]) == 2:
-            return signal[1][1].endswith('M')
+    def get_signal_is_multiplexer(signal_tokens: TokenList) -> bool:
+        mux_field = dbc_assert_type(signal_tokens[1], list)
+        if len(mux_field) == 2:
+            # normal signal -> mux marker == None
+            # multiplexer signal -> mux marker == 'M'
+            # multiplexed signal -> mux marker == 'm<multiplexer_id>'
+            mux_marker = dbc_assert_type(mux_field[1], str)
+            return mux_marker.endswith('M')
         else:
             return False
 
-    def get_signal_multiplexer_ids(signal, multiplexer_signal):
-        ids = []
+    def get_signal_multiplexer_ids(mux_field: list[str], multiplexer_signal_name: str | None) -> list[int] | None:
+        ids: list[int] = []
 
-        if multiplexer_signal is not None:
-            if len(signal) == 2 and not signal[1].endswith('M'):
-                value = signal[1][1:].rstrip('M')
-                ids.append(int(value))
+        # determine the name of the multiplexer signal for the given
+        # payload signal
+        if multiplexer_signal_name is not None:
+            if len(mux_field) == 2:
+                mux_marker = mux_field[1]
+                if not mux_marker.endswith('M'):
+                    assert mux_marker.startswith('m'), ParseError("multiplexed signals must specify a m<ID> as their multiplexer marker")
+                    ids.append(int(mux_field[1][1:]))
         else:
-            multiplexer_signal = get_multiplexer_signal(signal,
-                                                        multiplexer_signal)
+            multiplexer_signal_name = multiplexer_of_signal.get(signal_name)
 
-        if multiplexer_signal is not None:
-            mux_entry = signal_multiplexer_values.get(multiplexer_signal)
-            if mux_entry is not None and signal[0] in mux_entry:
-                ids.extend(mux_entry[signal[0]])
+        # if we did not find a multiplexer which contains the signal
+        # of interest, return None
+        if multiplexer_signal_name is None:
+            return None
+
+        mux_entry = frame_mux_values.get(multiplexer_signal_name)
+        if mux_entry is not None and signal_name in mux_entry:
+            ids.extend(mux_entry[signal_name])
 
         if ids:
             # make the IDs unique (and sort them)
@@ -1551,37 +1646,40 @@ def _load_signals(tokens,
 
         return None
 
-    def get_multiplexer_signal(mux_field, multiplexer_signal_name):
+    def get_multiplexer_signal_name(mux_field: list[str], multiplexer_signal_name: str | None) -> str | None:
         if len(mux_field) != 2:
+            # non-multiplexed signal
             return None
 
         signal_name = mux_field[0]
-        if multiplexer_signal is None:
-            return signal_to_multiplexer.get(signal_name)
+        if multiplexer_signal_name is None:
+            return multiplexer_of_signal.get(signal_name)
         elif signal_name != multiplexer_signal_name:
             return multiplexer_signal_name
 
+        # the multiplexer signal itself is not one of the signals
+        # which it multiplexes
         return None
 
-    def get_signal_receivers(receivers):
+    def get_signal_receivers(receivers: list[str]) -> list[str]:
         if receivers == ['Vector__XXX']:
             receivers = []
 
         return [_get_node_long_name(attributes, receiver) for receiver in receivers]
 
-    def get_signal_minimum(minimum, maximum):
+    def get_signal_minimum(minimum: str, maximum: str) -> int | float | None:
         if minimum == maximum == '0':
             return None
         else:
             return num(minimum)
 
-    def get_signal_maximum(minimum, maximum):
+    def get_signal_maximum(minimum: str, maximum: str) -> int | float | None:
         if minimum == maximum == '0':
             return None
         else:
             return num(maximum)
 
-    def get_signal_is_float(frame_id_dbc, signal):
+    def get_signal_is_float(frame_id_dbc: int, signal: str) -> bool:
         """Get is_float for given signal.
 
         """
@@ -1589,67 +1687,77 @@ def _load_signals(tokens,
         frame_signal_types = signal_types.get(frame_id_dbc)
         if frame_signal_types is None:
             return False
-        return frame_signal_types.get(signal) in FLOAT_SIGNAL_TYPES
+        signal_type = frame_signal_types.get(signal)
+        return signal_type in FLOAT_SIGNAL_TYPES
 
-    def get_signal_name(frame_id_dbc, name):
-        signal_attributes = get_signal_attributes(frame_id_dbc, name)
+    def get_signal_long_name(frame_id_dbc: int, signal_short_name: str) -> str:
+        signal_attributes = get_signal_attributes(frame_id_dbc, signal_short_name)
+        if signal_attributes is None:
+            return signal_short_name
 
-        attrib = signal_attributes.get('SystemSignalLongSymbol')
-        if attrib is not None:
+        if (attrib := signal_attributes.get('SystemSignalLongSymbol')) is not None:
+            return str(attrib.value)
+
+        return signal_short_name
+
+    def get_signal_initial_value(frame_id_dbc: int, signal_short_name: str) -> int | float | None:
+        signal_attributes = get_signal_attributes(frame_id_dbc, signal_short_name)
+        if signal_attributes is None:
+            return None
+
+        if (attrib := signal_attributes.get('GenSigStartValue')) is not None:
+            if not isinstance(attrib.value, (int, float)):
+                raise ParseError(
+                    f'Expected int or float, got {type(attrib.value).__name__}: {attrib.value!r}')
+
             return attrib.value
-        return name
 
-    def get_signal_initial_value(frame_id_dbc, name):
-        signal_attributes = get_signal_attributes(frame_id_dbc, name)
-
-        attrib = signal_attributes.get('GenSigStartValue')
-        if attrib is not None:
-            return attrib.value
         return None
 
-    def get_signal_spn(frame_id_dbc, name):
+    def get_signal_spn(frame_id_dbc: int, name: str) -> int | None:
         signal_attributes = get_signal_attributes(frame_id_dbc, name)
-        if 'SPN' in signal_attributes and \
-           (value := signal_attributes['SPN'].value) is not None:
-            return value
+        if signal_attributes is None:
+            return None
+        elif (spn_attrib := signal_attributes.get('SPN')) is not None:
+            return dbc_assert_type(spn_attrib.value, int)
 
         if definitions is not None and 'SPN' in definitions:
-            return definitions['SPN'].default_value
+            return typing.cast('int | None', definitions['SPN'].default_value)
 
         return None
 
     signals = []
 
-    for signal in tokens:
+    for _signal_tokens in tokens:
+        signal_tokens = dbc_assert_type(_signal_tokens, list)
+        mux_field = dbc_assert_type(signal_tokens[1], list)
+        signal_name = mux_field[0]
         signals.append(
-            Signal(name=get_signal_name(frame_id_dbc, signal[1][0]),
-                   start=int(signal[3]),
-                   length=int(signal[5]),
-                   receivers=get_signal_receivers(signal[20]),
+            Signal(name=get_signal_long_name(frame_id_dbc, signal_name),
+                   start=int(dbc_assert_type(signal_tokens[3], str)),
+                   length=int(dbc_assert_type(signal_tokens[5], str)),
+                   receivers=get_signal_receivers(dbc_assert_type(signal_tokens[20], list)),
                    byte_order=('big_endian'
-                               if signal[7] == '0'
+                               if signal_tokens[7] == '0'
                                else 'little_endian'),
-                   is_signed=(signal[8] == '-'),
-                   raw_initial=get_signal_initial_value(frame_id_dbc, signal[1][0]),
+                   is_signed=(signal_tokens[8] == '-'),
+                   raw_initial=get_signal_initial_value(frame_id_dbc, signal_name),
                    conversion=BaseConversion.factory(
-                       scale=num(signal[10]),
-                       offset=num(signal[12]),
-                       is_float=get_signal_is_float(frame_id_dbc, signal[1][0]),
-                       choices=get_signal_choices(frame_id_dbc, signal[1][0]),
+                       scale=num(dbc_assert_type(signal_tokens[10], str)),
+                       offset=num(dbc_assert_type(signal_tokens[12], str)),
+                       is_float=get_signal_is_float(frame_id_dbc, signal_name),
+                       choices=get_signal_choices(frame_id_dbc, signal_name),
                    ),
-                   minimum=get_signal_minimum(signal[15], signal[17]),
-                   maximum=get_signal_maximum(signal[15], signal[17]),
-                   unit=(None if signal[19] == '' else signal[19]),
-                   spn=get_signal_spn(frame_id_dbc, signal[1][0]),
-                   dbc_specifics=DbcSpecifics(attributes=get_signal_attributes(frame_id_dbc, signal[1][0]),
+                   minimum=get_signal_minimum(dbc_assert_type(signal_tokens[15], str), dbc_assert_type(signal_tokens[17], str)),
+                   maximum=get_signal_maximum(dbc_assert_type(signal_tokens[15], str), dbc_assert_type(signal_tokens[17], str)),
+                   unit=(None if signal_tokens[19] == '' else dbc_assert_type(signal_tokens[19], str)),
+                   spn=get_signal_spn(frame_id_dbc, signal_name),
+                   dbc_specifics=DbcSpecifics(attributes=get_signal_attributes(frame_id_dbc, signal_name),
                                               attribute_definitions=definitions),
-                   comment=get_signal_comment(frame_id_dbc,
-                                              signal[1][0]),
-                   is_multiplexer=get_signal_is_multiplexer(signal),
-                   multiplexer_ids=get_signal_multiplexer_ids(signal[1],
-                                                       multiplexer_signal),
-                   multiplexer_signal=get_multiplexer_signal(signal[1],
-                                                             multiplexer_signal)))
+                   comment=get_signal_comment(frame_id_dbc, signal_name),
+                   is_multiplexer=get_signal_is_multiplexer(signal_tokens),
+                   multiplexer_ids=get_signal_multiplexer_ids(mux_field, multiplexer_signal),
+                   multiplexer_signal=get_multiplexer_signal_name(mux_field, multiplexer_signal)))
 
     return signals
 
@@ -1664,40 +1772,41 @@ def _get_enum_vframeformat_definition(attribute_definition: AttributeDefinitionT
     """
 
     if attribute_definition.type_name != 'INT':
-        return typing.cast('AttributeDefinition[str]', attribute_definition)
+        return dbc_assert_type(attribute_definition, AttributeDefinition)
 
     default_value = attribute_definition.default_value
-    assert default_value is not None, 'Default value for VFrameFormat attribute must be defined if the attribute is defined as an INT.'
-    assert isinstance(default_value, int)
+    if default_value is None:
+        raise ParseError('Default value for VFrameFormat attribute must be defined '
+                         'if the attribute is defined as an INT.')
     enum_attribute = deepcopy(ATTRIBUTE_DEFINITION_VFRAMEFORMAT)
-    enum_attribute.default_value = enum_attribute.choices[default_value]
+    enum_attribute.default_value = enum_attribute.choices[int(default_value)]
 
     return enum_attribute
 
-def _load_messages(tokens,
-                   comments,
-                   attributes,
-                   definitions,
-                   choices,
-                   message_senders,
-                   signal_types,
-                   signal_multiplexer_values,
-                   strict,
-                   bus_name,
-                   signal_groups,
-                   sort_signals):
+def _load_messages(tokens: DbcTokens,
+                   comments: DbcComments,
+                   attributes: DbcAttributes,
+                   definitions: OrderedDict[str, AttributeDefinitionType],
+                   choices: ChoicesDict,
+                   message_senders: dict[int, list[str]],
+                   signal_types: dict[int, dict[str, int]],
+                   signal_multiplexer_values: MuxValues,
+                   strict: bool,
+                   bus_name: str | None,
+                   signal_groups: dict[int, list[SignalGroup]],
+                   sort_signals: type_sort_signals) -> list[Message]:
     """Load messages.
 
     """
 
-    def get_message_attributes(frame_id_dbc: int) -> typing.Any:
+    def get_message_attributes(frame_id_dbc: int) -> DbcAttributeMap | None:
         """Get attributes for given message.
 
         """
 
         return attributes.messages.get(frame_id_dbc)
 
-    def get_message_comment(frame_id_dbc):
+    def get_message_comment(frame_id_dbc: int) -> str | None:
         """Get comment for given message.
 
         """
@@ -1709,20 +1818,23 @@ def _load_messages(tokens,
 
         """
 
-        result = None
-        message_attributes = get_message_attributes(frame_id_dbc)
-
         send_type_def = definitions.get('GenMsgSendType')
         if send_type_def is None:
             return None
+
+        result: str | None = None
+        message_attributes = get_message_attributes(frame_id_dbc)
         if message_attributes is not None:
             send_type_attr = message_attributes.get('GenMsgSendType')
             if send_type_attr is not None:
-                result = send_type_attr.value
-                if send_type_def.choices and result is not None:
-                    result = send_type_def.choices[int(result)]
-        if result is None and (tmp := send_type_def.default_value) is not None:
-            result = str(tmp)
+                raw_result = send_type_attr.value
+                if send_type_def.choices and raw_result is not None:
+                    result = send_type_def.choices[int(raw_result)]
+                else:
+                    result = dbc_assert_type(raw_result, str)
+
+        if result is None and send_type_def.default_value is not None:
+            result = dbc_assert_type(send_type_def.default_value, str)
 
         return result
 
@@ -1739,9 +1851,9 @@ def _load_messages(tokens,
         if message_attributes:
             gen_msg_cycle_time_attr = message_attributes.get('GenMsgCycleTime')
             if gen_msg_cycle_time_attr:
-                return gen_msg_cycle_time_attr.value or None
+                return typing.cast('int | None', gen_msg_cycle_time_attr.value or None)
 
-        return gen_msg_cycle_time_def.default_value or None
+        return typing.cast('int | None', gen_msg_cycle_time_def.default_value or None)
 
 
     def get_message_frame_format(frame_id_dbc: int) -> str | None:
@@ -1757,9 +1869,9 @@ def _load_messages(tokens,
         frame_format: str | None
         if message_attributes is not None and 'VFrameFormat' in message_attributes:
             frame_format_choice = message_attributes['VFrameFormat'].value
-            frame_format = ref_definitions.choices[frame_format_choice]
-        else:
-            frame_format = ref_definitions.default_value
+            frame_format = ref_definitions.choices[dbc_assert_type(frame_format_choice, int)]
+        elif ref_definitions.default_value is not None:
+            frame_format = str(ref_definitions.default_value)
 
         return frame_format
 
@@ -1780,22 +1892,24 @@ def _load_messages(tokens,
 
         if message_attributes is not None and 'SystemMessageLongSymbol' in message_attributes:
             return str(message_attributes['SystemMessageLongSymbol'].value)
+
         return message_short_name
 
-    def get_message_signal_groups(frame_id_dbc):
+    def get_message_signal_groups(frame_id_dbc: int) -> list[SignalGroup] | None:
         return signal_groups.get(frame_id_dbc)
 
     messages = []
 
-    for message in tokens.get('BO_', []):
+    for _message_tokens in tokens.get('BO_', []):
+        message_tokens = dbc_assert_type(_message_tokens, list)
         # Any message named VECTOR__INDEPENDENT_SIG_MSG contains
         # signals not assigned to any message. Cantools does not yet
         # support unassigned signals. Discard them for now.
-        if message[2] == 'VECTOR__INDEPENDENT_SIG_MSG':
+        if message_tokens[2] == 'VECTOR__INDEPENDENT_SIG_MSG':
             continue
 
         # Frame id.
-        frame_id_dbc = int(message[1])
+        frame_id_dbc = int(dbc_assert_type(message_tokens[1], str))
         frame_id = frame_id_dbc & 0x7fffffff
         is_extended_frame = bool(frame_id_dbc & 0x80000000)
         frame_format = get_message_frame_format(frame_id_dbc)
@@ -1805,7 +1919,7 @@ def _load_messages(tokens,
             is_fd = False
 
         # Senders.
-        senders = [_get_node_long_name(attributes, message[5])]
+        senders = [_get_node_long_name(attributes, dbc_assert_type(message_tokens[5], str))]
 
         for node in message_senders.get(frame_id_dbc, []):
             if node not in senders:
@@ -1815,17 +1929,20 @@ def _load_messages(tokens,
             senders = []
 
         # Signal multiplexing.
-        multiplexer_signal = None
+        multiplexer_signal: str | None = None
 
-        for signal in message[6]:
-            if len(signal[1]) == 2 and signal[1][1].endswith('M'):
+        for _signal_tokens in dbc_assert_type(message_tokens[6], list):
+            signal_tokens = dbc_assert_type(_signal_tokens, list)
+            mux_field = dbc_assert_type(signal_tokens[1], list)
+            if len(mux_field) == 2 and mux_field[1].endswith('M'):
                 if multiplexer_signal is None:
-                    multiplexer_signal = signal[1][0]
+                    multiplexer_signal = mux_field[0]
                 else:
                     multiplexer_signal = None
                     break
 
-        signals = _load_signals(message[6],
+        all_signals_tokens = dbc_assert_type(message_tokens[6], list)
+        signals = _load_signals(all_signals_tokens,
                                 comments,
                                 attributes,
                                 definitions,
@@ -1838,8 +1955,8 @@ def _load_messages(tokens,
         messages.append(
             Message(frame_id=frame_id,
                     is_extended_frame=is_extended_frame,
-                    name=get_message_long_name(frame_id_dbc, message[2]),
-                    length=int(message[4], 0),
+                    name=get_message_long_name(frame_id_dbc, dbc_assert_type(message_tokens[2], str)),
+                    length=int(dbc_assert_type(message_tokens[4], str), 0),
                     senders=senders,
                     send_type=get_message_send_type(frame_id_dbc),
                     cycle_time=get_message_cycle_time(frame_id_dbc),
@@ -1858,20 +1975,23 @@ def _load_messages(tokens,
     return messages
 
 
-def _load_version(tokens):
-    return tokens.get('VERSION', [[None, None]])[0][1]
+def _load_version(tokens: DbcTokens) -> str | None:
+    version_tokens = tokens.get('VERSION', [])
+    if not version_tokens:
+        return None
+    return typing.cast('str | None', dbc_assert_type(version_tokens[0], list)[1])
 
 
-def _load_bus(attributes, comments):
+def _load_bus(attributes: DbcAttributes, comments: DbcComments) -> Bus | None:
     bus_name_attr = attributes.database.get('DBName')
     bus_name = ''
     if bus_name_attr is not None:
-        bus_name = bus_name_attr.value
+        bus_name = dbc_assert_type(bus_name_attr.value, str)
 
     bus_baudrate_attr = attributes.database.get('Baudrate')
     bus_baudrate = None
     if bus_baudrate_attr is not None:
-        bus_baudrate = bus_baudrate_attr.value
+        bus_baudrate = dbc_assert_type(bus_baudrate_attr.value, int)
 
     bus_comment = comments.bus
 
@@ -1881,15 +2001,16 @@ def _load_bus(attributes, comments):
     return Bus(bus_name, baudrate=bus_baudrate, comment=bus_comment)
 
 
-def _load_nodes(tokens, comments, attributes, definitions):
+def _load_nodes(tokens: DbcTokens, comments: DbcComments, attributes: DbcAttributes, attribute_definitions: OrderedDict[str, AttributeDefinitionType]) -> list[Node] | None:
     nodes = None
 
-    for token in tokens.get('BU_', []):
+    for _node_tokens in tokens.get('BU_', []):
+        node_tokens = dbc_assert_type(_node_tokens, list)
         nodes = [Node(name=_get_node_long_name(attributes, node_short_name),
                       comment=comments.nodes.get(node_short_name),
-                      dbc_specifics=DbcSpecifics(attributes=attributes.nodes.get(node_short_name),
-                                                 attribute_definitions=definitions))
-                 for node_short_name in token[2]]
+                      dbc_specifics=DbcSpecifics(attributes=attributes.nodes.get(node_short_name, None),
+                                                 attribute_definitions=attribute_definitions))
+                 for node_short_name in dbc_assert_type(node_tokens[2], list)]
 
     return nodes
 
@@ -1905,27 +2026,27 @@ def get_attribute_definition(database: InternalDatabase, name: str, default: Att
 
 
 def get_long_envvar_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
-    return typing.cast('AttributeDefinition[str]', get_attribute_definition(database,
-                                    'SystemEnvVarLongSymbol',
-                                    ATTRIBUTE_DEFINITION_LONG_ENVVAR_NAME))
+    return dbc_assert_type(get_attribute_definition(database,
+                                                    'SystemEnvVarLongSymbol',
+                                                    ATTRIBUTE_DEFINITION_LONG_ENVVAR_NAME), AttributeDefinition)
 
 
 def get_long_node_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
-    return typing.cast('AttributeDefinition[str]', get_attribute_definition(database,
-                                    'SystemNodeLongSymbol',
-                                    ATTRIBUTE_DEFINITION_LONG_NODE_NAME))
+    return dbc_assert_type(get_attribute_definition(database,
+                                                    'SystemNodeLongSymbol',
+                                                    ATTRIBUTE_DEFINITION_LONG_NODE_NAME), AttributeDefinition)
 
 
 def get_long_message_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
-    return typing.cast('AttributeDefinition[str]', get_attribute_definition(database,
-                                    'SystemMessageLongSymbol',
-                                    ATTRIBUTE_DEFINITION_LONG_MESSAGE_NAME))
+    return dbc_assert_type(get_attribute_definition(database,
+                                                    'SystemMessageLongSymbol',
+                                                    ATTRIBUTE_DEFINITION_LONG_MESSAGE_NAME), AttributeDefinition)
 
 
 def get_long_signal_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
-    return typing.cast('AttributeDefinition[str]', get_attribute_definition(database,
-                                    'SystemSignalLongSymbol',
-                                    ATTRIBUTE_DEFINITION_LONG_SIGNAL_NAME))
+    return dbc_assert_type(get_attribute_definition(database,
+                                                    'SystemSignalLongSymbol',
+                                                    ATTRIBUTE_DEFINITION_LONG_SIGNAL_NAME), AttributeDefinition)
 
 
 def try_remove_attribute(dbc: DbcSpecifics, name: str) -> None:
@@ -2164,10 +2285,10 @@ def dump_string(database: InternalDatabase,
                           sig_mux_values='\r\n'.join(sig_mux_values))
 
 
-def get_attribute_definitions_dict(definitions: typing.Any, defaults: typing.Any) -> OrderedDict[str, AttributeDefinitionType]:
+def get_attribute_definitions_dict(definitions_tokens: list[MatchObject], defaults: DbcAttributeDefaults) -> OrderedDict[str, AttributeDefinitionType]:
     result: OrderedDict[str, AttributeDefinitionType] = OrderedDict()
 
-    def convert_value(definition, value):
+    def convert_value(definition: AttributeDefinitionType, value: AttributeValue) -> AttributeValue:
         if definition.type_name in ['INT', 'HEX']:
             value = to_int(value)
         elif definition.type_name == 'FLOAT':
@@ -2175,26 +2296,25 @@ def get_attribute_definitions_dict(definitions: typing.Any, defaults: typing.Any
 
         return value
 
-    for item in definitions:
-        if len(item[1]) > 0:
-            kind = item[1][0]
-        else:
-            kind = None
+    for _definition_tokens in definitions_tokens:
+        definition_tokens = dbc_assert_type(_definition_tokens, list)
+        kind_list = dbc_assert_type(definition_tokens[1], list)
+        kind: str | None = kind_list[0] if len(kind_list) > 0 else None
 
-        definition = AttributeDefinition(name=item[2],
+        definition = AttributeDefinition(name=dbc_assert_type(definition_tokens[2], str),
                                          kind=kind,
-                                         type_name=item[3])
-        values = item[4][0]
+                                         type_name=dbc_assert_type(definition_tokens[3], str))
+        values = dbc_assert_type(dbc_assert_type(definition_tokens[4], list)[0], list)
 
         if len(values) > 0:
             if definition.type_name == 'ENUM':
-                definition.choices = values
+                definition.choices = dbc_assert_type(values, list)
             elif definition.type_name in ['INT', 'FLOAT', 'HEX']:
-                definition.minimum = convert_value(definition, values[0])
-                definition.maximum = convert_value(definition, values[1])
+                definition.minimum = typing.cast('int | float', convert_value(definition, typing.cast('AttributeValue', values[0])))
+                definition.maximum = typing.cast('int | float', convert_value(definition, typing.cast('AttributeValue', values[1])))
 
         if definition.name in defaults:
-            definition.default_value = convert_value(definition, defaults[definition.name])
+            definition.default_value = convert_value(definition, defaults[definition.name])  # type: ignore[assignment]
         else:
             definition.default_value = None
 
@@ -2203,10 +2323,10 @@ def get_attribute_definitions_dict(definitions: typing.Any, defaults: typing.Any
     return result
 
 
-def get_relation_definitions_dict(definitions, defaults):
-    result = OrderedDict()
+def get_relation_definitions_dict(definitions_tokens: list[MatchObject], defaults: DbcAttributeDefaults) -> OrderedDict[str, AttributeDefinitionType]:
+    result: OrderedDict[str, AttributeDefinitionType] = OrderedDict()
 
-    def convert_value(definition, value):
+    def convert_value(definition: AttributeDefinitionType, value: AttributeValue) -> AttributeValue:
         if definition.type_name in ['INT', 'HEX']:
             value = to_int(value)
         elif definition.type_name == 'FLOAT':
@@ -2214,26 +2334,26 @@ def get_relation_definitions_dict(definitions, defaults):
 
         return value
 
-    for item in definitions:
-        if len(item[1]) > 0:
-            kind = item[1][0]
-        else:
-            kind = None
+    for _definition_tokens in definitions_tokens:
+        definition_tokens = dbc_assert_type(_definition_tokens, list)
+        kind_list = dbc_assert_type(definition_tokens[1], list)
+        kind: str | None = kind_list[0] if len(kind_list) > 0 else None
 
-        definition = AttributeDefinition(name=item[2],
+        definition = AttributeDefinition(name=dbc_assert_type(definition_tokens[2], str),
                                          kind=kind,
-                                         type_name=item[3])
-        values = item[4]
+                                         type_name=dbc_assert_type(definition_tokens[3], str))
+        values = dbc_assert_type(definition_tokens[4], list)
 
         if len(values) > 0:
             if definition.type_name == 'ENUM':
-                definition.choices = values[0]
+                definition.choices = dbc_assert_type(values[0], list)
             elif definition.type_name in ['INT', 'FLOAT', 'HEX']:
-                definition.minimum = convert_value(definition, values[0][0])
-                definition.maximum = convert_value(definition, values[0][1])
+                inner = dbc_assert_type(values[0], list)
+                definition.minimum = typing.cast('int | float', convert_value(definition, inner[0]))
+                definition.maximum = typing.cast('int | float', convert_value(definition, inner[1]))
 
         if definition.name in defaults:
-            definition.default_value = convert_value(definition, defaults[definition.name])
+            definition.default_value = convert_value(definition, defaults[definition.name])  # type: ignore[assignment]
         else:
             definition.default_value = None
 
@@ -2272,15 +2392,15 @@ def load_string(string: str, strict: bool = True,
 
     """
 
-    tokens = DbcParser().parse(string)
+    tokens: DbcTokens = dbc_assert_type(DbcParser().parse(string), dict)
 
     comments = _load_comments(tokens)
-    definitions = _load_attribute_definitions(tokens)
+    attribute_definitions = _load_attribute_definitions(tokens)
     defaults = _load_attribute_definition_defaults(tokens)
     relation_definitions = _load_relation_attribute_definitions(tokens)
     relation_defaults = _load_relation_attribute_definition_defaults(tokens)
-    attribute_definitions = get_attribute_definitions_dict(definitions, defaults)
-    attributes = _load_attributes(tokens, attribute_definitions)
+    attribute_definitions_dict = get_attribute_definitions_dict(attribute_definitions, defaults)
+    attributes = _load_attributes(tokens, attribute_definitions_dict)
     relation_attribute_definitions = get_relation_definitions_dict(relation_definitions, relation_defaults)
     relation_attributes = _load_relation_attributes(tokens, relation_attribute_definitions)
     bus = _load_bus(attributes, comments)
@@ -2293,7 +2413,7 @@ def load_string(string: str, strict: bool = True,
     messages = _load_messages(tokens,
                               comments,
                               attributes,
-                              attribute_definitions,
+                              attribute_definitions_dict,
                               choices,
                               message_senders,
                               signal_types,
@@ -2306,18 +2426,18 @@ def load_string(string: str, strict: bool = True,
         messages,
         attributes,
         relation_attributes)
-    nodes = _load_nodes(tokens, comments, attributes, attribute_definitions)
+    nodes = _load_nodes(tokens, comments, attributes, attribute_definitions_dict)
     version = _load_version(tokens)
-    environment_variables = _load_environment_variables(tokens, comments, attributes, attribute_definitions)
+    environment_variables = _load_environment_variables(tokens, comments, attributes, attribute_definitions_dict)
     dbc_specifics = DbcSpecifics(attributes=attributes.database or None,
-                                 attribute_definitions=attribute_definitions,
+                                 attribute_definitions=attribute_definitions_dict,
                                  environment_variables=environment_variables,
                                  value_tables=value_tables,
                                  relation_attributes=relation_attributes,
                                  relation_attribute_definitions=relation_attribute_definitions)
 
     return InternalDatabase(messages,
-                            nodes,
+                            nodes or [],
                             [bus] if bus else [],
                             version,
                             dbc_specifics)

--- a/src/cantools/database/can/node.py
+++ b/src/cantools/database/can/node.py
@@ -10,8 +10,9 @@ from ...typechecking import Comments
 
 
 class Node:
-    """An NODE on the CAN bus.
+    """A device communicating on a CAN bus.
 
+    This usually corresponds to an electronic control unit (ECU).
     """
 
     def __init__(self,


### PR DESCRIPTION
with this, `mypy --strict` passes for `dbc.py`.

The main mechanism which this commit introduces is the `dbc_assert_type(x, T)` function. It returns `x` if `x` is of type `T` or raises a `ParseError` if this is not the case. For most cases, this allows to tell the type checker the type of `x` without introducing too much code churn.

Besides this I did a few additional renames (much fewer than #820) , but I did not find the nerves of factoring them out into a separate PR.
