### PR TITLE
kcd: capture the full text of a Notes element

### DIFF
--- a/src/cantools/database/can/formats/kcd.py
+++ b/src/cantools/database/can/formats/kcd.py
@@ -98,11 +98,13 @@ def _load_signal_element(signal, nodes):
                 LOGGER.debug("Ignoring unsupported signal value attribute '%s'.",
                              key)
 
-    # Notes.
-    try:
-        notes = signal.find('ns:Notes', NAMESPACES).text
-    except AttributeError:
-        pass
+    # Notes. A Notes element may contain more than just a leading text
+    # node (e.g. line breaks), so gather all of its text instead of only
+    # the part before the first child element.
+    notes_element = signal.find('ns:Notes', NAMESPACES)
+
+    if notes_element is not None:
+        notes = ''.join(notes_element.itertext())
 
     # Label set XML element.
     label_set = signal.find('ns:LabelSet', NAMESPACES)
@@ -197,11 +199,12 @@ def _load_message_element(message, bus_name, nodes, strict, sort_signals):
             LOGGER.debug("Ignoring unsupported message attribute '%s'.", key)
             # TODO: triggered, count, remote
 
-    # Comment.
-    try:
-        notes = message.find('ns:Notes', NAMESPACES).text
-    except AttributeError:
-        pass
+    # Comment. See the note in _load_signal_element about why all of the
+    # text is gathered rather than just the leading text node.
+    notes_element = message.find('ns:Notes', NAMESPACES)
+
+    if notes_element is not None:
+        notes = ''.join(notes_element.itertext())
 
     # Senders.
     producer = message.find('ns:Producer', NAMESPACES)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1746,6 +1746,30 @@ class CanToolsDatabaseTest(unittest.TestCase):
             '{http://kayak.2codeornot2code.org/1.0}NetworkDefinition, but '
             'got WrongRootElement."')
 
+    def test_multiline_notes_kcd(self):
+        # A Notes element may hold more than a single text node. Make sure
+        # the whole note ends up in the comment instead of only the text
+        # before the first child element.
+        db = cantools.database.load_string(
+            '<NetworkDefinition '
+            'xmlns="http://kayak.2codeornot2code.org/1.0">'
+            '  <Node id="1" name="Node1"/>'
+            '  <Bus name="Bus1">'
+            '    <Message id="1" name="Message1">'
+            '      <Notes>First line<br/>Second line</Notes>'
+            '      <Producer><NodeRef id="1"/></Producer>'
+            '      <Signal name="Signal1" offset="0" length="8">'
+            '        <Notes>Alpha<br/>Beta</Notes>'
+            '      </Signal>'
+            '    </Message>'
+            '  </Bus>'
+            '</NetworkDefinition>',
+            database_format='kcd')
+
+        message = db.messages[0]
+        self.assertEqual(message.comment, 'First lineSecond line')
+        self.assertEqual(message.signals[0].comment, 'AlphaBeta')
+
     def test_jopp_5_0_sym(self):
         db = cantools.database.Database()
 


### PR DESCRIPTION
Closes #709.

When loading a KCD, the text of a `<Notes>` element was read with `element.text`, which only returns the text before the first child element. So a note like `<Notes>First line<br/>Second line</Notes>` came back as just "First line" and anything after the first child was silently dropped, on both messages and signals.

This gathers the whole note with `itertext()` instead. For the common case of a single text node the result is identical, so every existing KCD fixture loads exactly as before. In #709 @andlaus suggested simply concatenating the notes, which is what this does.

Added a test with a multi-part note that fails on master and passes here. Full test suite, ruff and mypy are all clean.
