### PR TITLE
Only swallow format errors while probing a database string

### DIFF
--- a/src/cantools/database/__init__.py
+++ b/src/cantools/database/__init__.py
@@ -5,6 +5,9 @@ import os
 import warnings
 from contextlib import nullcontext
 from typing import Any, TextIO
+from xml.etree import ElementTree
+
+import textparser
 
 try:
     import diskcache  # type: ignore
@@ -24,6 +27,20 @@ from .errors import (
     EncodeError,
     Error,
     UnsupportedDatabaseFormatError,
+)
+
+# Exceptions which mean "this string is not in the format being probed for".
+# Anything else - an OSError from a logging handler, a MemoryError, a bug in
+# cantools itself - is not a statement about the format and must reach the
+# caller with its own traceback instead of being reported as a parse failure.
+_FORMAT_PROBE_ERRORS: tuple[type[Exception], ...] = (
+    Error,
+    textparser.ParseError,
+    ElementTree.ParseError,
+    # arxml and kcd reject an unexpected root tag with a plain ValueError,
+    # cdd reports a missing ECUDOC root with a KeyError.
+    ValueError,
+    KeyError,
 )
 
 
@@ -339,25 +356,25 @@ def load_string(string: str,
     if database_format in ['arxml', None]:
         try:
             return load_can_database('arxml')
-        except Exception as e:
+        except _FORMAT_PROBE_ERRORS as e:
             e_arxml = e
 
     if database_format in ['dbc', None]:
         try:
             return load_can_database('dbc')
-        except Exception as e:
+        except _FORMAT_PROBE_ERRORS as e:
             e_dbc = e
 
     if database_format in ['kcd', None]:
         try:
             return load_can_database('kcd')
-        except Exception as e:
+        except _FORMAT_PROBE_ERRORS as e:
             e_kcd = e
 
     if database_format in ['sym', None]:
         try:
             return load_can_database('sym')
-        except Exception as e:
+        except _FORMAT_PROBE_ERRORS as e:
             e_sym = e
 
     if database_format in ['cdd', None]:
@@ -365,7 +382,7 @@ def load_string(string: str,
             db = diagnostics.Database()
             db.add_cdd_string(string)
             return db
-        except Exception as e:
+        except _FORMAT_PROBE_ERRORS as e:
             e_cdd = e
 
     if database_format is not None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2627,6 +2627,51 @@ class CanToolsDatabaseTest(unittest.TestCase):
         with self.assertRaises(UnsupportedDatabaseFormatError):
             cantools.database.load(StringIO(''))
 
+    def test_load_string_lets_unrelated_errors_through(self):
+        """An error unrelated to the format must not be reported as a parse failure.
+
+        Format probing runs each parser in turn and remembers why it failed. An
+        exception which says nothing about the format - here one raised by a
+        logging handler while cantools emits a warning of its own - has to reach
+        the caller with its own traceback instead.
+        """
+        duplicate_message_dbc = (
+            'VERSION ""\n'
+            '\n'
+            'BU_: ECU\n'
+            '\n'
+            'BO_ 256 Msg: 8 ECU\n'
+            ' SG_ Sig1 : 0|8@1+ (1,0) [0|0] "" ECU\n'
+            '\n'
+            'BO_ 256 Msg: 8 ECU\n'
+            ' SG_ Sig2 : 8|8@1+ (1,0) [0|0] "" ECU\n'
+        )
+
+        class FailingHandler(logging.Handler):
+            def emit(self, record):
+                raise OSError(1, 'Incorrect function')
+
+        logger = logging.getLogger('cantools')
+        handler = FailingHandler()
+        logger.addHandler(handler)
+        propagate = logger.propagate
+        logger.propagate = False
+
+        try:
+            with self.assertRaises(OSError) as cm:
+                cantools.database.load_string(duplicate_message_dbc, strict=False)
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = propagate
+
+        self.assertEqual(cm.exception.errno, 1)
+
+    def test_load_string_still_reports_a_bad_format(self):
+        """Narrowing the probe must not stop genuine format failures being caught."""
+        for content in ['not a database at all', '', '\x00\x01\x02']:
+            with self.assertRaises(UnsupportedDatabaseFormatError):
+                cantools.database.load_string(content)
+
     def test_add_bad_kcd_string(self):
         db = cantools.database.Database()
 


### PR DESCRIPTION
Fixes #814.

`load_string()` probes each supported format in turn and keeps the failure from each one so that it can report all five reasons together if none of them works. Every attempt was wrapped in a bare `except Exception`, so an error that says nothing about the format was recorded as if it did.

The reporter's case, reproduced unchanged on `c1dcd39`:

```
cantools.database.errors.UnsupportedDatabaseFormatError: DBC: "[Errno 1] Incorrect function"
```

The file parses fine. The `OSError` comes from a logging handler that fails while cantools emits its own "Overwriting message ..." warning, and the traceback pointing at it is lost.

After the change the same script raises the `OSError` itself, with the handler still in the traceback.

**Which exceptions actually mean "wrong format"**

Rather than guess, I fed every parser each of the other formats plus junk and an empty string, and recorded what came out — 30 combinations:

| exception | occurrences |
| --- | --- |
| `ElementTree.ParseError` | 12 |
| `cantools.errors.Error` | 6 |
| `textparser.ParseError` | 5 |
| `ValueError` | 2 |
| `KeyError` | 2 |

The last two are wider than I would like. They come from three places that reject a wrong root tag with a plain builtin:

- `arxml/__init__.py:57` — `ValueError("No XML namespace specified or illegal root tag name ...")`
- `kcd.py:475` — `ValueError("Expected root element tag ...")`
- `cdd.py:244` — `KeyError("Could not find ECUDOC root element!")`

Making those raise `ParseError` would be tidier and would let the probe narrow to cantools' own errors plus the two parser ones. I left it alone because those exceptions are visible to anyone calling `add_arxml_string()` and friends directly, and several tests assert on them — that seemed like a separate decision rather than something to fold into a bugfix. Happy to do it if you would prefer that shape.

**Verification**

- Auto-detection unchanged: loaded all **131** database files under `tests/` with no explicit format, before and after. Same outcome for every file, including the 12 that already failed.
- Junk, empty string and binary input still raise `UnsupportedDatabaseFormatError`.
- Two tests added. The first fails on `master` with `UnsupportedDatabaseFormatError` and passes with the change; the second guards the other direction, that a genuinely bad format is still reported as one.
- `ruff` and `mypy` clean. Suite goes 415 → 417 passing. `test_cache_env_var` fails on my machine both before and after — unrelated to this change.
