### PR TITLE
Fix for Issue #205 (Overlapping Signals / Multiplexors)

### DIFF
--- a/src/cantools/database/utils.py
+++ b/src/cantools/database/utils.py
@@ -14,6 +14,7 @@ from typing import (
 from ..typechecking import (
     ByteOrder,
     Choices,
+    CompiledFormatDict,
     Formats,
     SignalDictType,
     SignalMappingType,
@@ -231,7 +232,7 @@ def _group_non_overlapping_signals(
     return layers
 
 
-def _compile_bitstruct(fmt: str, names: list[str]):
+def _compile_bitstruct(fmt: str, names: list[str]) -> CompiledFormatDict:
     try:
         return bitstruct.c.compile(fmt, names)
     except Exception:

--- a/src/cantools/database/utils.py
+++ b/src/cantools/database/utils.py
@@ -30,10 +30,12 @@ if TYPE_CHECKING:
     from ..database.can.signal import Signal
     from ..database.diagnostics import Data
 
+import bitstruct  # type: ignore
+
 try:
     import bitstruct.c  # type: ignore
 except ImportError:
-    import bitstruct  # type: ignore
+    pass
 
 
 def format_or(items: list[int | str]) -> str:
@@ -104,6 +106,21 @@ def _encode_signal_values(signals: Sequence[Union["Signal", "Data"]],
     return raw_values
 
 
+def _pack_formats(formats: Formats, raw_signal_values: dict[str, int | float]) -> int:
+    packed_union = (
+        int.from_bytes(formats.big_endian.pack(raw_signal_values), "big")
+        | int.from_bytes(formats.little_endian.pack(raw_signal_values), "little")
+    )
+
+    for big_endian, little_endian in formats.extra_layers:
+        packed_union |= (
+            int.from_bytes(big_endian.pack(raw_signal_values), "big")
+            | int.from_bytes(little_endian.pack(raw_signal_values), "little")
+        )
+
+    return packed_union
+
+
 def encode_data(signal_values: SignalMappingType,
                 signals: Sequence[Union["Signal", "Data"]],
                 formats: Formats,
@@ -113,11 +130,7 @@ def encode_data(signal_values: SignalMappingType,
         return 0
 
     raw_signal_values = _encode_signal_values(signals, signal_values, scaling)
-    big_packed = formats.big_endian.pack(raw_signal_values)
-    little_packed = formats.little_endian.pack(raw_signal_values)
-    packed_union = int.from_bytes(big_packed, "big") | int.from_bytes(little_packed, "little")
-
-    return packed_union
+    return _pack_formats(formats, raw_signal_values)
 
 
 def decode_data(data: bytes,
@@ -151,6 +164,9 @@ def decode_data(data: bytes,
             **formats.big_endian.unpack(data),
             **formats.little_endian.unpack(data[::-1]),
         }
+        for big_endian, little_endian in formats.extra_layers:
+            unpacked.update(big_endian.unpack(data))
+            unpacked.update(little_endian.unpack(data[::-1]))
     except (bitstruct.Error, ValueError) as e:
         # bitstruct returns different errors in PyPy and cpython
         raise DecodeError("unpacking failed") from e
@@ -189,6 +205,39 @@ def decode_data(data: bytes,
     return decoded
 
 
+def _group_non_overlapping_signals(
+        signals: Sequence[Union["Data", "Signal"]],
+        start_fn: Callable[[Union["Data", "Signal"]], int],
+) -> list[list[Union["Data", "Signal"]]]:
+    """Split signals into layers that do not overlap in bitstruct layout.
+
+    Overlapping signals (e.g. bit flags plus a status byte covering the
+    same bits) cannot be represented by a single bitstruct format string.
+    """
+    layers: list[list] = []
+    layer_ends: list[int] = []
+
+    for signal in sorted(signals, key=start_fn):
+        start = start_fn(signal)
+        for index, end in enumerate(layer_ends):
+            if start >= end:
+                layers[index].append(signal)
+                layer_ends[index] = start + signal.length
+                break
+        else:
+            layers.append([signal])
+            layer_ends.append(start + signal.length)
+
+    return layers
+
+
+def _compile_bitstruct(fmt: str, names: list[str]):
+    try:
+        return bitstruct.c.compile(fmt, names)
+    except Exception:
+        return bitstruct.compile(fmt, names)
+
+
 def create_encode_decode_formats(signals: Sequence[Union["Data", "Signal"]], number_of_bytes: int) -> Formats:
     format_length = (8 * number_of_bytes)
 
@@ -224,18 +273,17 @@ def create_encode_decode_formats(signals: Sequence[Union["Data", "Signal"]], num
         except ValueError:
             return 0
 
-    def create_big() -> tuple[str, int, list[str]]:
+    def create_big(be_signals: Sequence[Union["Data", "Signal"]]) -> tuple[str, int, list[str]]:
         items: list[tuple[str, str, str | None]] = []
         start = 0
 
-        # Select BE signals
-        be_signals = [signal for signal in signals if signal.byte_order == "big_endian"]
-
         # Ensure BE signals are sorted in network order
-        sorted_signals = sorted(be_signals, key = lambda signal: sawtooth_to_network_bitnum(signal.start))
+        sorted_signals = sorted(
+            be_signals,
+            key=lambda signal: sawtooth_to_network_bitnum(signal.start),
+        )
 
         for signal in sorted_signals:
-
             padding_length = (start_bit(signal) - start)
 
             if padding_length > 0:
@@ -250,14 +298,12 @@ def create_encode_decode_formats(signals: Sequence[Union["Data", "Signal"]], num
 
         return fmt(items), padding_mask(items), names(items)
 
-    def create_little() -> tuple[str, int, list[str]]:
+    def create_little(le_signals: Sequence[Union["Data", "Signal"]]) -> tuple[str, int, list[str]]:
         items: list[tuple[str, str, str | None]] = []
         end = format_length
 
-        for signal in signals[::-1]:
-            if signal.byte_order == 'big_endian':
-                continue
-
+        # Work from the highest start bit so padding stays non-negative.
+        for signal in sorted(le_signals, key=lambda signal: signal.start, reverse=True):
             padding_length = end - (signal.start + signal.length)
 
             if padding_length > 0:
@@ -278,22 +324,46 @@ def create_encode_decode_formats(signals: Sequence[Union["Data", "Signal"]], num
 
         return fmt(items), value, names(items)
 
-    big_fmt, big_padding_mask, big_names = create_big()
-    little_fmt, little_padding_mask, little_names = create_little()
+    def compile_layer(
+            be_signals: Sequence[Union["Data", "Signal"]],
+            le_signals: Sequence[Union["Data", "Signal"]],
+    ) -> Formats:
+        big_fmt, big_padding_mask, big_names = create_big(be_signals)
+        little_fmt, little_padding_mask, little_names = create_little(le_signals)
+        return Formats(
+            _compile_bitstruct(big_fmt, big_names),
+            _compile_bitstruct(little_fmt, little_names),
+            big_padding_mask & little_padding_mask,
+        )
 
-    try:
-        big_compiled = bitstruct.c.compile(big_fmt, big_names)
-    except Exception:
-        big_compiled = bitstruct.compile(big_fmt, big_names)
+    be_signals = [signal for signal in signals if signal.byte_order == "big_endian"]
+    le_signals = [signal for signal in signals if signal.byte_order != "big_endian"]
+    be_layers = _group_non_overlapping_signals(be_signals, start_bit)
+    le_layers = _group_non_overlapping_signals(le_signals, lambda signal: signal.start)
+    layer_count = max(len(be_layers), len(le_layers), 1)
 
-    try:
-        little_compiled = bitstruct.c.compile(little_fmt, little_names)
-    except Exception:
-        little_compiled = bitstruct.compile(little_fmt, little_names)
+    compiled_layers = [
+        compile_layer(
+            be_layers[index] if index < len(be_layers) else [],
+            le_layers[index] if index < len(le_layers) else [],
+        )
+        for index in range(layer_count)
+    ]
 
-    return Formats(big_compiled,
-                   little_compiled,
-                   big_padding_mask & little_padding_mask)
+    padding = compiled_layers[0].padding_mask
+    for layer in compiled_layers[1:]:
+        padding &= layer.padding_mask
+
+    extra_layers = tuple(
+        (layer.big_endian, layer.little_endian)
+        for layer in compiled_layers[1:]
+    )
+    return Formats(
+        compiled_layers[0].big_endian,
+        compiled_layers[0].little_endian,
+        padding,
+        extra_layers,
+    )
 
 
 def sawtooth_to_network_bitnum(sawtooth_bitnum: int) -> int:

--- a/src/cantools/database/utils.py
+++ b/src/cantools/database/utils.py
@@ -31,12 +31,10 @@ if TYPE_CHECKING:
     from ..database.can.signal import Signal
     from ..database.diagnostics import Data
 
-import bitstruct  # type: ignore
-
 try:
     import bitstruct.c  # type: ignore
 except ImportError:
-    pass
+    import bitstruct  # type: ignore
 
 
 def format_or(items: list[int | str]) -> str:
@@ -108,11 +106,21 @@ def _encode_signal_values(signals: Sequence[Union["Signal", "Data"]],
 
 
 def _pack_formats(formats: Formats, raw_signal_values: dict[str, int | float]) -> int:
+    """Pack raw signal values into a big-endian integer payload.
+
+    The primary big- and little-endian codecs cover the first
+    internally non-overlapping layer. ``formats.extra_layers`` holds
+    additional (big, little) codecs for overlapping signals that
+    cannot share a bitstruct format string with that first layer, for
+    example bit flags plus a status field on the same bits. Those
+    layers are packed separately and OR-ed together.
+    """
     packed_union = (
         int.from_bytes(formats.big_endian.pack(raw_signal_values), "big")
         | int.from_bytes(formats.little_endian.pack(raw_signal_values), "little")
     )
 
+    # Overlapping signals: extra codecs OR-ed into the same payload.
     for big_endian, little_endian in formats.extra_layers:
         packed_union |= (
             int.from_bytes(big_endian.pack(raw_signal_values), "big")
@@ -165,6 +173,7 @@ def decode_data(data: bytes,
             **formats.big_endian.unpack(data),
             **formats.little_endian.unpack(data[::-1]),
         }
+        # Merge overlapping interpretations from extra bitstruct layers.
         for big_endian, little_endian in formats.extra_layers:
             unpacked.update(big_endian.unpack(data))
             unpacked.update(little_endian.unpack(data[::-1]))
@@ -355,6 +364,8 @@ def create_encode_decode_formats(signals: Sequence[Union["Data", "Signal"]], num
     for layer in compiled_layers[1:]:
         padding &= layer.padding_mask
 
+    # Remaining layers are overlapping signals that did not fit in the
+    # first internally non-overlapping bitstruct format.
     extra_layers = tuple(
         (layer.big_endian, layer.little_endian)
         for layer in compiled_layers[1:]

--- a/src/cantools/typechecking.py
+++ b/src/cantools/typechecking.py
@@ -21,6 +21,9 @@ class Formats(NamedTuple):
     big_endian: CompiledFormatDict
     little_endian: CompiledFormatDict
     padding_mask: int
+    # Additional (big, little) codecs for overlapping signals. Each
+    # layer is internally non-overlapping so bitstruct can unpack it.
+    extra_layers: tuple[tuple[CompiledFormatDict, CompiledFormatDict], ...] = ()
 
 
 StringPathLike = str | os.PathLike[str]

--- a/tests/files/sym/issue_205.sym
+++ b/tests/files/sym/issue_205.sym
@@ -1,0 +1,25 @@
+FormatVersion=6.0 // Do not edit this line!
+Title="Untitled"
+
+{ENUMS}
+
+{SIGNALS}
+Sig=StatusWord unsigned 32
+Sig=StatusMsb unsigned 1
+Sig=StatusBitA unsigned 1
+Sig=StatusBitB unsigned 1
+
+{SENDRECEIVE}
+
+[BootLog]
+ID=75Fh
+Len=8
+Mux=Selector 0,24 0
+Sig=StatusBitA 33
+Sig=StatusBitB 34
+
+[BootLog]
+Len=8
+Mux=Flags 0,24 030000h
+Sig=StatusWord 32
+Sig=StatusMsb 63

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4045,6 +4045,43 @@ BO_ 287 Message01: 1 Vector__XXX
         self.assertEqual(decoded['StatusBitA'], 1)
         self.assertEqual(decoded['StatusBitB'], 0)
 
+    def test_overlapping_multiplexed_signals_decode_and_encode(self):
+        # Codecs are compiled per multiplexer variant, so overlapping
+        # signals in a muxed frame use extra bitstruct layers too.
+        mux = cantools.database.can.Signal(
+            'Mux', 0, 8, is_multiplexer=True)
+        status = cantools.database.can.Signal(
+            'Status', 8, 8,
+            multiplexer_ids=[1],
+            multiplexer_signal='Mux')
+        flag = cantools.database.can.Signal(
+            'Flag', 8, 1,
+            multiplexer_ids=[1],
+            multiplexer_signal='Mux')
+        other = cantools.database.can.Signal(
+            'Other', 8, 8,
+            multiplexer_ids=[0],
+            multiplexer_signal='Mux')
+        message = cantools.database.can.Message(
+            1, 'M', 2, [mux, status, flag, other], strict=False)
+
+        decoded = message.decode(b'\x01\xab')
+        self.assertEqual(decoded, {
+            'Mux': 1,
+            'Status': 0xab,
+            'Flag': 1,
+        })
+        encoded = message.encode(decoded, strict=False)
+        self.assertEqual(encoded, b'\x01\xab')
+
+        decoded = message.decode(b'\x00\x55')
+        self.assertEqual(decoded, {
+            'Mux': 0,
+            'Other': 0x55,
+        })
+        encoded = message.encode(decoded, strict=False)
+        self.assertEqual(encoded, b'\x00\x55')
+
     def test_database_signals_check_failure(self):
         signal = cantools.database.can.Signal('S',
                                               7,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3920,6 +3920,131 @@ class CanToolsDatabaseTest(unittest.TestCase):
             self.assertEqual(message_1.signals[0].start, 8)
             self.assertEqual(message_1.signals[0].length, 1)
 
+    def test_overlapping_little_endian_signals_decode_and_encode(self):
+        # Issue #205: overlapping Intel signals (bit flags plus the
+        # whole byte as a status code) used to raise "Short data".
+        dbc = '''VERSION ""
+
+NS_ :
+    NS_DESC_
+    CM_
+    BA_DEF_
+    BA_
+    VAL_
+    CAT_DEF_
+    CAT_
+    FILTER
+    BA_DEF_DEF_
+    EV_DATA_
+    ENVVAR_DATA_
+    SGTYPE_
+    SGTYPE_VAL_
+    BA_DEF_SGTYPE_
+    BA_SGTYPE_
+    SIG_TYPE_REF_
+    VAL_TABLE_
+    SIG_GROUP_
+    SIG_VALTYPE_
+    SIGTYPE_VALTYPE_
+    BO_TX_BU_
+    BA_DEF_REL_
+    BA_REL_
+    BA_DEF_DEF_REL_
+    BU_SG_REL_
+    BU_EV_REL_
+    BU_BO_REL_
+    SG_MUL_VAL_
+
+BS_:
+
+BU_:
+
+BO_ 287 Message01: 1 Vector__XXX
+ SG_ Flag1 : 0|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ Flag2 : 1|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ Flag3 : 2|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ Flag4 : 3|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ Flag5 : 4|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ Flag6 : 5|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ Flag7 : 6|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ Flag8 : 7|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ Status : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+'''
+        db = cantools.database.load_string(dbc, strict=False)
+        decoded = db.decode_message(287, b'\x00')
+        self.assertEqual(decoded, {
+            'Flag1': 0,
+            'Flag2': 0,
+            'Flag3': 0,
+            'Flag4': 0,
+            'Flag5': 0,
+            'Flag6': 0,
+            'Flag7': 0,
+            'Flag8': 0,
+            'Status': 0,
+        })
+
+        decoded = db.decode_message(287, b'\xaa')
+        self.assertEqual(decoded, {
+            'Flag1': 0,
+            'Flag2': 1,
+            'Flag3': 0,
+            'Flag4': 1,
+            'Flag5': 0,
+            'Flag6': 1,
+            'Flag7': 0,
+            'Flag8': 1,
+            'Status': 0b10101010,
+        })
+
+        encoded = db.encode_message(287, decoded, strict=False)
+        self.assertEqual(encoded, b'\xaa')
+
+    def test_overlapping_big_endian_signals_decode_and_encode(self):
+        status = cantools.database.can.Signal(
+            'Status', 7, 8, 'big_endian')
+        msb = cantools.database.can.Signal(
+            'Msb', 7, 1, 'big_endian')
+        message = cantools.database.can.Message(
+            1, 'M', 1, [status, msb], strict=False)
+
+        decoded = message.decode(b'\x80')
+        self.assertEqual(decoded, {'Status': 0x80, 'Msb': 1})
+
+        encoded = message.encode(decoded, strict=False)
+        self.assertEqual(encoded, b'\x80')
+
+    def test_overlapping_signals_issue_205_sym(self):
+        # Reduced/obfuscated SYM based on a real multiplexed boot-log
+        # frame: a 32-bit status word shares its MSB with a 1-bit flag
+        # (issue #205).
+        filename = 'tests/files/sym/issue_205.sym'
+
+        with self.assertRaises(cantools.database.Error) as cm:
+            cantools.database.load_file(filename, strict=True)
+
+        self.assertIn('overlapping', str(cm.exception))
+
+        db = cantools.database.load_file(filename, strict=False)
+        self.assertEqual(len(db.messages), 1)
+
+        flags_frame = bytes([0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x80])
+        decoded = db.decode_message('BootLog', flags_frame)
+        self.assertEqual(decoded, {
+            'Selector': 0x030000,
+            'StatusWord': 0x80000000,
+            'StatusMsb': 1,
+        })
+        encoded = db.encode_message('BootLog', decoded, strict=False)
+        self.assertEqual(encoded, flags_frame)
+
+        # Non-overlapping mux variant still decodes individual bits.
+        reset_frame = bytes([0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00])
+        decoded = db.decode_message('BootLog', reset_frame)
+        self.assertEqual(decoded['Selector'], 0)
+        self.assertEqual(decoded['StatusBitA'], 1)
+        self.assertEqual(decoded['StatusBitB'], 0)
+
     def test_database_signals_check_failure(self):
         signal = cantools.database.can.Signal('S',
                                               7,


### PR DESCRIPTION
## Summary

Fixes #205.

cantools still treated overlapping signals as invalid at decode/encode time, even when a database was loaded with `strict=False`. That shows up as `ValueError: Short data` (or a `DecodeError` wrapping it).

This is a real pattern in automotive DBs: bit flags plus a wider status/fault field covering the same bits. The original report used eight 1-bit flags overlapping an 8-bit `Status` on a 1-byte Intel message. The same failure also happened for Motorola signals and for multiplexed SYM frames where a status word shares bits with a flag.

`strict=True` is unchanged: overlapping signals still raise at load time. With `strict=False`, decode and encode now return consistent values for both the wide field and the overlapping bits.

## Approach

`bitstruct` cannot represent overlapping fields in a single format string. Overlapping signals are now split into internally non-overlapping layers, each compiled as its own codec. Decode unpacks every layer and merges the results. Encode packs each layer and ORs them together.

Non-overlapping messages still use a single layer, so the common path is unchanged.

## Tests

- The original #205 DBC (little-endian flags + status byte)
- Overlapping big-endian signals
- A reduced multiplexed SYM frame (`tests/files/sym/issue_205.sym`)

## Notes

Load overlapping databases with `strict=False`, same as before. Encoding also needs `strict=False` so the overlap check in `Message.encode()` does not reject the payload.