### PR TITLE
fix: textparser minimal version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "bitstruct>=8.16.1",
     "python-can>=4.6.0",
-    "textparser>=0.21.1",
+    "textparser>=0.26",
     "argparse_addons",
     "crccheck",
 ]


### PR DESCRIPTION
 Issue:
 
In dbc.py imports from textparser [MatchObject](https://github.com/cantools/textparser/blob/ddd6812d8fd9cdfe05e5c122578713402ee14e21/textparser/__init__.py#L82) which is only available starting from 0.26

 Fix:
 Set minimal version of textparser: 0.26