### PR TITLE
format loaders: raise ParseError for input that cannot be loaded

### DIFF
--- a/src/cantools/database/__init__.py
+++ b/src/cantools/database/__init__.py
@@ -1,6 +1,7 @@
 __all__ = ["Bus", "Database", "DecodeError", "EncodeError", "Message",
            "Node", "Signal", "dump_file", "load", "load_file", "load_string"]
 
+import logging
 import os
 import warnings
 from contextlib import nullcontext
@@ -24,7 +25,10 @@ from .errors import (
     EncodeError,
     Error,
     UnsupportedDatabaseFormatError,
+    format_load_error,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _resolve_database_format_and_encoding(database_format: str | None,
@@ -122,7 +126,8 @@ def load_file(filename: StringPathLike,
     Raises an
     :class:`~cantools.database.UnsupportedDatabaseFormatError`
     exception if given file does not contain a supported database
-    format.
+    format and a :class:`NotImplementedError` if the file uses a
+    variant of a supported format which is not supported.
 
     >>> db = cantools.database.load_file('foo.dbc')
     >>> db.version
@@ -249,7 +254,8 @@ def load(fp: TextIO,
     Raises an
     :class:`~cantools.database.UnsupportedDatabaseFormatError`
     exception if given file-like object does not contain a supported
-    database format.
+    database format and a :class:`NotImplementedError` if it uses a
+    variant of a supported format which is not supported.
 
     >>> with open('foo.kcd') as fin:
     ...    db = cantools.database.load(fin)
@@ -297,7 +303,8 @@ def load_string(string: str,
     Raises an
     :class:`~cantools.database.UnsupportedDatabaseFormatError`
     exception if given string does not contain a supported database
-    format.
+    format and a :class:`NotImplementedError` if the string uses a
+    variant of a supported format which is not supported.
 
     >>> with open('foo.dbc') as fin:
     ...    db = cantools.database.load_string(fin.read())
@@ -311,13 +318,12 @@ def load_string(string: str,
             f"expected database format 'arxml', 'dbc', 'kcd', 'sym', 'cdd' or "
             f"None, but got '{database_format}'")
 
-    e_arxml = None
-    e_dbc = None
-    e_kcd = None
-    e_sym = None
-    e_cdd = None
+    def load_database(fmt: str) -> can.Database | diagnostics.Database:
+        if fmt == 'cdd':
+            diagnostics_db = diagnostics.Database()
+            diagnostics_db.add_cdd_string(string)
+            return diagnostics_db
 
-    def load_can_database(fmt: str) -> can.Database:
         db = can.Database(frame_id_mask=frame_id_mask,
                           strict=strict,
                           sort_signals=sort_signals)
@@ -336,48 +342,42 @@ def load_string(string: str,
 
         return db
 
-    if database_format in ['arxml', None]:
-        try:
-            return load_can_database('arxml')
-        except Exception as e:
-            e_arxml = e
-
-    if database_format in ['dbc', None]:
-        try:
-            return load_can_database('dbc')
-        except Exception as e:
-            e_dbc = e
-
-    if database_format in ['kcd', None]:
-        try:
-            return load_can_database('kcd')
-        except Exception as e:
-            e_kcd = e
-
-    if database_format in ['sym', None]:
-        try:
-            return load_can_database('sym')
-        except Exception as e:
-            e_sym = e
-
-    if database_format in ['cdd', None]:
-        try:
-            db = diagnostics.Database()
-            db.add_cdd_string(string)
-            return db
-        except Exception as e:
-            e_cdd = e
-
-    if database_format is not None:
-        # raise an error while keeping the traceback of the original
-        # exception usable. note that for this we cannot auto-detect
-        # the format because the probing mechanism raises an exception
-        # for every single supported database format in this case
-        exc = e_arxml or e_dbc or e_kcd or e_sym or e_cdd
-        raise UnsupportedDatabaseFormatError(e_arxml,
-                                             e_dbc,
-                                             e_kcd,
-                                             e_sym,
-                                             e_cdd) from exc
+    if database_format is None:
+        formats = ['arxml', 'dbc', 'kcd', 'sym', 'cdd']
     else:
-        raise UnsupportedDatabaseFormatError(e_arxml, e_dbc, e_kcd, e_sym, e_cdd)
+        formats = [database_format]
+
+    errors: dict[str, Exception] = {}
+
+    for fmt in formats:
+        try:
+            return load_database(fmt)
+        except Error as e:
+            # the string cannot be loaded as this format. try the next
+            # one
+            errors[fmt] = e
+        except NotImplementedError:
+            # the string is in this format, but the loader does not
+            # support this variant of it. trying further formats is
+            # pointless
+            raise
+        except Exception as e:
+            # loaders are supposed to raise ParseError for everything
+            # that is wrong with the input, so this is a bug. report
+            # it, but do not let it get in the way of the other formats
+            LOGGER.warning(format_load_error(fmt, e))
+            errors[fmt] = e
+
+    exc = UnsupportedDatabaseFormatError(errors.get('arxml'),
+                                         errors.get('dbc'),
+                                         errors.get('kcd'),
+                                         errors.get('sym'),
+                                         errors.get('cdd'))
+
+    if database_format is None:
+        raise exc
+
+    # keep the traceback of the loader's exception usable. this is not
+    # possible when probing because then there is one exception per
+    # format
+    raise exc from errors[database_format]

--- a/src/cantools/database/can/formats/arxml/__init__.py
+++ b/src/cantools/database/can/formats/arxml/__init__.py
@@ -8,6 +8,7 @@ from xml.etree import ElementTree
 
 from cantools.database.can.internal_database import InternalDatabase
 
+from ....errors import ParseError
 from ....utils import sort_signals_by_start_bit, type_sort_signals
 from .bus_specifics import AutosarBusSpecifics
 from .database_specifics import AutosarDatabaseSpecifics
@@ -50,11 +51,14 @@ def load_string(string:str,
 
     """
 
-    root = ElementTree.fromstring(string)
+    try:
+        root = ElementTree.fromstring(string)
+    except ElementTree.ParseError as e:
+        raise ParseError(str(e)) from e
 
     m = re.match(r'{(.*)}AUTOSAR', root.tag)
     if not m:
-        raise ValueError(f"No XML namespace specified or illegal root tag name '{root.tag}'")
+        raise ParseError(f"No XML namespace specified or illegal root tag name '{root.tag}'")
     xml_namespace = m.group(1)
 
     # Should be replaced with a validation using the XSD file.
@@ -65,12 +69,12 @@ def load_string(string:str,
         recognized_namespace = True
 
     if not recognized_namespace:
-        raise ValueError(f"Unrecognized XML namespace '{xml_namespace}'")
+        raise ParseError(f"Unrecognized XML namespace '{xml_namespace}'")
 
     if is_ecu_extract(root):
         expected_root = f'{{{xml_namespace}}}AUTOSAR'
         if root.tag != expected_root:
-            raise ValueError(f'Expected root element tag {expected_root}, '
+            raise ParseError(f'Expected root element tag {expected_root}, '
                              f'but got {root.tag}.')
 
         return EcuExtractLoader(root, strict, sort_signals).load()

--- a/src/cantools/database/can/formats/arxml/ecu_extract_loader.py
+++ b/src/cantools/database/can/formats/arxml/ecu_extract_loader.py
@@ -8,6 +8,7 @@ from ....utils import sort_signals_by_start_bit, type_sort_signals
 from ...internal_database import InternalDatabase
 from ...message import Message
 from ...signal import Signal
+from ..utils import parse_int
 
 if TYPE_CHECKING:
     from ...bus import Bus
@@ -80,6 +81,9 @@ class EcuExtractLoader:
                 f'Expected 1 /Com, but got {len(com_xpaths)}.')
 
         com_config = self.find_com_config(com_xpaths[0] + '/ComConfig')
+
+        if com_config is None:
+            raise ParseError(f'Could not find ComConfig for {com_xpaths[0]}.')
 
         for ecuc_container_value in com_config:
             definition_ref = ecuc_container_value.find(DEFINITION_REF_XPATH,
@@ -205,9 +209,9 @@ class EcuExtractLoader:
         if can_if_tx_pdu_cfg is not None:
             for parameter, value in self.iter_parameter_values(can_if_tx_pdu_cfg):
                 if parameter == parameter_can_id:
-                    frame_id = int(value)
+                    frame_id = parse_int(value, f"parameter '{parameter}'")
                 elif parameter == parameter_dlc:
-                    length = int(value)
+                    length = parse_int(value, f"parameter '{parameter}'")
                 elif parameter == parameter_can_id_type:
                     is_extended_frame = (value == 'EXTENDED_CAN')
 
@@ -239,9 +243,9 @@ class EcuExtractLoader:
 
         for parameter, value in self.iter_parameter_values(ecuc_container_value):
             if parameter == 'ComBitPosition':
-                bit_position = int(value)
+                bit_position = parse_int(value, f"parameter '{parameter}'")
             elif parameter == 'ComBitSize':
-                length = int(value)
+                length = parse_int(value, f"parameter '{parameter}'")
             elif parameter == 'ComSignalEndianness':
                 byte_order = value.lower()
             elif parameter == 'ComSignalType':

--- a/src/cantools/database/can/formats/arxml/ecu_extract_loader.py
+++ b/src/cantools/database/can/formats/arxml/ecu_extract_loader.py
@@ -3,6 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ....conversion import BaseConversion
+from ....errors import ParseError
 from ....utils import sort_signals_by_start_bit, type_sort_signals
 from ...internal_database import InternalDatabase
 from ...message import Message
@@ -75,7 +76,7 @@ class EcuExtractLoader:
         ]
 
         if len(com_xpaths) != 1:
-            raise ValueError(
+            raise ParseError(
                 f'Expected 1 /Com, but got {len(com_xpaths)}.')
 
         com_config = self.find_com_config(com_xpaths[0] + '/ComConfig')
@@ -120,7 +121,7 @@ class EcuExtractLoader:
                 break
 
         if com_pdu_id_ref is None:
-            raise ValueError('No ComPduIdRef reference found.')
+            raise ParseError('No ComPduIdRef reference found.')
 
         if direction == 'SEND':
             frame_id, length, is_extended_frame = self.load_message_tx(
@@ -347,7 +348,7 @@ class EcuExtractLoader:
                                                NAMESPACES)
 
         if parameters is None:
-            raise ValueError('PARAMETER-VALUES does not exist.')
+            raise ParseError('PARAMETER-VALUES does not exist.')
 
         for parameter in parameters:
             definition_ref = parameter.find(DEFINITION_REF_XPATH,
@@ -362,7 +363,7 @@ class EcuExtractLoader:
                                                NAMESPACES)
 
         if references is None:
-            raise ValueError('REFERENCE-VALUES does not exist.')
+            raise ParseError('REFERENCE-VALUES does not exist.')
 
         for reference in references:
             definition_ref = reference.find(DEFINITION_REF_XPATH,

--- a/src/cantools/database/can/formats/arxml/system_loader.py
+++ b/src/cantools/database/can/formats/arxml/system_loader.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from typing import Any
 
 from ....conversion import BaseConversion, IdentityConversion
+from ....errors import ParseError
 from ....namedsignalvalue import NamedSignalValue
 from ....utils import sort_signals_by_start_bit, type_sort_signals
 from ...bus import Bus
@@ -35,7 +36,7 @@ class SystemLoader:
         m = re.match(r'^\{(.*)\}AUTOSAR$', self._root.tag)
 
         if not m:
-            raise ValueError(f"No XML namespace specified or illegal root tag "
+            raise ParseError(f"No XML namespace specified or illegal root tag "
                              f"name '{self._root.tag}'")
 
         xml_namespace = m.group(1)
@@ -74,14 +75,14 @@ class SystemLoader:
                     autosar_version_string = m.group(1)
 
                 else:
-                    raise ValueError(f"Unrecognized AUTOSAR XML namespace "
+                    raise ParseError(f"Unrecognized AUTOSAR XML namespace "
                                      f"'{xml_namespace}'")
 
         m = re.match(r'^([0-9]*)(\.[0-9]*)?(\.[0-9]*)?$',
                      autosar_version_string)
 
         if not m:
-            raise ValueError(f"Could not parse AUTOSAR version "
+            raise ParseError(f"Could not parse AUTOSAR version "
                              f"'{autosar_version_string}'")
 
         self.autosar_version_major = \
@@ -92,7 +93,7 @@ class SystemLoader:
             0 if m.group(3) is None else int(m.group(3)[1:])
 
         if self.autosar_version_major not in {4, 3}:
-            raise ValueError('This class only supports AUTOSAR '
+            raise ParseError('This class only supports AUTOSAR '
                              'versions 3 and 4')
 
         self._create_arxml_reference_dicts()
@@ -1780,7 +1781,7 @@ class SystemLoader:
                                                   ['&COMPU-NUMERATOR', '*&V'])
 
             if len(numerators) != 2:
-                raise ValueError(
+                raise ParseError(
                     f'Expected 2 numerator values for linear scaling, but '
                     f'got {len(numerators)}.')
 
@@ -1788,7 +1789,7 @@ class SystemLoader:
                                                     ['&COMPU-DENOMINATOR', '*&V'])
 
             if len(denominators) != 1:
-                raise ValueError(
+                raise ParseError(
                     f'Expected 1 denominator value for linear scaling, but '
                     f'got {len(denominators)}.')
 
@@ -1982,7 +1983,7 @@ class SystemLoader:
             if base_type_encoding is None:
                 btt = base_type.find('./ns:SHORT-NAME', self._xml_namespaces)
                 btt = btt.text
-                raise ValueError(
+                raise ParseError(
                     f'BASE-TYPE-ENCODING in base type "{btt}" does not exist.')
 
             base_type_encoding = base_type_encoding.text
@@ -2059,7 +2060,7 @@ class SystemLoader:
                 break
 
         if refbase_path is None:
-            raise ValueError(f"Unknown reference base '{refbase_name}' "
+            raise ParseError(f"Unknown reference base '{refbase_name}' "
                              f"for relative ARXML reference '{arxml_path}'")
 
         return f'{refbase_path}/{arxml_path}'
@@ -2116,7 +2117,7 @@ class SystemLoader:
                 elem_path = f'{elem_path}/{short_name}'
 
                 if elem_path in self._arxml_path_to_node:
-                    raise ValueError(f"File contains multiple elements with "
+                    raise ParseError(f"File contains multiple elements with "
                                      f"path '{elem_path}'")
 
                 self._arxml_path_to_node[elem_path] = elem
@@ -2145,7 +2146,7 @@ class SystemLoader:
                     self._package_default_refbase_path.get(cur_package_path)
 
                 if is_default and current_default_refbase_path is not None:
-                    raise ValueError(f'Multiple default reference bases bases '
+                    raise ParseError(f'Multiple default reference bases bases '
                                      f'specified for package '
                                      f'"{cur_package_path}".')
                 elif is_default:
@@ -2158,7 +2159,7 @@ class SystemLoader:
                     is_global = (is_global.text.strip().lower() == "true")
 
                 if is_global:
-                    raise ValueError(f'Non-canonical relative references are '
+                    raise ParseError(f'Non-canonical relative references are '
                                      f'not yet supported.')
 
                 # ensure that a dictionary for the refbases of the package exists
@@ -2166,7 +2167,7 @@ class SystemLoader:
                     self._package_refbase_paths[cur_package_path] = {}
                 elif refbase_name in \
                      self._package_refbase_paths[cur_package_path]:
-                    raise ValueError(f'Package "{cur_package_path}" specifies '
+                    raise ParseError(f'Package "{cur_package_path}" specifies '
                                      f'multiple reference bases named '
                                      f'"{refbase_name}".')
                 self._package_refbase_paths[cur_package_path][refbase_name] = \
@@ -2216,7 +2217,7 @@ class SystemLoader:
         """
 
         if base_elems is None:
-            raise ValueError(
+            raise ParseError(
                 'Cannot retrieve a child element of a non-existing node!')
 
         # make sure that the children_location is a list. for convenience we
@@ -2266,7 +2267,7 @@ class SystemLoader:
                             refbase_name=child_elem.attrib.get('BASE'))
 
                         if tmp is None:
-                            raise ValueError(f'Encountered dangling reference '
+                            raise ParseError(f'Encountered dangling reference '
                                              f'{child_tag_name}-REF of type '
                                              f'"{child_elem.attrib.get("DEST")}": '
                                              f'{child_elem.text}')
@@ -2274,7 +2275,7 @@ class SystemLoader:
                         local_result.append(tmp)
 
                 if not is_nodeset and len(local_result) > 1:
-                    raise ValueError(f'Encountered a a non-unique child node '
+                    raise ParseError(f'Encountered a a non-unique child node '
                                      f'of type {child_tag_name} which ought to '
                                      f'be unique')
 
@@ -2288,7 +2289,7 @@ class SystemLoader:
         """This method does the same as get_arxml_children, but it assumes
         that the location yields at most a single node.
 
-        It returns None if no match was found and it raises ValueError
+        It returns None if no match was found and it raises ParseError
         if multiple nodes match the location, i.e., the returned
         object can be used directly if the corresponding node is
         assumed to be present.
@@ -2300,7 +2301,7 @@ class SystemLoader:
         elif len(tmp) == 1:
             return tmp[0]
         else:
-            raise ValueError(f'{child_location} does not resolve into a '
+            raise ParseError(f'{child_location} does not resolve into a '
                              f'unique node')
 
     def _get_can_frame(self, can_frame_triggering):

--- a/src/cantools/database/can/formats/arxml/system_loader.py
+++ b/src/cantools/database/can/formats/arxml/system_loader.py
@@ -93,8 +93,8 @@ class SystemLoader:
             0 if m.group(3) is None else int(m.group(3)[1:])
 
         if self.autosar_version_major not in {4, 3}:
-            raise ParseError('This class only supports AUTOSAR '
-                             'versions 3 and 4')
+            raise NotImplementedError('This class only supports AUTOSAR '
+                                      'versions 3 and 4')
 
         self._create_arxml_reference_dicts()
 
@@ -2159,8 +2159,8 @@ class SystemLoader:
                     is_global = (is_global.text.strip().lower() == "true")
 
                 if is_global:
-                    raise ParseError(f'Non-canonical relative references are '
-                                     f'not yet supported.')
+                    raise NotImplementedError(f'Non-canonical relative references are '
+                                              f'not yet supported.')
 
                 # ensure that a dictionary for the refbases of the package exists
                 if cur_package_path not in self._package_refbase_paths:

--- a/src/cantools/database/can/formats/arxml/system_loader.py
+++ b/src/cantools/database/can/formats/arxml/system_loader.py
@@ -1096,7 +1096,7 @@ class SystemLoader:
 
         cycle_time = None
         if time_period is not None:
-            cycle_time = int(float(time_period.text) * 1000)
+            cycle_time = int(parse_number_string(time_period.text, True) * 1000)
 
         # ordinary non-multiplexed message
         signals = self._load_pdu_signals(pdu)
@@ -1500,7 +1500,7 @@ class SystemLoader:
         if initial_string is not None:
             try:
                 raw_initial = parse_number_string(initial_string)
-            except ValueError:
+            except ParseError:
                 LOGGER.warning(f'The initial value ("{initial_string}") of signal '
                                f'{name} does not represent a number')
 
@@ -1757,10 +1757,11 @@ class SystemLoader:
 
             # the current scale is an enumeration value
             lower_limit, upper_limit = self._load_scale_limits(compu_scale)
-            assert lower_limit is not None \
-                   and lower_limit == upper_limit, \
-                   f'Invalid value specified for enumeration {vt}: ' \
-                   f'[{lower_limit}, {upper_limit}]'
+
+            if lower_limit is None or lower_limit != upper_limit:
+                raise ParseError(f'Invalid value specified for enumeration '
+                                 f'{vt}: [{lower_limit}, {upper_limit}]')
+
             value = lower_limit
             name = vt.text
             comments = self._load_comments(compu_scale)
@@ -1794,6 +1795,11 @@ class SystemLoader:
                     f'got {len(denominators)}.')
 
             denominator = parse_number_string(denominators[0].text, True)
+
+            if denominator == 0:
+                raise ParseError(
+                    'The denominator of a linear scaling must not be zero.')
+
             factor = parse_number_string(numerators[1].text, True) / denominator
             offset = parse_number_string(numerators[0].text, True) / denominator
 

--- a/src/cantools/database/can/formats/arxml/utils.py
+++ b/src/cantools/database/can/formats/arxml/utils.py
@@ -1,5 +1,7 @@
 # utility functions that are helpful when dealing with ARXML files
 
+from ....errors import ParseError
+
 
 def parse_number_string(in_string: str, allow_float: bool=False) \
     -> int | float:
@@ -54,7 +56,7 @@ def parse_number_string(in_string: str, allow_float: bool=False) \
         # check for not allowed non-integer values
         if not allow_float:
             if ret != int(ret):
-                raise ValueError('Floating point value specified where integer '
+                raise ParseError('Floating point value specified where integer '
                                  'is required')
             # if an integer is required but a .0 floating point value is
             # specified, we accept the input anyway. (this seems to be an

--- a/src/cantools/database/can/formats/arxml/utils.py
+++ b/src/cantools/database/can/formats/arxml/utils.py
@@ -3,7 +3,7 @@
 from ....errors import ParseError
 
 
-def parse_number_string(in_string: str, allow_float: bool=False) \
+def parse_number_string(in_string: str | None, allow_float: bool=False) \
     -> int | float:
     """Convert a string representing numeric value that is specified
     within an ARXML file to either an integer or a floating point object
@@ -16,6 +16,17 @@ def parse_number_string(in_string: str, allow_float: bool=False) \
     - Some ARXML editors seem to sometimes include a dot in integer
       numbers (e.g., they produce "123.0" instead of "123")
     """
+    if in_string is None:
+        raise ParseError('Expected a number, but the element is empty')
+
+    try:
+        return _parse_number_string(in_string, allow_float)
+    except ValueError:
+        raise ParseError(f"Expected a number, but got '{in_string.strip()}'") \
+            from None
+
+
+def _parse_number_string(in_string: str, allow_float: bool) -> int | float:
     ret: int | float | None = None
     in_string = in_string.strip().lower()
 

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import TypeVar
 
+import textparser
 from textparser import (
     Any,
     AnyUntil,
@@ -2392,7 +2393,10 @@ def load_string(string: str, strict: bool = True,
 
     """
 
-    tokens: DbcTokens = dbc_assert_type(DbcParser().parse(string), dict)
+    try:
+        tokens: DbcTokens = dbc_assert_type(DbcParser().parse(string), dict)
+    except (TokenizeError, textparser.ParseError) as e:
+        raise ParseError(str(e)) from e
 
     comments = _load_comments(tokens)
     attribute_definitions = _load_attribute_definitions(tokens)

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -5,7 +5,7 @@ import typing
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from dataclasses import dataclass, field
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import TypeVar
 
 import textparser
@@ -55,7 +55,7 @@ from ..node import Node
 from ..signal import Signal
 from ..signal_group import SignalGroup
 from .dbc_specifics import DbcSpecifics
-from .utils import num
+from .utils import num, parse_int
 
 # make mypy complain if we assign a value to the empty dictionary but
 # do not pay the runtime performance penalty of MappingProxyType.
@@ -311,12 +311,20 @@ ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE = AttributeDefinition[float](
 
 def to_int(value: AttributeValue) -> int:
     if isinstance(value, str):
-        return int(Decimal(value))
+        try:
+            return int(Decimal(value))
+        except (InvalidOperation, ValueError, OverflowError):
+            raise ParseError(
+                f"Expected an integer attribute value, but got '{value}'.") from None
     return int(value)
 
 def to_float(value: AttributeValue) -> float:
     if isinstance(value, str):
-        return float(Decimal(value))
+        try:
+            return float(Decimal(value))
+        except InvalidOperation:
+            raise ParseError(
+                f"Expected a number as attribute value, but got '{value}'.") from None
     return float(value)
 
 class DbcParser(Parser):
@@ -1228,7 +1236,8 @@ def _load_comments(tokens: DbcTokens) -> DbcComments:
 
         if kind == 'SG_':
             # signal comment
-            frame_id = int(dbc_assert_type(item[1], str))
+            frame_id = parse_int(dbc_assert_type(item[1], str),
+                                 'the frame id of CM_ SG_')
             signal_name = dbc_assert_type(item[2], str)
             if frame_id not in comments.signals:
                 comments.signals[frame_id] = {}
@@ -1236,7 +1245,8 @@ def _load_comments(tokens: DbcTokens) -> DbcComments:
             message_signal_comments[signal_name] = dbc_assert_type(item[3], str)
         elif kind == 'BO_':
             # message comment
-            frame_id = int(dbc_assert_type(item[1], str))
+            frame_id = parse_int(dbc_assert_type(item[1], str),
+                                 'the frame id of CM_ BO_')
             comments.messages[frame_id] = dbc_assert_type(item[2], str)
         elif kind == 'BU_':
             # node comment
@@ -1283,7 +1293,13 @@ def _load_attributes(tokens: DbcTokens, definitions: OrderedDict[str, AttributeD
 
     def to_attribute_object(attribute_tokens: TokenList) -> AttributeType:
         raw_value = dbc_assert_type(attribute_tokens[3], str)
-        definition = definitions[dbc_assert_type(attribute_tokens[1], str)]
+        attribute_name = dbc_assert_type(attribute_tokens[1], str)
+
+        try:
+            definition = definitions[attribute_name]
+        except KeyError:
+            raise ParseError(
+                f"Attribute '{attribute_name}' is not defined.") from None
 
         if definition.type_name in ['INT', 'HEX', 'ENUM']:
             return Attribute[int](value=to_int(raw_value),
@@ -1307,7 +1323,8 @@ def _load_attributes(tokens: DbcTokens, definitions: OrderedDict[str, AttributeD
             attribute_kind = dbc_assert_type(attribute_items[0], str)
 
             if attribute_kind == 'SG_':
-                frame_id_dbc = int(dbc_assert_type(attribute_items[1], str))
+                frame_id_dbc = parse_int(dbc_assert_type(attribute_items[1], str),
+                                         'the frame id of BA_ SG_')
 
                 if frame_id_dbc not in attributes.signals:
                     attributes.signals[frame_id_dbc] = OrderedDict()
@@ -1320,7 +1337,8 @@ def _load_attributes(tokens: DbcTokens, definitions: OrderedDict[str, AttributeD
 
                 signal_attrs[attribute_name] = to_attribute_object(attribute_tokens)
             elif attribute_kind == 'BO_':
-                frame_id_dbc = int(dbc_assert_type(attribute_items[1], str))
+                frame_id_dbc = parse_int(dbc_assert_type(attribute_items[1], str),
+                                         'the frame id of BA_ BO_')
 
                 if frame_id_dbc not in attributes.messages:
                     attributes.messages[frame_id_dbc] = OrderedDict()
@@ -1371,7 +1389,8 @@ def _load_relation_attributes(tokens: DbcTokens, definitions: OrderedDict[str, A
         node_name = dbc_assert_type(relation_attribute_tokens[3], str)
 
         if relation_type == 'BU_SG_REL_':
-            frame_id_dbc = int(dbc_assert_type(relation_attribute_tokens[5], str))
+            frame_id_dbc = parse_int(dbc_assert_type(relation_attribute_tokens[5], str),
+                                     'the frame id of BA_REL_ BU_SG_REL_')
             signal_name = dbc_assert_type(relation_attribute_tokens[6], str)
 
             if frame_id_dbc not in relation_attributes.node_signal_relations:
@@ -1385,7 +1404,8 @@ def _load_relation_attributes(tokens: DbcTokens, definitions: OrderedDict[str, A
                 to_relation_attribute_object(relation_attribute_tokens, dbc_assert_type(relation_attribute_tokens[7], str))
 
         elif relation_type == 'BU_BO_REL_':
-            frame_id_dbc = int(dbc_assert_type(relation_attribute_tokens[4], str))
+            frame_id_dbc = parse_int(dbc_assert_type(relation_attribute_tokens[4], str),
+                                     'the frame id of BA_REL_ BU_BO_REL_')
 
             if frame_id_dbc not in relation_attributes.node_message_relations:
                 relation_attributes.node_message_relations[frame_id_dbc] = OrderedDict()
@@ -1409,8 +1429,13 @@ def _load_value_tables(tokens: DbcTokens) -> OrderedDict[str, Choices]:
         value_table_tokens = dbc_assert_type(_value_table_tokens, list)
         name = dbc_assert_type(value_table_tokens[1], str)
         number_text_pairs = dbc_assert_type(value_table_tokens[2], list)
-        value_tables[name] = OrderedDict((int(number), NamedSignalValue(int(number), text))
-                                         for number, text in number_text_pairs)
+        value_table: Choices = OrderedDict()
+
+        for number, text in number_text_pairs:
+            value = parse_int(number, f'a value of VAL_TABLE_ {name}')
+            value_table[value] = NamedSignalValue(value, text)
+
+        value_tables[name] = value_table
 
     return value_tables
 
@@ -1424,12 +1449,14 @@ def _load_environment_variables(tokens: DbcTokens, comments: DbcComments, attrib
         long_name = _get_envvar_long_name(attributes, short_name)
         environment_variables[long_name] = EnvironmentVariable(
             name=long_name,
-            env_type=int(dbc_assert_type(envvar_tokens[3], str)),
+            env_type=parse_int(dbc_assert_type(envvar_tokens[3], str),
+                               f'the type of EV_ {short_name}'),
             minimum=num(dbc_assert_type(envvar_tokens[5], str)),
             maximum=num(dbc_assert_type(envvar_tokens[7], str)),
             unit=dbc_assert_type(envvar_tokens[9], str),
             initial_value=num(dbc_assert_type(envvar_tokens[10], str)),
-            env_id=int(dbc_assert_type(envvar_tokens[11], str)),
+            env_id=parse_int(dbc_assert_type(envvar_tokens[11], str),
+                             f'the id of EV_ {short_name}'),
             access_type=dbc_assert_type(envvar_tokens[12], str),
             access_node=dbc_assert_type(envvar_tokens[13], str),
             comment=comments.envvars.get(short_name),
@@ -1447,14 +1474,20 @@ def _load_choices(tokens: DbcTokens) -> ChoicesDict:
         if len(frame_id_list) == 0:
             continue
 
+        signal_name = dbc_assert_type(choice_tokens[2], str)
         pairs = dbc_assert_type(choice_tokens[3], list)
-        od: Choices = OrderedDict((int(v[0]), NamedSignalValue(int(v[0]), v[1])) for v in pairs)
+        od: Choices = OrderedDict()
+
+        for v in pairs:
+            value = parse_int(v[0], f'a value of VAL_ {signal_name}')
+            od[value] = NamedSignalValue(value, v[1])
 
         if len(od) == 0:
             continue
 
-        frame_id = int(frame_id_list[0])
-        choices[frame_id][dbc_assert_type(choice_tokens[2], str)] = od
+        frame_id = parse_int(frame_id_list[0],
+                             f'the frame id of VAL_ {signal_name}')
+        choices[frame_id][signal_name] = od
 
     return choices
 
@@ -1467,7 +1500,8 @@ def _load_message_senders(tokens: DbcTokens, attributes: DbcAttributes) -> defau
 
     for _sender_tokens in tokens.get('BO_TX_BU_', []):
         sender_tokens = dbc_assert_type(_sender_tokens, list)
-        frame_id = int(dbc_assert_type(sender_tokens[1], str))
+        frame_id = parse_int(dbc_assert_type(sender_tokens[1], str),
+                             'the frame id of BO_TX_BU_')
         message_senders[frame_id] += [
             _get_node_long_name(attributes, sender) for sender in dbc_assert_type(sender_tokens[3], list)
         ]
@@ -1484,9 +1518,12 @@ def _load_signal_types(tokens: DbcTokens) -> defaultdict[int, dict[str, int]]:
 
     for _signal_type_tokens in tokens.get('SIG_VALTYPE_', []):
         signal_type_tokens = dbc_assert_type(_signal_type_tokens, list)
-        frame_id = int(dbc_assert_type(signal_type_tokens[1], str))
+        frame_id = parse_int(dbc_assert_type(signal_type_tokens[1], str),
+                             'the frame id of SIG_VALTYPE_')
         signal_name = dbc_assert_type(signal_type_tokens[2], str)
-        signal_types[frame_id][signal_name] = int(dbc_assert_type(signal_type_tokens[4], str))
+        signal_types[frame_id][signal_name] = parse_int(
+            dbc_assert_type(signal_type_tokens[4], str),
+            f'the type of SIG_VALTYPE_ {signal_name}')
 
     return signal_types
 
@@ -1500,14 +1537,17 @@ def _load_signal_multiplexer_values(tokens: DbcTokens) -> MuxValues:
 
     for _signal_multiplexer_value_tokens in tokens.get('SG_MUL_VAL_', []):
         signal_multiplexer_value_tokens = dbc_assert_type(_signal_multiplexer_value_tokens, list)
-        frame_id = int(dbc_assert_type(signal_multiplexer_value_tokens[1], str))
+        frame_id = parse_int(dbc_assert_type(signal_multiplexer_value_tokens[1], str),
+                             'the frame id of SG_MUL_VAL_')
         signal_name = dbc_assert_type(signal_multiplexer_value_tokens[2], str)
         multiplexer_signal_name = dbc_assert_type(signal_multiplexer_value_tokens[3], str)
         multiplexer_ids: list[int] = []
 
         for lower_str, upper_str in dbc_assert_type(signal_multiplexer_value_tokens[4], list):
-            lower = int(lower_str)
-            upper = int(upper_str[1:])
+            lower = parse_int(lower_str,
+                              f'a multiplexer value of SG_MUL_VAL_ {signal_name}')
+            upper = parse_int(upper_str[1:],
+                              f'a multiplexer value of SG_MUL_VAL_ {signal_name}')
             # TODO: Probably store ranges as tuples to not run out of
             #       memory on huge ranges.
             multiplexer_ids.extend(range(lower, upper + 1))
@@ -1548,10 +1588,14 @@ def _load_signal_groups(tokens: DbcTokens, attributes: DbcAttributes) -> default
 
     for _signal_group_tokens in tokens.get('SIG_GROUP_',[]):
         signal_group_tokens = dbc_assert_type(_signal_group_tokens, list)
-        frame_id = int(dbc_assert_type(signal_group_tokens[1], str))
+        name = dbc_assert_type(signal_group_tokens[2], str)
+        frame_id = parse_int(dbc_assert_type(signal_group_tokens[1], str),
+                             f'the frame id of SIG_GROUP_ {name}')
+        repetitions = parse_int(dbc_assert_type(signal_group_tokens[3], str),
+                                f'the repetitions of SIG_GROUP_ {name}')
         signal_names = [get_signal_long_name(frame_id, sn) for sn in dbc_assert_type(signal_group_tokens[5], list)]
-        signal_groups[frame_id].append(SignalGroup(name=dbc_assert_type(signal_group_tokens[2], str),
-                                                   repetitions=int(dbc_assert_type(signal_group_tokens[3], str)),
+        signal_groups[frame_id].append(SignalGroup(name=name,
+                                                   repetitions=repetitions,
                                                    signal_names=signal_names))
 
     return signal_groups
@@ -1735,8 +1779,10 @@ def _load_signals(tokens: list[MatchObject],
         signal_name = mux_field[0]
         signals.append(
             Signal(name=get_signal_long_name(frame_id_dbc, signal_name),
-                   start=int(dbc_assert_type(signal_tokens[3], str)),
-                   length=int(dbc_assert_type(signal_tokens[5], str)),
+                   start=parse_int(dbc_assert_type(signal_tokens[3], str),
+                                   f'the start bit of SG_ {signal_name}'),
+                   length=parse_int(dbc_assert_type(signal_tokens[5], str),
+                                    f'the length of SG_ {signal_name}'),
                    receivers=get_signal_receivers(dbc_assert_type(signal_tokens[20], list)),
                    byte_order=('big_endian'
                                if signal_tokens[7] == '0'
@@ -1780,7 +1826,13 @@ def _get_enum_vframeformat_definition(attribute_definition: AttributeDefinitionT
         raise ParseError('Default value for VFrameFormat attribute must be defined '
                          'if the attribute is defined as an INT.')
     enum_attribute = deepcopy(ATTRIBUTE_DEFINITION_VFRAMEFORMAT)
-    enum_attribute.default_value = enum_attribute.choices[int(default_value)]
+    index = to_int(default_value)
+
+    if enum_attribute.choices is None or not 0 <= index < len(enum_attribute.choices):
+        raise ParseError(f'Default value {default_value} of the VFrameFormat '
+                         'attribute is out of range.')
+
+    enum_attribute.default_value = enum_attribute.choices[index]
 
     return enum_attribute
 
@@ -1830,7 +1882,13 @@ def _load_messages(tokens: DbcTokens,
             if send_type_attr is not None:
                 raw_result = send_type_attr.value
                 if send_type_def.choices and raw_result is not None:
-                    result = send_type_def.choices[int(raw_result)]
+                    index = to_int(raw_result)
+
+                    if not 0 <= index < len(send_type_def.choices):
+                        raise ParseError(f'GenMsgSendType {raw_result} of the message '
+                                         f'with frame id {frame_id_dbc} is out of range.')
+
+                    result = send_type_def.choices[index]
                 else:
                     result = dbc_assert_type(raw_result, str)
 
@@ -1910,7 +1968,8 @@ def _load_messages(tokens: DbcTokens,
             continue
 
         # Frame id.
-        frame_id_dbc = int(dbc_assert_type(message_tokens[1], str))
+        frame_id_dbc = parse_int(dbc_assert_type(message_tokens[1], str),
+                                 f'the frame id of BO_ {message_tokens[2]}')
         frame_id = frame_id_dbc & 0x7fffffff
         is_extended_frame = bool(frame_id_dbc & 0x80000000)
         frame_format = get_message_frame_format(frame_id_dbc)
@@ -1957,7 +2016,9 @@ def _load_messages(tokens: DbcTokens,
             Message(frame_id=frame_id,
                     is_extended_frame=is_extended_frame,
                     name=get_message_long_name(frame_id_dbc, dbc_assert_type(message_tokens[2], str)),
-                    length=int(dbc_assert_type(message_tokens[4], str), 0),
+                    length=parse_int(dbc_assert_type(message_tokens[4], str),
+                                     f'the length of BO_ {message_tokens[2]}',
+                                     0),
                     senders=senders,
                     send_type=get_message_send_type(frame_id_dbc),
                     cycle_time=get_message_cycle_time(frame_id_dbc),

--- a/src/cantools/database/can/formats/kcd.py
+++ b/src/cantools/database/can/formats/kcd.py
@@ -19,7 +19,7 @@ from ..internal_database import InternalDatabase
 from ..message import Message
 from ..node import Node
 from ..signal import Signal
-from .utils import num
+from .utils import num, parse_int
 
 LOGGER = logging.getLogger(__name__)
 
@@ -41,6 +41,31 @@ def _get_node_name_by_id(nodes, node_id):
     for node in nodes:
         if node['id'] == node_id:
             return node['name']
+
+
+def _where(element):
+    tag = element.tag.rsplit('}', 1)[-1]
+    name = element.get('name')
+
+    if name is None:
+        return f"element '{tag}'"
+
+    return f"{tag} '{name}'"
+
+
+def _attribute(element, key):
+    try:
+        return element.attrib[key]
+    except KeyError:
+        raise ParseError(
+            f"Missing attribute '{key}' of {_where(element)}.") from None
+
+
+def _parse_int_attribute(element, key, value=None, base=10):
+    if value is None:
+        value = _attribute(element, key)
+
+    return parse_int(value, f"attribute '{key}' of {_where(element)}", base)
 
 
 def _load_signal_element(signal, nodes):
@@ -69,13 +94,16 @@ def _load_signal_element(signal, nodes):
         if key == 'name':
             name = value
         elif key == 'offset':
-            offset = int(value)
+            offset = _parse_int_attribute(signal, key, value)
         elif key == 'length':
-            length = int(value)
+            length = _parse_int_attribute(signal, key, value)
         elif key == 'endianess':
             byte_order = f'{value}_endian'
         else:
             LOGGER.debug("Ignoring unsupported signal attribute '%s'.", key)
+
+    if offset is None:
+        raise ParseError(f"Missing attribute 'offset' of {_where(signal)}.")
 
     # Value XML element.
     value = signal.find('ns:Value', NAMESPACES)
@@ -114,8 +142,8 @@ def _load_signal_element(signal, nodes):
         labels = {}
 
         for label in label_set.iterfind('ns:Label', NAMESPACES):
-            label_value = int(label.attrib['value'])
-            label_name = label.attrib['name']
+            label_value = _parse_int_attribute(label, 'value')
+            label_name = _attribute(label, 'name')
             labels[label_value] = NamedSignalValue(label_value, label_name)
 
         # TODO: Label groups.
@@ -126,7 +154,7 @@ def _load_signal_element(signal, nodes):
     if consumer is not None:
         for receiver in consumer.iterfind('ns:NodeRef', NAMESPACES):
             receivers.append(_get_node_name_by_id(nodes,
-                                                  receiver.attrib['id']))
+                                                  _attribute(receiver, 'id')))
 
     conversion = BaseConversion.factory(
         scale=slope,
@@ -159,11 +187,11 @@ def _load_multiplex_element(mux, nodes):
     signals = [mux_signal]
 
     for mux_group in mux.iterfind('ns:MuxGroup', NAMESPACES):
-        multiplexer_id = mux_group.attrib['count']
+        multiplexer_id = _parse_int_attribute(mux_group, 'count')
 
         for signal_element in mux_group.iterfind('ns:Signal', NAMESPACES):
             signal = _load_signal_element(signal_element, nodes)
-            signal.multiplexer_ids = [int(multiplexer_id)]
+            signal.multiplexer_ids = [multiplexer_id]
             signal.multiplexer_signal = mux_signal.name
             signals.append(signal)
 
@@ -189,16 +217,19 @@ def _load_message_element(message, bus_name, nodes, strict, sort_signals):
         if key == 'name':
             name = value
         elif key == 'id':
-            frame_id = int(value, 0)
+            frame_id = _parse_int_attribute(message, key, value, base=0)
         elif key == 'format':
             is_extended_frame = (value == 'extended')
         elif key == 'length':
             length = value  # 'auto' needs additional processing after knowing all signals
         elif key == 'interval':
-            interval = int(value)
+            interval = _parse_int_attribute(message, key, value)
         else:
             LOGGER.debug("Ignoring unsupported message attribute '%s'.", key)
             # TODO: triggered, count, remote
+
+    if frame_id is None:
+        raise ParseError(f"Missing attribute 'id' of {_where(message)}.")
 
     # Comment. See the note in _load_signal_element about why all of the
     # text is gathered rather than just the leading text node.
@@ -213,7 +244,7 @@ def _load_message_element(message, bus_name, nodes, strict, sort_signals):
     if producer is not None:
         for sender in producer.iterfind('ns:NodeRef', NAMESPACES):
             senders.append(_get_node_name_by_id(nodes,
-                                                sender.attrib['id']))
+                                                _attribute(sender, 'id')))
 
     # Find all signals in this message.
     signals = []
@@ -232,7 +263,7 @@ def _load_message_element(message, bus_name, nodes, strict, sort_signals):
         else:
             length = 0
     else:
-        length = int(length)
+        length = _parse_int_attribute(message, 'length', length)
 
     return Message(frame_id=frame_id,
                    is_extended_frame=is_extended_frame,
@@ -481,7 +512,10 @@ def load_string(string:str, strict:bool=True, sort_signals:type_sort_signals=sor
     if root.tag != ROOT_TAG:
         raise ParseError(f'Expected root element tag {ROOT_TAG}, but got {root.tag}.')
 
-    nodes = [node.attrib for node in root.iterfind('./ns:Node', NAMESPACES)]
+    nodes = [
+        {'id': _attribute(node, 'id'), 'name': _attribute(node, 'name')}
+        for node in root.iterfind('./ns:Node', NAMESPACES)
+    ]
     buses = []
     messages = []
 
@@ -492,8 +526,10 @@ def load_string(string:str, strict:bool=True, sort_signals:type_sort_signals=sor
         version = None
 
     for bus in root.iterfind('ns:Bus', NAMESPACES):
-        bus_name = bus.attrib['name']
-        bus_baudrate = int(bus.get('baudrate', 500000))
+        bus_name = _attribute(bus, 'name')
+        bus_baudrate = _parse_int_attribute(bus,
+                                            'baudrate',
+                                            bus.get('baudrate', '500000'))
         buses.append(Bus(bus_name, baudrate=bus_baudrate))
 
         for message in bus.iterfind('ns:Message', NAMESPACES):

--- a/src/cantools/database/can/formats/kcd.py
+++ b/src/cantools/database/can/formats/kcd.py
@@ -6,6 +6,7 @@ from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 
 from ...conversion import BaseConversion
+from ...errors import ParseError
 from ...namedsignalvalue import NamedSignalValue
 from ...utils import (
     SORT_SIGNALS_DEFAULT,
@@ -471,11 +472,14 @@ def load_string(string:str, strict:bool=True, sort_signals:type_sort_signals=sor
 
     """
 
-    root = ElementTree.fromstring(string)
+    try:
+        root = ElementTree.fromstring(string)
+    except ElementTree.ParseError as e:
+        raise ParseError(str(e)) from e
 
     # Should be replaced with a validation using the XSD file.
     if root.tag != ROOT_TAG:
-        raise ValueError(f'Expected root element tag {ROOT_TAG}, but got {root.tag}.')
+        raise ParseError(f'Expected root element tag {ROOT_TAG}, but got {root.tag}.')
 
     nodes = [node.attrib for node in root.iterfind('./ns:Node', NAMESPACES)]
     buses = []

--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from itertools import groupby
 from typing import TYPE_CHECKING
 
+import textparser
 from textparser import (
     Any,
     DelimitedList,
@@ -653,7 +654,7 @@ def _get_senders(section_name: str) -> list[str]:
     elif section_name == '{SENDRECEIVE}':
         return [SEND_MESSAGE_SENDER, RECEIVE_MESSAGE_SENDER]
     else:
-        raise ValueError(f'Unexpected message section named {section_name}')
+        raise ParseError(f'Unexpected message section named {section_name}')
 
 def _load_message(frame_id,
                   is_extended_frame,
@@ -997,7 +998,10 @@ def load_string(string:str, strict:bool=True, sort_signals:type_sort_signals=sor
     if not re.search('^FormatVersion=6.0', string, re.MULTILINE):
         raise ParseError('Only SYM version 6.0 is supported.')
 
-    tokens = SymParser60().parse(string)
+    try:
+        tokens = SymParser60().parse(string)
+    except (TokenizeError, textparser.ParseError) as e:
+        raise ParseError(str(e)) from e
 
     version = _load_version(tokens)
     enums = _load_enums(tokens)

--- a/src/cantools/database/can/formats/sym.py
+++ b/src/cantools/database/can/formats/sym.py
@@ -34,7 +34,7 @@ from ...utils import (
 from ..internal_database import InternalDatabase
 from ..message import Message
 from ..signal import Signal
-from .utils import num
+from .utils import num, parse_int
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -305,7 +305,7 @@ def _load_enums(tokens):
     return all_enums
 
 
-def _load_signal_type_and_length(type_, tokens, enums):
+def _load_signal_type_and_length(name, type_, tokens, enums):
     # Default values.
     is_signed = False
     is_float = False
@@ -314,11 +314,17 @@ def _load_signal_type_and_length(type_, tokens, enums):
     minimum = None
     maximum = None
 
+    def length_from_tokens():
+        if not tokens:
+            raise ParseError(f"Missing length of signal '{name}'.")
+
+        return parse_int(tokens[0], f"the length of signal '{name}'")
+
     if type_ == 'signed':
         is_signed = True
-        length = int(tokens[0])
+        length = length_from_tokens()
     elif type_ == 'unsigned':
-        length = int(tokens[0])
+        length = length_from_tokens()
     elif type_ == 'float':
         is_float = True
         length = 32
@@ -335,10 +341,10 @@ def _load_signal_type_and_length(type_, tokens, enums):
         length = 8
     elif type_ in ['string', 'raw']:
         # As unsigned integer for now.
-        length = int(tokens[0])
+        length = length_from_tokens()
     else:
         # Enum. As unsigned integer for now.
-        length = int(tokens[0])
+        length = length_from_tokens()
         enum = _get_enum(enums, type_)
 
     return is_signed, is_float, length, enum, minimum, maximum
@@ -365,7 +371,7 @@ def _load_signal_attributes(tokens, enum, enums, minimum, maximum, spn):
             elif key == '/e:':
                 enum = _get_enum(enums, value)
             elif key == '/spn:':
-                spn = int(value)
+                spn = parse_int(value, 'the SPN')
             else:
                 LOGGER.debug("Ignoring unsupported message attribute '%s'.", key)
         elif item.startswith('/u:"'):
@@ -391,7 +397,8 @@ def _load_signal(tokens, enums):
      length,
      enum,
      minimum,
-     maximum) = _load_signal_type_and_length(tokens[3],
+     maximum) = _load_signal_type_and_length(name,
+                                             tokens[3],
                                              tokens[4],
                                              enums)
 
@@ -449,8 +456,14 @@ def _load_message_signal(tokens,
                          signals,
                          multiplexer_signal,
                          multiplexer_ids):
-    signal = signals[tokens[2]]
-    start = int(tokens[3])
+    name = tokens[2]
+
+    try:
+        signal = signals[name]
+    except KeyError:
+        raise ParseError(f"Signal '{name}' is not defined.") from None
+
+    start = parse_int(tokens[3], f"the start bit of signal '{name}'")
     start = _convert_start(start, signal.byte_order)
 
     conversion = BaseConversion.factory(
@@ -488,7 +501,7 @@ def _load_message_variable(tokens,
     # Default values.
     name = tokens[2]
     byte_order = 'little_endian'
-    start = int(tokens[4])
+    start = parse_int(tokens[4], f"the start bit of variable '{name}'")
     comment = None
     spn = None
 
@@ -498,7 +511,8 @@ def _load_message_variable(tokens,
      length,
      enum,
      minimum,
-     maximum) = _load_signal_type_and_length(tokens[3],
+     maximum) = _load_signal_type_and_length(name,
+                                             tokens[3],
                                              [tokens[6]],
                                              enums)
 
@@ -576,7 +590,9 @@ def _load_muxed_message_signals(message_tokens,
             base = 16
             mux_id = mux_id[:-1]
 
-        return [int(mux_id, base=base)]
+        return [parse_int(mux_id,
+                          f"the multiplexer value of '{mux_tokens[2]}'",
+                          base)]
 
     mux_tokens = message_tokens[3]['Mux'][0]
     multiplexer_signal = mux_tokens[2]
@@ -584,7 +600,8 @@ def _load_muxed_message_signals(message_tokens,
         byte_order = 'big_endian'
     else:
         byte_order = 'little_endian'
-    start = int(mux_tokens[3])
+    start = parse_int(mux_tokens[3],
+                      f"the start bit of multiplexer '{multiplexer_signal}'")
     start = _convert_start(start, byte_order)
     if mux_tokens[8]:
         comment = _load_comment(mux_tokens[8][0])
@@ -593,7 +610,9 @@ def _load_muxed_message_signals(message_tokens,
     result = [
         Signal(name=multiplexer_signal,
                start=start,
-               length=int(mux_tokens[5]),
+               length=parse_int(
+                   mux_tokens[5],
+                   f"the length of multiplexer '{multiplexer_signal}'"),
                byte_order=byte_order,
                is_multiplexer=True,
                comment=comment,
@@ -609,7 +628,13 @@ def _load_muxed_message_signals(message_tokens,
 
     for tokens in message_section_tokens:
         if tokens[1] == message_tokens[1] and tokens != message_tokens:
-            mux_tokens = tokens[3]['Mux'][0]
+            try:
+                mux_tokens = tokens[3]['Mux'][0]
+            except KeyError:
+                raise ParseError(
+                    f"Missing Mux entry in a definition of the multiplexed "
+                    f"message '{tokens[1]}'.") from None
+
             multiplexer_ids = get_mutliplexer_ids(mux_tokens)
             result += _load_message_signals_inner(tokens,
                                                   signals,
@@ -673,7 +698,8 @@ def _load_message(frame_id,
     comment = None
 
     if 'Len' in message_tokens[3]:
-        length = int(message_tokens[3]['Len'][0][2])
+        length = parse_int(message_tokens[3]['Len'][0][2],
+                           f"the length of message '{name}'")
 
     # Cycle time.
     try:
@@ -704,8 +730,10 @@ def _load_message(frame_id,
 
 
 def _parse_message_frame_ids(message):
+    name = message[1]
+
     def to_int(string):
-        return int(string, 16)
+        return parse_int(string, f"the frame id of message '{name}'", 16)
 
     def is_extended_frame(string, type_str):
         # Length of 9 includes terminating 'h' for hex

--- a/src/cantools/database/can/formats/utils.py
+++ b/src/cantools/database/can/formats/utils.py
@@ -15,3 +15,33 @@ def num(number_as_string: str) -> int | float:
         return float(number_as_string)
     except ValueError:
         raise ParseError('Expected integer or floating point number.') from None
+
+
+def parse_int(number_as_string: str, what: str, base: int = 10) -> int:
+    """Convert given string to an integer.
+
+    `what` names the value in the message of the ParseError raised if
+    the string is not an integer, for example "the length of signal
+    'Foo'".
+
+    """
+
+    try:
+        return int(number_as_string, base)
+    except ValueError:
+        raise ParseError(f"Expected an integer for {what}, but got "
+                         f"'{number_as_string}'.") from None
+
+
+def parse_float(number_as_string: str, what: str) -> float:
+    """Convert given string to a floating point number.
+
+    See :func:`parse_int` for `what`.
+
+    """
+
+    try:
+        return float(number_as_string)
+    except ValueError:
+        raise ParseError(f"Expected a number for {what}, but got "
+                         f"'{number_as_string}'.") from None

--- a/src/cantools/database/can/formats/utils.py
+++ b/src/cantools/database/can/formats/utils.py
@@ -1,3 +1,4 @@
+from ...errors import ParseError
 
 
 def num(number_as_string: str) -> int | float:
@@ -8,6 +9,9 @@ def num(number_as_string: str) -> int | float:
     try:
         return int(number_as_string)
     except ValueError:
+        pass
+
+    try:
         return float(number_as_string)
-    except Exception:
-        raise ValueError('Expected integer or floating point number.') from None
+    except ValueError:
+        raise ParseError('Expected integer or floating point number.') from None

--- a/src/cantools/database/diagnostics/formats/cdd.py
+++ b/src/cantools/database/diagnostics/formats/cdd.py
@@ -52,7 +52,7 @@ def _load_choices(data_type: ElementTree.Element) -> Choices | None:
         if start == end:
             choice_text = choice.findtext('TEXT/TUV[1]')
             if choice_text is None:
-                raise ValueError(f"Could not find name in TUV!")
+                raise ParseError(f"Could not find name in TUV!")
             choices[start] = choice_text
 
     if not choices:
@@ -87,7 +87,7 @@ def _load_data_types(ecu_doc: ElementTree.Element | None) -> dict[str, DataType]
         # Name and id.
         type_name = data_type.findtext('NAME/TUV[1]')
         if type_name is None:
-            raise ValueError(f"Could not find name in DATATYPE IDENT with id={data_type.attrib.get('id')}!")
+            raise ParseError(f"Could not find name in DATATYPE IDENT with id={data_type.attrib.get('id')}!")
         type_id = data_type.attrib['id']
 
         # Load from C-type element.
@@ -165,7 +165,7 @@ def _load_data_element(data: ElementTree.Element, offset: int, data_types: dict[
 
     name = data.findtext('QUAL')
     if name is None:
-        raise ValueError(f"Could not get QUAL text in data with id={data.attrib.get('id')}!")
+        raise ParseError(f"Could not get QUAL text in data with id={data.attrib.get('id')}!")
 
     return Data(name=name,
                 start=dbc_start_bitnum,
@@ -205,11 +205,11 @@ def _load_did_element(did: ElementTree.Element, data_types: dict[str, DataType],
 
     static_value = did.find('STATICVALUE')
     if static_value is None:
-        raise KeyError(f"Could not find STATICVALUE element in DID with id={did.attrib.get('id')}!")
+        raise ParseError(f"Could not find STATICVALUE element in DID with id={did.attrib.get('id')}!")
     identifier = int(static_value.attrib['v'])
     name = did.findtext('QUAL')
     if name is None:
-        raise ValueError(f"Could not get QUAL text in DID with id={did.attrib.get('id')}!")
+        raise ParseError(f"Could not get QUAL text in DID with id={did.attrib.get('id')}!")
     length = (offset + 7) // 8
 
     return Did(identifier=identifier,
@@ -238,15 +238,19 @@ def load_string(string: str) -> InternalDatabase:
 
     """
 
-    root = ElementTree.fromstring(string)
+    try:
+        root = ElementTree.fromstring(string)
+    except ElementTree.ParseError as e:
+        raise ParseError(str(e)) from e
+
     ecu_doc = root.find('ECUDOC')
     if ecu_doc is None:
-        raise KeyError("Could not find ECUDOC root element!")
+        raise ParseError("Could not find ECUDOC root element!")
     data_types = _load_data_types(ecu_doc)
     did_data_lib = _load_did_data_refs(ecu_doc)
     var = ecu_doc.findall('ECU')[0].find('VAR')
     if var is None:
-        raise KeyError(f"Could not find VAR element in ECU with id={ecu_doc.findall('ECU')[0].attrib.get('id')}!")
+        raise ParseError(f"Could not find VAR element in ECU with id={ecu_doc.findall('ECU')[0].attrib.get('id')}!")
     dids: list[Did] = []
 
     for diag_class in var.findall('DIAGCLASS'):

--- a/src/cantools/database/diagnostics/formats/cdd.py
+++ b/src/cantools/database/diagnostics/formats/cdd.py
@@ -5,6 +5,7 @@ from xml.etree import ElementTree
 
 from cantools.typechecking import ByteOrder, Choices
 
+from ...can.formats.utils import parse_float, parse_int
 from ...conversion import BaseConversion
 from ...errors import ParseError
 from ...utils import cdd_offset_to_dbc_start_bit
@@ -42,12 +43,22 @@ class DataType:
         self.offset = offset
 
 
+def _attribute(element: ElementTree.Element, name: str) -> str:
+    try:
+        return element.attrib[name]
+    except KeyError:
+        raise ParseError(f"Could not find attribute '{name}' in {element.tag} "
+                         f"element with id={element.attrib.get('id')}!") from None
+
+
 def _load_choices(data_type: ElementTree.Element) -> Choices | None:
     choices: Choices = OrderedDict()
 
     for choice in data_type.findall('TEXTMAP'):
-        start = int(choice.attrib['s'].strip('()'))
-        end = int(choice.attrib['e'].strip('()'))
+        start = parse_int(_attribute(choice, 's').strip('()'),
+                          "attribute 's' of TEXTMAP")
+        end = parse_int(_attribute(choice, 'e').strip('()'),
+                        "attribute 'e' of TEXTMAP")
 
         if start == end:
             choice_text = choice.findtext('TEXT/TUV[1]')
@@ -88,29 +99,33 @@ def _load_data_types(ecu_doc: ElementTree.Element | None) -> dict[str, DataType]
         type_name = data_type.findtext('NAME/TUV[1]')
         if type_name is None:
             raise ParseError(f"Could not find name in DATATYPE IDENT with id={data_type.attrib.get('id')}!")
-        type_id = data_type.attrib['id']
+        type_id = _attribute(data_type, 'id')
 
         # Load from C-type element.
         ctype = data_type.find('CVALUETYPE')
         if ctype is not None:
             for key, value in ctype.attrib.items():
+                what = f"attribute '{key}' of CVALUETYPE in data type {type_name}"
+
                 if key == 'bl':
-                    bit_length = int(value)
+                    bit_length = parse_int(value, what)
                 elif key == 'enc':
                     encoding = value
                 elif key == 'minsz':
-                    minimum = int(value)
+                    minimum = parse_int(value, what)
                 elif key == 'maxsz':
-                    maximum = int(value)
+                    maximum = parse_int(value, what)
                 else:
                     LOGGER.debug("Ignoring unsupported attribute '%s'.", key)
 
-            if ctype.attrib['bo'] == '21':
+            byte_order_code = _attribute(ctype, 'bo')
+
+            if byte_order_code == '21':
                 byte_order = 'big_endian'
-            elif ctype.attrib['bo'] == '12':
+            elif byte_order_code == '12':
                 byte_order = 'little_endian'
             else:
-                raise ParseError(f"Unknown byte order code: {ctype.attrib['bo']}")
+                raise ParseError(f"Unknown byte order code: {byte_order_code}")
 
         # Load from P-type element.
         unit = data_type.findtext('PVALUETYPE/UNIT')
@@ -122,11 +137,13 @@ def _load_data_types(ecu_doc: ElementTree.Element | None) -> dict[str, DataType]
         comp = data_type.find('COMP')
 
         if comp is not None:
-            factor = float(comp.attrib['f'])
-            offset = float(comp.attrib['o'])
+            factor = parse_float(_attribute(comp, 'f'),
+                                 f"attribute 'f' of COMP in data type {type_name}")
+            offset = parse_float(_attribute(comp, 'o'),
+                                 f"attribute 'o' of COMP in data type {type_name}")
 
         if bit_length == 0:
-            raise RuntimeError("CVALUETYPE element cannot have bit length 0!")
+            raise ParseError("CVALUETYPE element cannot have bit length 0!")
 
         data_types[type_id] = DataType(type_name,
                                        type_id,
@@ -148,7 +165,13 @@ def _load_data_element(data: ElementTree.Element, offset: int, data_types: dict[
 
     """
 
-    data_type = data_types[data.attrib['dtref']]
+    data_type_id = _attribute(data, 'dtref')
+
+    try:
+        data_type = data_types[data_type_id]
+    except KeyError:
+        raise ParseError(f"Could not find data type {data_type_id} referenced "
+                         f"by data with id={data.attrib.get('id')}!") from None
 
     # Map CDD/c-style field offset to the DBC/can.Signal.start bit numbering
     # convention for compatibility with can.Signal objects and the shared codec
@@ -206,7 +229,9 @@ def _load_did_element(did: ElementTree.Element, data_types: dict[str, DataType],
     static_value = did.find('STATICVALUE')
     if static_value is None:
         raise ParseError(f"Could not find STATICVALUE element in DID with id={did.attrib.get('id')}!")
-    identifier = int(static_value.attrib['v'])
+    identifier = parse_int(_attribute(static_value, 'v'),
+                           f"attribute 'v' of STATICVALUE in DID with "
+                           f"id={did.attrib.get('id')}")
     name = did.findtext('QUAL')
     if name is None:
         raise ParseError(f"Could not get QUAL text in DID with id={did.attrib.get('id')}!")
@@ -230,7 +255,7 @@ def _load_did_data_refs(ecu_doc: ElementTree.Element | None) -> dict[str, Elemen
     if dids is None:
         return {}
     else:
-        return {did.attrib['id']: did for did in dids.findall('DID')}
+        return {_attribute(did, 'id'): did for did in dids.findall('DID')}
 
 
 def load_string(string: str) -> InternalDatabase:
@@ -248,9 +273,12 @@ def load_string(string: str) -> InternalDatabase:
         raise ParseError("Could not find ECUDOC root element!")
     data_types = _load_data_types(ecu_doc)
     did_data_lib = _load_did_data_refs(ecu_doc)
-    var = ecu_doc.findall('ECU')[0].find('VAR')
+    ecu = ecu_doc.find('ECU')
+    if ecu is None:
+        raise ParseError("Could not find ECU element in ECUDOC!")
+    var = ecu.find('VAR')
     if var is None:
-        raise ParseError(f"Could not find VAR element in ECU with id={ecu_doc.findall('ECU')[0].attrib.get('id')}!")
+        raise ParseError(f"Could not find VAR element in ECU with id={ecu.attrib.get('id')}!")
     dids: list[Did] = []
 
     for diag_class in var.findall('DIAGCLASS'):

--- a/src/cantools/database/errors.py
+++ b/src/cantools/database/errors.py
@@ -19,6 +19,22 @@ class DecodeError(Error):
     pass
 
 
+def format_load_error(database_format: str, e: Exception) -> str:
+    """Describe why a string could not be loaded as `database_format`.
+
+    Loaders raise ParseError, or another cantools Error for the checks
+    of strict mode, if the string is at fault. Any other exception is a
+    bug in cantools.
+
+    """
+
+    if isinstance(e, Error):
+        return f'{database_format.upper()}: "{e}"'
+
+    return (f'{database_format.upper()}: "{type(e).__name__}: {e}" '
+            f'(this is a bug in cantools that ought to be fixed)')
+
+
 class UnsupportedDatabaseFormatError(Error):
     """This exception is raised when
     :func:`~cantools.database.load_file()`,
@@ -36,20 +52,13 @@ class UnsupportedDatabaseFormatError(Error):
                  e_cdd: Exception | None) -> None:
         message_chunks: list[str] = []
 
-        if e_arxml is not None:
-            message_chunks.append(f'ARXML: "{e_arxml}"')
-
-        if e_dbc is not None:
-            message_chunks.append(f'DBC: "{e_dbc}"')
-
-        if e_kcd is not None:
-            message_chunks.append(f'KCD: "{e_kcd}"')
-
-        if e_sym is not None:
-            message_chunks.append(f'SYM: "{e_sym}"')
-
-        if e_cdd is not None:
-            message_chunks.append(f'CDD: "{e_cdd}"')
+        for database_format, e in [('arxml', e_arxml),
+                                   ('dbc', e_dbc),
+                                   ('kcd', e_kcd),
+                                   ('sym', e_sym),
+                                   ('cdd', e_cdd)]:
+            if e is not None:
+                message_chunks.append(format_load_error(database_format, e))
 
         message = ', '.join(message_chunks)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import traceback
+
+import pytest
+
+from cantools.database.can.formats import arxml, dbc, kcd, sym
+from cantools.database.diagnostics.formats import cdd
+from cantools.database.errors import Error
+
+LOADERS = [arxml, dbc, kcd, sym, cdd]
+
+
+@pytest.fixture(autouse=True)
+def loaders_raise_only_cantools_errors(request, monkeypatch):
+    """Fail the test if a format loader raises anything but a cantools
+    Error (ParseError, or Error for the checks of strict mode) or
+    NotImplementedError.
+
+    """
+
+    leaks = set()
+
+    def checked(module):
+        load_string = module.load_string
+
+        def wrapper(*args, **kwargs):
+            try:
+                return load_string(*args, **kwargs)
+            except (Error, NotImplementedError):
+                raise
+            except Exception as e:
+                frames = traceback.extract_tb(e.__traceback__)
+                origin = ([f for f in frames if 'cantools' in f.filename]
+                          or frames)[-1]
+                leaks.add(f'{module.__name__}: {type(e).__name__}: {e} '
+                          f'(raised at {origin.filename}:{origin.lineno})')
+                raise
+
+        return wrapper
+
+    for module in LOADERS:
+        monkeypatch.setattr(module, 'load_string', checked(module))
+
+    yield
+
+    if leaks and request.node.get_closest_marker('loader_may_raise') is None:
+        pytest.fail('A loader raised something other than a cantools Error:\n'
+                    + '\n'.join(sorted(leaks)))

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4493,6 +4493,13 @@ class CanToolsDatabaseTest(unittest.TestCase):
             str(cm.exception),
             'ARXML: "Could not parse AUTOSAR version \'4.2.2.1.0\'"')
 
+    def test_unsupported_autosar_version_arxml(self):
+        with self.assertRaises(NotImplementedError) as cm:
+            arxml.load_string('<AUTOSAR xmlns="http://autosar.org/2.1.DAI.0"/>')
+
+        self.assertEqual(str(cm.exception),
+                         'This class only supports AUTOSAR versions 3 and 4')
+
     def test_arxml_version(self):
         root = ElementTree.parse('tests/files/arxml/system-4.2.arxml').getroot()
         loader = cantools.database.can.formats.arxml.SystemLoader(root, strict=False)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2778,6 +2778,109 @@ class CanToolsDatabaseTest(unittest.TestCase):
                       '(this is a bug in cantools that ought to be fixed)',
                       str(cm.exception))
 
+    def test_malformed_content_raises_parse_error(self):
+        # the string is in the format and tokenizes, but a value in it
+        # cannot be used or a reference cannot be resolved. this is a
+        # statement about the input, so it is a ParseError and not a
+        # bug that load_string() reports
+        kcd_string = (
+            '<NetworkDefinition xmlns="http://kayak.2codeornot2code.org/1.0">'
+            '<Node id="1" name="N"/>'
+            '<Bus name="B"><Message id="0x1" name="M">'
+            '<Signal name="S" offset="0" length="8">'
+            '<LabelSet><Label name="L" value="1"/></LabelSet>'
+            '</Signal></Message></Bus></NetworkDefinition>')
+        sym_string = ('FormatVersion=6.0 // Do not edit this line!\n'
+                      '{SIGNALS}\n'
+                      'Sig=S unsigned 8\n'
+                      '{SENDRECEIVE}\n'
+                      '[M]\n'
+                      'ID=001h\n'
+                      'Sig=S 0\n')
+        dbc_string = ('VERSION "1"\n'
+                      'BO_ 1 M: 8 N\n'
+                      ' SG_ S : 0|8@1+ (1,0) [0|0] "" N\n')
+        cdd_string = (
+            '<CANDELA><ECUDOC>'
+            '<DATATYPES><IDENT id="t"><NAME><TUV>T</TUV></NAME>'
+            '<CVALUETYPE bl="8" bo="21"/></IDENT></DATATYPES>'
+            '<ECU><VAR><DIAGCLASS><DIAGINST id="d"><SIMPLECOMPCONT>'
+            '<DATAOBJ id="x" dtref="t"><QUAL>Q</QUAL></DATAOBJ>'
+            '</SIMPLECOMPCONT><STATICVALUE v="1"/><QUAL>D</QUAL>'
+            '</DIAGINST></DIAGCLASS></VAR></ECU>'
+            '</ECUDOC></CANDELA>')
+
+        with open('tests/files/arxml/system-4.2.arxml', encoding='utf-8') as fin:
+            arxml_string = fin.read()
+
+        with open('tests/files/arxml/ecu-extract-4.2.arxml',
+                  encoding='utf-8') as fin:
+            ecu_extract_string = fin.read()
+
+        for load, string in [(kcd.load_string, kcd_string),
+                             (sym.load_string, sym_string),
+                             (dbc.load_string, dbc_string),
+                             (cdd.load_string, cdd_string)]:
+            load(string)
+
+        cases = [
+            ('kcd', kcd.load_string,
+             kcd_string.replace('length="8"', 'length=""'),
+             ("Expected an integer for attribute 'length' of Signal 'S', "
+              "but got ''.")),
+            ('kcd', kcd.load_string,
+             kcd_string.replace('value="1"', 'value="x"'),
+             ("Expected an integer for attribute 'value' of Label 'L', "
+              "but got 'x'.")),
+            ('kcd', kcd.load_string,
+             kcd_string.replace(' offset="0"', ''),
+             "Missing attribute 'offset' of Signal 'S'."),
+            ('sym', sym.load_string,
+             sym_string.replace('Sig=S 0', 'Sig=U 0'),
+             "Signal 'U' is not defined."),
+            ('sym', sym.load_string,
+             sym_string.replace('unsigned 8', 'unsigned 8.5'),
+             ("Expected an integer for the length of signal 'S', "
+              "but got '8.5'.")),
+            ('dbc', dbc.load_string,
+             dbc_string.replace('BO_ 1 M', 'BO_ 1.5 M'),
+             "Expected an integer for the frame id of BO_ M, but got '1.5'."),
+            ('dbc', dbc.load_string,
+             dbc_string + 'BA_ "Nope" BO_ 1 1;\n',
+             "Attribute 'Nope' is not defined."),
+            ('arxml', arxml.load_string,
+             arxml_string.replace('<FRAME-LENGTH>2<', '<FRAME-LENGTH>x<', 1),
+             "Expected a number, but got 'x'"),
+            ('arxml', arxml.load_string,
+             re.sub(r'(ComBitPosition</DEFINITION-REF>\s*<VALUE>)4',
+                    r'\1x',
+                    ecu_extract_string,
+                    count=1),
+             ("Expected an integer for parameter 'ComBitPosition', "
+              "but got 'x'.")),
+            ('cdd', cdd.load_string,
+             cdd_string.replace('bl="8"', 'bl="x"'),
+             ("Expected an integer for attribute 'bl' of CVALUETYPE in data "
+              "type T, but got 'x'.")),
+            ('cdd', cdd.load_string,
+             cdd_string.replace('dtref="t"', 'dtref="u"'),
+             'Could not find data type u referenced by data with id=x!'),
+        ]
+
+        for fmt, load, string, message in cases:
+            with self.subTest(fmt=fmt, message=message):
+                with self.assertRaises(ParseError) as cm:
+                    load(string)
+
+                self.assertEqual(str(cm.exception), message)
+
+                with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
+                    cantools.database.load_string(string)
+
+                self.assertIsInstance(getattr(cm.exception, f'e_{fmt}'),
+                                      ParseError)
+                self.assertNotIn('bug in cantools', str(cm.exception))
+
     def test_bus(self):
         bus = cantools.database.Bus('foo')
         self.assertEqual(repr(bus), "bus('foo', None)")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -12,6 +12,7 @@ from io import StringIO
 from pathlib import Path
 from xml.etree import ElementTree
 
+import pytest
 from parameterized import parameterized  # type: ignore
 
 import cantools.autosar
@@ -2758,6 +2759,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             self.assertEqual(str(cm.exception), bug)
             self.assertIsInstance(cm.exception.__cause__, RuntimeError)
 
+    @pytest.mark.loader_may_raise
     def test_load_string_sort_signals_exception(self):
         # an exception raised by the sort_signals callback is not a
         # statement about the input, so it ends up in the same class as
@@ -2880,6 +2882,36 @@ class CanToolsDatabaseTest(unittest.TestCase):
                 self.assertIsInstance(getattr(cm.exception, f'e_{fmt}'),
                                       ParseError)
                 self.assertNotIn('bug in cantools', str(cm.exception))
+
+    def test_files_raise_only_parse_error(self):
+        # load every file of the test suite as every format. a loader
+        # either succeeds or raises ParseError (or Error in strict
+        # mode); anything else is reported as a bug by load_string()
+        encodings = {'.dbc': 'cp1252', '.sym': 'cp1252', '.cdd': 'iso-8859-1'}
+
+        for path in sorted(Path('tests/files').rglob('*')):
+            if not path.is_file():
+                continue
+
+            with open(path,
+                      encoding=encodings.get(path.suffix, 'utf-8'),
+                      errors='replace') as fin:
+                string = fin.read()
+
+            for database_format in ['arxml', 'dbc', 'kcd', 'sym', 'cdd', None]:
+                for strict in [True, False]:
+                    with self.subTest(file=str(path),
+                                      database_format=database_format,
+                                      strict=strict):
+                        try:
+                            cantools.database.load_string(
+                                string,
+                                database_format=database_format,
+                                strict=strict)
+                        except NotImplementedError:
+                            pass
+                        except UnsupportedDatabaseFormatError as e:
+                            self.assertNotIn('bug in cantools', str(e))
 
     def test_bus(self):
         bus = cantools.database.Bus('foo')

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -12,14 +12,14 @@ from io import StringIO
 from pathlib import Path
 from xml.etree import ElementTree
 
-import textparser  # type: ignore
 from parameterized import parameterized  # type: ignore
 
 import cantools.autosar
 import cantools.database
 from cantools.database import Message, Signal
-from cantools.database.can.formats import dbc
+from cantools.database.can.formats import arxml, dbc, kcd, sym
 from cantools.database.can.formats.dbc import LongNamesConverter
+from cantools.database.diagnostics.formats import cdd
 from cantools.database.errors import (
     DecodeError,
     EncodeError,
@@ -2397,7 +2397,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_add_bad_sym_string(self):
         db = cantools.database.Database()
 
-        with self.assertRaises(textparser.ParseError) as cm:
+        with self.assertRaises(ParseError) as cm:
             db.add_sym_string('FormatVersion=6.0\n'
                               'Foo="Jopp"')
 
@@ -2654,10 +2654,48 @@ class CanToolsDatabaseTest(unittest.TestCase):
     def test_add_bad_kcd_string(self):
         db = cantools.database.Database()
 
-        with self.assertRaises(ElementTree.ParseError) as cm:
+        with self.assertRaises(ParseError) as cm:
             db.add_kcd_string('not xml')
 
         self.assertEqual(str(cm.exception), 'syntax error: line 1, column 0')
+
+    def test_malformed_string_raises_parse_error(self):
+        cases = [
+            ('dbc', dbc.load_string, 'abc',
+             'Invalid syntax at line 1, column 1: ">>!<<abc"'),
+            ('kcd', kcd.load_string, 'not xml',
+             'syntax error: line 1, column 0'),
+            ('kcd', kcd.load_string, '<WrongRootElement/>',
+             ('Expected root element tag '
+              '{http://kayak.2codeornot2code.org/1.0}NetworkDefinition, but '
+              'got WrongRootElement.')),
+            ('sym', sym.load_string, 'FormatVersion=6.0\nFoo="Jopp"',
+             'Invalid syntax at line 2, column 1: ">>!<<Foo="Jopp""'),
+            ('arxml', arxml.load_string, 'not xml',
+             'syntax error: line 1, column 0'),
+            ('arxml', arxml.load_string, '<AUTOSAR/>',
+             "No XML namespace specified or illegal root tag name 'AUTOSAR'"),
+            ('cdd', cdd.load_string, 'not xml',
+             'syntax error: line 1, column 0'),
+            ('cdd', cdd.load_string, '<ROOT/>',
+             'Could not find ECUDOC root element!'),
+        ]
+
+        for fmt, load, string, message in cases:
+            with self.subTest(fmt=fmt, string=string):
+                with self.assertRaises(ParseError) as cm:
+                    load(string)
+
+                self.assertNotIsInstance(cm.exception, ValueError)
+                self.assertEqual(str(cm.exception), message)
+
+                with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
+                    cantools.database.load_string(string, database_format=fmt)
+
+                self.assertIsInstance(getattr(cm.exception, f'e_{fmt}'),
+                                      ParseError)
+                self.assertEqual(str(cm.exception),
+                                 f'{fmt.upper()}: "{message}"')
 
     def test_bus(self):
         bus = cantools.database.Bus('foo')
@@ -2670,7 +2708,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(cantools.database.can.formats.utils.num('1'), 1)
         self.assertEqual(cantools.database.can.formats.utils.num('1.0'), 1.0)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParseError):
             cantools.database.can.formats.utils.num('x')
 
     def test_timing(self):
@@ -3040,7 +3078,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
     def test_dbc_parse_error_messages(self):
         # No valid entry.
-        with self.assertRaises(textparser.ParseError) as cm:
+        with self.assertRaises(ParseError) as cm:
 
             dbc.load_string('abc')
 
@@ -3049,7 +3087,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             'Invalid syntax at line 1, column 1: ">>!<<abc"')
 
         # Bad message frame id.
-        with self.assertRaises(textparser.ParseError) as cm:
+        with self.assertRaises(ParseError) as cm:
             dbc.load_string('VERSION "1.0"\n'
                             'BO_ dssd\n')
 
@@ -3058,7 +3096,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             'Invalid syntax at line 2, column 5: "BO_ >>!<<dssd"')
 
         # Bad entry key.
-        with self.assertRaises(textparser.ParseError) as cm:
+        with self.assertRaises(ParseError) as cm:
             dbc.load_string('VERSION "1.0"\n'
                             'dd\n')
 
@@ -3067,7 +3105,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             'Invalid syntax at line 2, column 1: ">>!<<dd"')
 
         # Missing colon in message.
-        with self.assertRaises(textparser.ParseError) as cm:
+        with self.assertRaises(ParseError) as cm:
             dbc.load_string('VERSION "1.0"\n'
                             'BO_ 546 EMV_Stati 8 EMV_Statusmeldungen\n')
 
@@ -3077,7 +3115,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             '>>!<<8 EMV_Statusmeldungen"')
 
         # Missing frame id in message comment.
-        with self.assertRaises(textparser.ParseError) as cm:
+        with self.assertRaises(ParseError) as cm:
             dbc.load_string('CM_ BO_ "Foo.";')
 
         self.assertEqual(
@@ -4424,7 +4462,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             'ARXML: "Unrecognized XML namespace \'http://autosar.org/schema/argh4.0\'"')
 
         root = ElementTree.parse('tests/files/arxml/system-illegal-namespace-4.2.arxml').getroot()
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParseError) as cm:
             cantools.database.can.formats.arxml.SystemLoader(root, strict=False)
 
         self.assertEqual(
@@ -4440,7 +4478,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
             'ARXML: "No XML namespace specified or illegal root tag name \'{http://autosar.org/schema/r4.0}AUTOSARGH\'"')
 
         root = ElementTree.parse('tests/files/arxml/system-illegal-root-4.2.arxml').getroot()
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParseError) as cm:
             cantools.database.can.formats.arxml.SystemLoader(root, strict=False)
 
         self.assertEqual(
@@ -5296,7 +5334,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         loader = cantools.database.can.formats.arxml.SystemLoader(root, strict=True)
 
         # a base node must always be specified
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParseError) as cm:
             loader._get_arxml_children(None, ["AR-PACKAGES", "*AR-PACKAGE"])
         self.assertEqual(str(cm.exception), "Cannot retrieve a child element of a non-existing node!")
 
@@ -5329,7 +5367,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
                          ])
 
         # test unique location specifier if child nodes exist
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParseError) as cm:
             loader._get_arxml_children(loader._root, ["AR-PACKAGES", "AR-PACKAGE"])
         self.assertEqual(str(cm.exception),
                          "Encountered a a non-unique child node of type AR-PACKAGE which ought to be unique")
@@ -5340,7 +5378,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(foo, bar)
 
         # test non-unique location while assuming that it is unique
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParseError) as cm:
             loader._get_unique_arxml_child(loader._root, ["AR-PACKAGES", "*AR-PACKAGE"])
         self.assertEqual(str(cm.exception), "['AR-PACKAGES', '*AR-PACKAGE'] does not resolve into a unique node")
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2697,6 +2697,87 @@ class CanToolsDatabaseTest(unittest.TestCase):
                 self.assertEqual(str(cm.exception),
                                  f'{fmt.upper()}: "{message}"')
 
+    def test_load_string_probing(self):
+        # ParseError: the string is not in this format, try the next one
+        with self.assertRaises(UnsupportedDatabaseFormatError) as cm:
+            cantools.database.load_string('abc')
+
+        for e in [cm.exception.e_arxml,
+                  cm.exception.e_dbc,
+                  cm.exception.e_kcd,
+                  cm.exception.e_sym,
+                  cm.exception.e_cdd]:
+            self.assertIsInstance(e, ParseError)
+
+        # NotImplementedError: the string is in this format, do not try
+        # further formats
+        unsupported = '<AUTOSAR xmlns="http://autosar.org/2.1.DAI.0"/>'
+
+        with (unittest.mock.patch.object(dbc, 'load_string',
+                                         wraps=dbc.load_string) as load_dbc,
+              self.assertRaises(NotImplementedError) as cm):
+            cantools.database.load_string(unsupported)
+
+        self.assertEqual(str(cm.exception),
+                         'This class only supports AUTOSAR versions 3 and 4')
+        load_dbc.assert_not_called()
+
+        with self.assertRaises(NotImplementedError):
+            cantools.database.load_string(unsupported, database_format='arxml')
+
+        # anything else is a bug in a loader: report it and try the next
+        # format anyway
+        kcd_string = (
+            '<NetworkDefinition xmlns="http://kayak.2codeornot2code.org/1.0">'
+            '<Bus name="B"><Message id="0x1" name="M">'
+            '<Signal name="S" offset="0" length="8"/>'
+            '</Message></Bus></NetworkDefinition>')
+        bug = ('DBC: "RuntimeError: boom" '
+               '(this is a bug in cantools that ought to be fixed)')
+
+        with unittest.mock.patch.object(dbc, 'load_string',
+                                        side_effect=RuntimeError('boom')):
+            with self.assertLogs('cantools.database', level='WARNING') as logs:
+                db = cantools.database.load_string(kcd_string)
+
+            self.assertEqual(db.messages[0].name, 'M')
+            self.assertEqual(logs.output, [f'WARNING:cantools.database:{bug}'])
+
+            with (self.assertLogs('cantools.database', level='WARNING'),
+                  self.assertRaises(UnsupportedDatabaseFormatError) as cm):
+                cantools.database.load_string('abc')
+
+            self.assertIsInstance(cm.exception.e_dbc, RuntimeError)
+            self.assertIsInstance(cm.exception.e_kcd, ParseError)
+            self.assertIn(bug, str(cm.exception))
+
+            with (self.assertLogs('cantools.database', level='WARNING'),
+                  self.assertRaises(UnsupportedDatabaseFormatError) as cm):
+                cantools.database.load_string('abc', database_format='dbc')
+
+            self.assertEqual(str(cm.exception), bug)
+            self.assertIsInstance(cm.exception.__cause__, RuntimeError)
+
+    def test_load_string_sort_signals_exception(self):
+        # an exception raised by the sort_signals callback is not a
+        # statement about the input, so it ends up in the same class as
+        # a bug in a loader
+        sentinel = TypeError('raised by sort_signals')
+
+        def sort_signals(signals):
+            raise sentinel
+
+        with (self.assertLogs('cantools.database', level='WARNING'),
+              self.assertRaises(UnsupportedDatabaseFormatError) as cm):
+            cantools.database.load_string(
+                'VERSION "1"\nBO_ 1 M: 8 N\n SG_ S : 0|8@1+ (1,0) [0|0] "" N\n',
+                sort_signals=sort_signals)
+
+        self.assertIs(cm.exception.e_dbc, sentinel)
+        self.assertIn('DBC: "TypeError: raised by sort_signals" '
+                      '(this is a bug in cantools that ought to be fixed)',
+                      str(cm.exception))
+
     def test_bus(self):
         bus = cantools.database.Bus('foo')
         self.assertEqual(repr(bus), "bus('foo', None)")

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,8 @@ commands =
 [pytest]
 testpaths = tests
 addopts = -v --color=yes
+markers =
+    loader_may_raise: the test makes a loader raise a non-cantools exception on purpose
 
 [coverage:run]
 relative_files = True


### PR DESCRIPTION
Prerequisite for #827, split out as requested there.

The dbc, kcd, sym, arxml and cdd loaders now raise `cantools.database.errors.ParseError` whenever the input cannot be loaded, instead of a mix of `ValueError`, `KeyError`, `textparser.ParseError` and `xml.etree.ElementTree.ParseError`. Message text is unchanged, with two exceptions: `num()` in `formats/utils.py` had an unreachable fallback, so a bad number now gets its intended message rather than Python's `float()` one; and the three cdd `KeyError`s lose the quotes `str(KeyError)` adds.

`NotImplementedError` for the unsupported ARXML direction in `ecu_extract_loader.py` is kept as is pending the question on #827; two converted sites in `system_loader.py` ("only AUTOSAR 3 and 4", "non-canonical references not yet supported") read as unsupported rather than malformed and can flip with it.

`load_string()` in `database/__init__.py` is not touched; #827 will be rebased on top of this.
