### PR TITLE
kcd: derive auto message length from the furthest-ending signal

### DIFF
--- a/src/cantools/database/can/formats/kcd.py
+++ b/src/cantools/database/can/formats/kcd.py
@@ -222,8 +222,9 @@ def _load_message_element(message, bus_name, nodes, strict, sort_signals):
 
     if length == 'auto':
         if signals:
-            last_signal = max(signals, key=start_bit)
-            length = (start_bit(last_signal) + last_signal.length + 7) // 8
+            last_bit = max(start_bit(signal) + signal.length
+                           for signal in signals)
+            length = (last_bit + 7) // 8
         else:
             length = 0
     else:

--- a/tests/files/kcd/auto_message_length.kcd
+++ b/tests/files/kcd/auto_message_length.kcd
@@ -1,0 +1,24 @@
+<NetworkDefinition xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://kayak.2codeornot2code.org/1.0" xsi:noNamespaceSchemaLocation="Definition.xsd">
+  <Document name="" version="" author="" company="" date="">
+  </Document>
+
+  <Node id="1" name="Node1"/>
+
+  <Bus name="Bus1">
+
+    <Message id="1" name="Message1">
+      <Producer>
+        <NodeRef id="1"/>
+      </Producer>
+      <Multiplex name="Mode" offset="0" length="8">
+        <MuxGroup count="0">
+          <Signal name="Signal1" offset="40" length="8"/>
+        </MuxGroup>
+        <MuxGroup count="1">
+          <Signal name="Signal2" offset="8" length="56"/>
+        </MuxGroup>
+      </Multiplex>
+    </Message>
+
+  </Bus>
+</NetworkDefinition>

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1729,6 +1729,12 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(db.version, None)
         self.assertEqual(db.nodes, [])
 
+    def test_auto_message_length_kcd(self):
+        db = cantools.database.load_file(
+            'tests/files/kcd/auto_message_length.kcd')
+
+        self.assertEqual(db.messages[0].length, 8)
+
     def test_invalid_kcd(self):
         with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
             cantools.database.load_string('<WrongRootElement/>',


### PR DESCRIPTION
`length` is optional on a KCD `<Message>`, and when it's left off the loader sizes the message from whichever signal starts furthest in, then treats that one signal's length as the end. Furthest-starting isnt furthest-ending. An 8-bit signal at offset 40 in one `<MuxGroup>` beats a 56-bit signal at offset 8 in another, so the message gets 6 bytes when it needs 8 and the file won't load at all:

```
$ cantools dump tests/files/kcd/auto_message_length.kcd
error: KCD: "The signal Signal2 does not fit in message Message1."
```

Mux groups are the only way in. Signals in a plain message can't overlap under strict mode, so whichever starts last ends last too. `the_homer.kcd` has two auto-length multiplexed messages and neither trips it, beacuse every mux-group signal in `ABS` and `Radio` is 8 bits at the same offset, so the old formula lands on the right number anyway. I compared old against new for every length-less message under `tests/files/kcd` and `examples/`, and new fixture is the only one that shifts.

New fixture rather than another message in `the_homer.kcd`, since that file's message count and indices get asserted in a lot of places.

Explicit `length=` still wins, including where it's too small for the signals in the message. That file is broken and should keep failing.
