### PR TITLE
decode: apply --no-decode-choices to contained messages

### DIFF
--- a/src/cantools/subparsers/__utils__.py
+++ b/src/cantools/subparsers/__utils__.py
@@ -156,7 +156,7 @@ def format_container_message(message : Message,
         unpacked_message = message.unpack_container(data,
                                                     allow_truncated=allow_truncated)
         decoded_message = message.decode_container(data,
-                                                   decode_choices=True,
+                                                   decode_choices=decode_choices,
                                                    scaling=True,
                                                    allow_truncated=allow_truncated,
                                                    allow_excess=allow_excess)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -742,6 +742,30 @@ BATTERY_VT(
             actual_output = stdout.getvalue()
             self.assertEqual(actual_output, expected_output)
 
+    def test_decode_no_decode_choices_contained_message(self):
+        argv = [
+            'cantools',
+            'decode',
+            '--no-decode-choices',
+            '--single-line',
+            'tests/files/arxml/system-4.2.arxml'
+        ]
+
+        input_data = """\
+  vcan0  066   [13]  0A 0B 0C 09 01 00 02 00 00 00 00 00 00
+"""
+
+        expected_output = """\
+  vcan0  066   [13]  0A 0B 0C 09 01 00 02 00 00 00 00 00 00 :: OneToContainThemAll( message1(message1_SeqCounter: 1, message1_CRC: 2, signal6: 0.0 wp, signal1: 0 m, signal5: 0.0))
+"""
+
+        stdout = StringIO()
+
+        with patch('sys.stdin', StringIO(input_data)), patch('sys.stdout', stdout), patch('sys.argv', argv):
+            cantools._main()
+            actual_output = stdout.getvalue()
+            self.assertEqual(actual_output, expected_output)
+
     def test_dump(self):
         argv = [
             'cantools',


### PR DESCRIPTION
Spent a while assuming my arxml was wrong. `-c` behaves fine on a normal message so I didnt think to suspect the flag, but `format_container_message()` in `subparsers/__utils__.py` takes `decode_choices` and then never passes it on. The call underneath is `decode_container(..., decode_choices=True, ...)`. Once the frame is a container, `-c` does nothing at all.

```
$ echo '  vcan0  066   [13]  0A 0B 0C 09 01 00 02 00 00 00 00 00 00' \
    | cantools decode -c tests/files/arxml/system-4.2.arxml
```

`signal6: zero` before, `signal6: 0.0 wp` after.

Reads like a slip in cdc748a rather than a decision. `format_message()` moved to `decode_simple()` in the same hunk and kept passing the argument through, only the container one picked up a literal `True`. If that `True` was on purpose, say so and I'll drop this.

Left `scaling=True` on the line below alone becuase nothing on the CLI exposes it, and `monitor.py` hardcodes `decode_choices=True` as well, though there's no flag there to ignore so I've not touched it. `ruff check src`, `mypy src` and the 415 tests are clean on 3.11; I've not run the windows or pypy legs.
