### PR TITLE
add support for float back to _load_bus

### DIFF
--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -1991,13 +1991,7 @@ def _load_bus(attributes: DbcAttributes, comments: DbcComments) -> Bus | None:
     bus_baudrate_attr = attributes.database.get('Baudrate')
     bus_baudrate = None
     if bus_baudrate_attr is not None:
-        try:
-            bus_baudrate = dbc_assert_type(bus_baudrate_attr.value, int)
-        except ParseError as original_error:
-            try:
-                bus_baudrate = int(dbc_assert_type(bus_baudrate_attr.value, float))
-            except ParseError as second_error:
-                raise second_error from original_error
+        bus_baudrate = int(float(bus_baudrate_attr.value))
 
     bus_comment = comments.bus
 

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -1991,7 +1991,13 @@ def _load_bus(attributes: DbcAttributes, comments: DbcComments) -> Bus | None:
     bus_baudrate_attr = attributes.database.get('Baudrate')
     bus_baudrate = None
     if bus_baudrate_attr is not None:
-        bus_baudrate = dbc_assert_type(bus_baudrate_attr.value, int)
+        try:
+            bus_baudrate = dbc_assert_type(bus_baudrate_attr.value, int)
+        except ParseError as original_error:
+            try:
+                bus_baudrate = int(dbc_assert_type(bus_baudrate_attr.value, float))
+            except ParseError as second_error:
+                raise second_error from original_error
 
     bus_comment = comments.bus
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -299,6 +299,15 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message.signals[0].is_float, False)
         self.assertEqual(message.signals[0].length, 64)
 
+    def test_dbc_load_bus_float_baudrate(self):
+        db = cantools.database.load_string(
+            'VERSION "1.0"\n'
+            'BA_DEF_ "Baudrate" FLOAT 0 1000000;\n'
+            'BA_ "Baudrate" 500000.0;\n')
+
+        self.assertEqual(len(db.buses), 1)
+        self.assertEqual(db.buses[0].baudrate, 500000)
+
     def test_foobar_encode_decode(self):
         db = cantools.database.Database()
         db.add_dbc_file('tests/files/dbc/foobar.dbc')


### PR DESCRIPTION
Version 43.0.0 removed support for FLOAT type bus baudrate. My use case specifies a FLOAT in the dbc even though it does not have any fractional elements. I am happy to do a validation of the decimal here to make sure that its `.0` but wanted to start with the simplest fix.