### PR TITLE
DBC cleanup, part 12: rename `{Attribute,EnvironmentVariable}` to `Dbc{Attribute,EnvironmentVariable}`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -315,8 +315,8 @@ nitpick_ignore = [
     ("py:class", "SignalValueType"),
     ("py:class", "cantools.typechecking.SignalValueType"),
     ("py:class", "type_sort_signals"),
-    ("py:class", "AttributeType"),
-    ("py:class", "AttributeDefinitionType"),
-    ("py:class", "cantools.database.can.formats.dbc.attribute_definition.AttributeValueTypeVar"),
+    ("py:class", "DbcAttributeType"),
+    ("py:class", "DbcAttributeDefinitionType"),
+    ("py:class", "cantools.database.can.formats.dbc.dbc_attribute_definition.DbcAttributeValueTypeVar"),
     ("py:class", "DbcRelationAttributes"),
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,12 +40,12 @@ Functions and classes
 .. autoclass:: cantools.database.can.signal_group.SignalGroup
     :members:
 
-.. autoclass:: cantools.database.can.formats.dbc.attribute_definition.AttributeDefinition
+.. autoclass:: cantools.database.can.formats.dbc.dbc_attribute_definition.DbcAttributeDefinition
     :members:
 
-.. autodata:: cantools.database.can.formats.dbc.attribute_definition.AttributeValueTypeVar
+.. autodata:: cantools.database.can.formats.dbc.dbc_attribute_definition.DbcAttributeValueTypeVar
 
-.. autoclass:: cantools.database.can.formats.dbc.attribute.Attribute
+.. autoclass:: cantools.database.can.formats.dbc.dbc_attribute.DbcAttribute
     :members:
 
 .. autoclass:: cantools.database.can.formats.dbc.dbc_environment_variable.DbcEnvironmentVariable

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,7 +48,7 @@ Functions and classes
 .. autoclass:: cantools.database.can.formats.dbc.attribute.Attribute
     :members:
 
-.. autoclass:: cantools.database.can.formats.dbc.environment_variable.EnvironmentVariable
+.. autoclass:: cantools.database.can.formats.dbc.dbc_environment_variable.DbcEnvironmentVariable
     :members:
 
 .. autoclass:: cantools.database.can.formats.dbc.dbc_specifics.DbcSpecifics

--- a/src/cantools/database/can/formats/dbc/__init__.py
+++ b/src/cantools/database/can/formats/dbc/__init__.py
@@ -4,10 +4,10 @@ from .attribute_definition import (
     AttributeDefinitionType,
     AttributeValue,
 )
+from .dbc_environment_variable import DbcEnvironmentVariable
 from .dbc_loader import load_string
 from .dbc_specifics import DbcSpecifics
 from .dbc_writer import dump_string
-from .environment_variable import EnvironmentVariable
 
 __all__ = [
     "Attribute",
@@ -15,8 +15,8 @@ __all__ = [
     "AttributeDefinitionType",
     "AttributeType",
     "AttributeValue",
+    "DbcEnvironmentVariable",
     "DbcSpecifics",
-    "EnvironmentVariable",
     "dump_string",
     "load_string",
 ]

--- a/src/cantools/database/can/formats/dbc/__init__.py
+++ b/src/cantools/database/can/formats/dbc/__init__.py
@@ -1,8 +1,8 @@
-from .attribute import Attribute, AttributeType
-from .attribute_definition import (
-    AttributeDefinition,
-    AttributeDefinitionType,
-    AttributeValue,
+from .dbc_attribute import DbcAttribute, DbcAttributeType
+from .dbc_attribute_definition import (
+    DbcAttributeDefinition,
+    DbcAttributeDefinitionType,
+    DbcAttributeValue,
 )
 from .dbc_environment_variable import DbcEnvironmentVariable
 from .dbc_loader import load_string
@@ -10,11 +10,11 @@ from .dbc_specifics import DbcSpecifics
 from .dbc_writer import dump_string
 
 __all__ = [
-    "Attribute",
-    "AttributeDefinition",
-    "AttributeDefinitionType",
-    "AttributeType",
-    "AttributeValue",
+    "DbcAttribute",
+    "DbcAttributeDefinition",
+    "DbcAttributeDefinitionType",
+    "DbcAttributeType",
+    "DbcAttributeValue",
     "DbcEnvironmentVariable",
     "DbcSpecifics",
     "dump_string",

--- a/src/cantools/database/can/formats/dbc/dbc_attribute.py
+++ b/src/cantools/database/can/formats/dbc/dbc_attribute.py
@@ -1,18 +1,21 @@
 from typing import Generic
 
-from .attribute_definition import AttributeDefinition, AttributeValueTypeVar
+from .dbc_attribute_definition import (
+    DbcAttributeDefinition,
+    DbcAttributeValueTypeVar,
+)
 
 
-class Attribute(Generic[AttributeValueTypeVar]):
+class DbcAttribute(Generic[DbcAttributeValueTypeVar]):
     """An attribute that can be associated with nodes/messages/signals.
 
     """
 
     def __init__(self,
-                 value: AttributeValueTypeVar,
-                 definition: AttributeDefinition[AttributeValueTypeVar]) -> None:
-        self._value: AttributeValueTypeVar = value
-        self._definition: AttributeDefinition[AttributeValueTypeVar] = definition
+                 value: DbcAttributeValueTypeVar,
+                 definition: DbcAttributeDefinition[DbcAttributeValueTypeVar]) -> None:
+        self._value: DbcAttributeValueTypeVar = value
+        self._definition: DbcAttributeDefinition[DbcAttributeValueTypeVar] = definition
 
     @property
     def name(self) -> str:
@@ -23,7 +26,7 @@ class Attribute(Generic[AttributeValueTypeVar]):
         return self._definition.name
 
     @property
-    def value(self) -> AttributeValueTypeVar:
+    def value(self) -> DbcAttributeValueTypeVar:
         """The value that this attribute has.
 
         """
@@ -31,7 +34,7 @@ class Attribute(Generic[AttributeValueTypeVar]):
         return self._value
 
     @value.setter
-    def value(self, value: AttributeValueTypeVar) -> None:
+    def value(self, value: DbcAttributeValueTypeVar) -> None:
         self._value = value
 
     @property
@@ -45,7 +48,7 @@ class Attribute(Generic[AttributeValueTypeVar]):
         return f'{self._value}'
 
     @property
-    def definition(self) -> AttributeDefinition[AttributeValueTypeVar]:
+    def definition(self) -> DbcAttributeDefinition[DbcAttributeValueTypeVar]:
         """The attribute definition.
 
         """
@@ -56,4 +59,4 @@ class Attribute(Generic[AttributeValueTypeVar]):
         return f"attribute('{self.name}', {self.value})"
 
 
-AttributeType = Attribute[str] | Attribute[int] | Attribute[float]
+DbcAttributeType = DbcAttribute[str] | DbcAttribute[int] | DbcAttribute[float]

--- a/src/cantools/database/can/formats/dbc/dbc_attribute_definition.py
+++ b/src/cantools/database/can/formats/dbc/dbc_attribute_definition.py
@@ -1,9 +1,9 @@
 from typing import Generic, TypeVar
 
-AttributeValue = str | int | float
-AttributeValueTypeVar = TypeVar('AttributeValueTypeVar', str, int, float)
+DbcAttributeValue = str | int | float
+DbcAttributeValueTypeVar = TypeVar('DbcAttributeValueTypeVar', str, int, float)
 
-class AttributeDefinition(Generic[AttributeValueTypeVar]):
+class DbcAttributeDefinition(Generic[DbcAttributeValueTypeVar]):
     """A definition of an attribute that can be associated with attributes
     in nodes/messages/signals.
 
@@ -11,14 +11,14 @@ class AttributeDefinition(Generic[AttributeValueTypeVar]):
 
     def __init__(self,
                  name: str,
-                 default_value: AttributeValueTypeVar | None = None,
+                 default_value: DbcAttributeValueTypeVar | None = None,
                  kind: str | None = None,
                  type_name: str | None = None,
                  minimum: float | None = None,
                  maximum: float | None = None,
                  choices: list[str] | None = None) -> None:
         self._name = name
-        self._default_value: AttributeValueTypeVar | None = default_value
+        self._default_value: DbcAttributeValueTypeVar | None = default_value
         self._kind = kind
         self._type_name = type_name
         self._minimum = minimum
@@ -34,7 +34,7 @@ class AttributeDefinition(Generic[AttributeValueTypeVar]):
         return self._name
 
     @property
-    def default_value(self) -> AttributeValueTypeVar | None:
+    def default_value(self) -> DbcAttributeValueTypeVar | None:
         """The default value that this attribute has, or ``None`` if
         unavailable.
 
@@ -43,7 +43,7 @@ class AttributeDefinition(Generic[AttributeValueTypeVar]):
         return self._default_value
 
     @default_value.setter
-    def default_value(self, value: AttributeValueTypeVar | None) -> None:
+    def default_value(self, value: DbcAttributeValueTypeVar | None) -> None:
         self._default_value = value
 
     @property
@@ -117,4 +117,4 @@ class AttributeDefinition(Generic[AttributeValueTypeVar]):
     def __repr__(self) -> str:
         return f"attribute_definition('{self._name}', {self._default_value})"
 
-AttributeDefinitionType = AttributeDefinition[str] | AttributeDefinition[int] | AttributeDefinition[float]
+DbcAttributeDefinitionType = DbcAttributeDefinition[str] | DbcAttributeDefinition[int] | DbcAttributeDefinition[float]

--- a/src/cantools/database/can/formats/dbc/dbc_environment_variable.py
+++ b/src/cantools/database/can/formats/dbc/dbc_environment_variable.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     from .dbc_specifics import DbcSpecifics
 
 
-class EnvironmentVariable:
+class DbcEnvironmentVariable:
     """A CAN environment variable.
 
     """

--- a/src/cantools/database/can/formats/dbc/dbc_loader.py
+++ b/src/cantools/database/can/formats/dbc/dbc_loader.py
@@ -48,8 +48,8 @@ from .attribute_definition import (
     AttributeDefinitionType,
     AttributeValue,
 )
+from .dbc_environment_variable import DbcEnvironmentVariable
 from .dbc_specifics import DbcSpecifics
-from .environment_variable import EnvironmentVariable
 
 # make mypy complain if we assign a value to the empty dictionary but
 # do not pay the runtime performance penalty of MappingProxyType.
@@ -640,14 +640,14 @@ def _load_value_tables(tokens: DbcTokens) -> OrderedDict[str, Choices]:
     return value_tables
 
 
-def _load_environment_variables(tokens: DbcTokens, comments: DbcComments, attributes: DbcAttributes, attribute_definitions: OrderedDict[str, AttributeDefinitionType]) -> OrderedDict[str, EnvironmentVariable]:
-    environment_variables: OrderedDict[str, EnvironmentVariable] = OrderedDict()
+def _load_environment_variables(tokens: DbcTokens, comments: DbcComments, attributes: DbcAttributes, attribute_definitions: OrderedDict[str, AttributeDefinitionType]) -> OrderedDict[str, DbcEnvironmentVariable]:
+    environment_variables: OrderedDict[str, DbcEnvironmentVariable] = OrderedDict()
 
     for _envvar_tokens in tokens.get('EV_', []):
         envvar_tokens = dbc_assert_type(_envvar_tokens, list)
         short_name = dbc_assert_type(envvar_tokens[1], str)
         long_name = _get_envvar_long_name(attributes, short_name)
-        environment_variables[long_name] = EnvironmentVariable(
+        environment_variables[long_name] = DbcEnvironmentVariable(
             name=long_name,
             env_type=int(dbc_assert_type(envvar_tokens[3], str)),
             minimum=num(dbc_assert_type(envvar_tokens[5], str)),

--- a/src/cantools/database/can/formats/dbc/dbc_loader.py
+++ b/src/cantools/database/can/formats/dbc/dbc_loader.py
@@ -42,11 +42,11 @@ from ...node import Node
 from ...signal import Signal
 from ...signal_group import SignalGroup
 from ..utils import num
-from .attribute import Attribute, AttributeType
-from .attribute_definition import (
-    AttributeDefinition,
-    AttributeDefinitionType,
-    AttributeValue,
+from .dbc_attribute import DbcAttribute, DbcAttributeType
+from .dbc_attribute_definition import (
+    DbcAttributeDefinition,
+    DbcAttributeDefinitionType,
+    DbcAttributeValue,
 )
 from .dbc_environment_variable import DbcEnvironmentVariable
 from .dbc_specifics import DbcSpecifics
@@ -66,7 +66,7 @@ DbcTokens = dict[str, list[MatchObject]]
 TokenList = list[MatchObject]
 
 # attribute_name -> attribute_object
-DbcAttributeMap = OrderedDict[str, AttributeType]
+DbcAttributeMap = OrderedDict[str, DbcAttributeType]
 
 # The internalized attributes for the whole dataset returned by
 # _load_attributes()
@@ -137,7 +137,7 @@ MuxValues = dict[int, MuxSignalValues]
 
 # Attribute definition defaults from BA_DEF_DEF_ tokens:
 #   attrib_default_dict[attribute_name] -> attribute_value
-DbcAttributeDefaults = OrderedDict[str, AttributeValue]
+DbcAttributeDefaults = OrderedDict[str, DbcAttributeValue]
 
 # Value tables:
 #   value_tables_dict[value_table_name] -> { choice_int_value: choice_string_value }
@@ -167,7 +167,7 @@ FLOAT_SIGNAL_TYPES = [
     SIGNAL_TYPE_DOUBLE
 ]
 
-ATTRIBUTE_DEFINITION_VFRAMEFORMAT = AttributeDefinition(
+ATTRIBUTE_DEFINITION_VFRAMEFORMAT = DbcAttributeDefinition(
     name='VFrameFormat',
     default_value='StandardCAN',
     kind='BO_',
@@ -181,12 +181,12 @@ ATTRIBUTE_DEFINITION_VFRAMEFORMAT = AttributeDefinition(
              'reserved', 'reserved',
              'StandardCAN_FD', 'ExtendedCAN_FD'])
 
-def to_int(value: AttributeValue) -> int:
+def to_int(value: DbcAttributeValue) -> int:
     if isinstance(value, str):
         return int(Decimal(value))
     return int(value)
 
-def to_float(value: AttributeValue) -> float:
+def to_float(value: DbcAttributeValue) -> float:
     if isinstance(value, str):
         return float(Decimal(value))
     return float(value)
@@ -484,7 +484,7 @@ def _load_attribute_definition_defaults(tokens: DbcTokens) -> DbcAttributeDefaul
 
     for _attribute_definition_default_tokens in tokens.get('BA_DEF_DEF_', []):
         attribute_definition_default_tokens = dbc_assert_type(_attribute_definition_default_tokens, list)
-        attribute_definition_defaults[dbc_assert_type(attribute_definition_default_tokens[1], str)] = typing.cast('AttributeValue', attribute_definition_default_tokens[2])
+        attribute_definition_defaults[dbc_assert_type(attribute_definition_default_tokens[1], str)] = typing.cast('DbcAttributeValue', attribute_definition_default_tokens[2])
 
     return attribute_definition_defaults
 
@@ -498,27 +498,27 @@ def _load_relation_attribute_definition_defaults(tokens: DbcTokens) -> DbcAttrib
 
     for _relation_attribute_definition_default_tokens in tokens.get('BA_DEF_DEF_REL_', []):
         relation_attribute_definition_default_tokens = dbc_assert_type(_relation_attribute_definition_default_tokens, list)
-        relation_attribute_definition_defaults[dbc_assert_type(relation_attribute_definition_default_tokens[1], str)] = typing.cast('AttributeValue', relation_attribute_definition_default_tokens[2])
+        relation_attribute_definition_defaults[dbc_assert_type(relation_attribute_definition_default_tokens[1], str)] = typing.cast('DbcAttributeValue', relation_attribute_definition_default_tokens[2])
 
     return relation_attribute_definition_defaults
 
 
-def _load_attributes(tokens: DbcTokens, definitions: OrderedDict[str, AttributeDefinitionType]) -> DbcAttributes:
+def _load_attributes(tokens: DbcTokens, definitions: OrderedDict[str, DbcAttributeDefinitionType]) -> DbcAttributes:
     attributes = DbcAttributes()
 
-    def to_attribute_object(attribute_tokens: TokenList) -> AttributeType:
+    def to_attribute_object(attribute_tokens: TokenList) -> DbcAttributeType:
         raw_value = dbc_assert_type(attribute_tokens[3], str)
         definition = definitions[dbc_assert_type(attribute_tokens[1], str)]
 
         if definition.type_name in ['INT', 'HEX', 'ENUM']:
-            return Attribute[int](value=to_int(raw_value),
-                                  definition=typing.cast('AttributeDefinition[int]', definition))
+            return DbcAttribute[int](value=to_int(raw_value),
+                                     definition=typing.cast('DbcAttributeDefinition[int]', definition))
         elif definition.type_name == 'FLOAT':
-            return Attribute[float](value=to_float(raw_value),
-                                    definition=typing.cast('AttributeDefinition[float]', definition))
+            return DbcAttribute[float](value=to_float(raw_value),
+                                       definition=typing.cast('DbcAttributeDefinition[float]', definition))
 
-        return Attribute[str](value=raw_value,
-                              definition=typing.cast('AttributeDefinition[str]', definition))
+        return DbcAttribute[str](value=raw_value,
+                                 definition=typing.cast('DbcAttributeDefinition[str]', definition))
 
     for _attribute_tokens in tokens.get('BA_', []):
         attribute_tokens = dbc_assert_type(_attribute_tokens, list)
@@ -573,21 +573,21 @@ def _load_attributes(tokens: DbcTokens, definitions: OrderedDict[str, AttributeD
     return attributes
 
 
-def _load_relation_attributes(tokens: DbcTokens, definitions: OrderedDict[str, AttributeDefinitionType]) -> DbcRelationAttributes:
+def _load_relation_attributes(tokens: DbcTokens, definitions: OrderedDict[str, DbcAttributeDefinitionType]) -> DbcRelationAttributes:
     relation_attributes = DbcRelationAttributes()
 
-    def to_relation_attribute_object(attribute_tokens: TokenList, value: AttributeValue) -> AttributeType:
+    def to_relation_attribute_object(attribute_tokens: TokenList, value: DbcAttributeValue) -> DbcAttributeType:
         definition = definitions[dbc_assert_type(attribute_tokens[1], str)]
 
         if definition.type_name in ['INT', 'HEX', 'ENUM']:
-            return Attribute[int](value=to_int(value),
-                                  definition=typing.cast('AttributeDefinition[int]', definition))
+            return DbcAttribute[int](value=to_int(value),
+                                     definition=typing.cast('DbcAttributeDefinition[int]', definition))
         elif definition.type_name == 'FLOAT':
-            return Attribute[float](value=to_float(value),
-                                    definition=typing.cast('AttributeDefinition[float]', definition))
+            return DbcAttribute[float](value=to_float(value),
+                                       definition=typing.cast('DbcAttributeDefinition[float]', definition))
         else:
-            return Attribute[str](str(value),
-                                  definition=typing.cast('AttributeDefinition[str]', definition))
+            return DbcAttribute[str](str(value),
+                                     definition=typing.cast('DbcAttributeDefinition[str]', definition))
 
     for _relation_attribute_tokens in tokens.get('BA_REL_', []):
         relation_attribute_tokens = dbc_assert_type(_relation_attribute_tokens, list)
@@ -640,7 +640,7 @@ def _load_value_tables(tokens: DbcTokens) -> OrderedDict[str, Choices]:
     return value_tables
 
 
-def _load_environment_variables(tokens: DbcTokens, comments: DbcComments, attributes: DbcAttributes, attribute_definitions: OrderedDict[str, AttributeDefinitionType]) -> OrderedDict[str, DbcEnvironmentVariable]:
+def _load_environment_variables(tokens: DbcTokens, comments: DbcComments, attributes: DbcAttributes, attribute_definitions: OrderedDict[str, DbcAttributeDefinitionType]) -> OrderedDict[str, DbcEnvironmentVariable]:
     environment_variables: OrderedDict[str, DbcEnvironmentVariable] = OrderedDict()
 
     for _envvar_tokens in tokens.get('EV_', []):
@@ -785,7 +785,7 @@ def _load_signal_groups(tokens: DbcTokens, attributes: DbcAttributes) -> default
 def _load_signals(tokens: list[MatchObject],
                   comments: DbcComments,
                   attributes: DbcAttributes,
-                  definitions: OrderedDict[str, AttributeDefinitionType] | None,
+                  definitions: OrderedDict[str, DbcAttributeDefinitionType] | None,
                   choices: ChoicesDict,
                   signal_types: dict[int, dict[str, int]],
                   signal_multiplexer_values: MuxValues,
@@ -988,7 +988,7 @@ def _load_signals(tokens: list[MatchObject],
     return signals
 
 
-def _get_enum_vframeformat_definition(attribute_definition: AttributeDefinitionType) -> AttributeDefinition[str]:
+def _get_enum_vframeformat_definition(attribute_definition: DbcAttributeDefinitionType) -> DbcAttributeDefinition[str]:
     """Get VFrameFormat attribute definition as ENUM.
 
     VFrameFormat can be defined as either an INT or an ENUM attribute in DBC files. If it is not defined,
@@ -998,7 +998,7 @@ def _get_enum_vframeformat_definition(attribute_definition: AttributeDefinitionT
     """
 
     if attribute_definition.type_name != 'INT':
-        return dbc_assert_type(attribute_definition, AttributeDefinition)
+        return dbc_assert_type(attribute_definition, DbcAttributeDefinition)
 
     default_value = attribute_definition.default_value
     if default_value is None:
@@ -1012,7 +1012,7 @@ def _get_enum_vframeformat_definition(attribute_definition: AttributeDefinitionT
 def _load_messages(tokens: DbcTokens,
                    comments: DbcComments,
                    attributes: DbcAttributes,
-                   definitions: OrderedDict[str, AttributeDefinitionType],
+                   definitions: OrderedDict[str, DbcAttributeDefinitionType],
                    choices: ChoicesDict,
                    message_senders: dict[int, list[str]],
                    signal_types: dict[int, dict[str, int]],
@@ -1227,7 +1227,7 @@ def _load_bus(attributes: DbcAttributes, comments: DbcComments) -> Bus | None:
     return Bus(bus_name, baudrate=bus_baudrate, comment=bus_comment)
 
 
-def _load_nodes(tokens: DbcTokens, comments: DbcComments, attributes: DbcAttributes, attribute_definitions: OrderedDict[str, AttributeDefinitionType]) -> list[Node] | None:
+def _load_nodes(tokens: DbcTokens, comments: DbcComments, attributes: DbcAttributes, attribute_definitions: OrderedDict[str, DbcAttributeDefinitionType]) -> list[Node] | None:
     nodes = None
 
     for _node_tokens in tokens.get('BU_', []):
@@ -1241,10 +1241,10 @@ def _load_nodes(tokens: DbcTokens, comments: DbcComments, attributes: DbcAttribu
     return nodes
 
 
-def get_attribute_definitions_dict(definitions_tokens: list[MatchObject], defaults: DbcAttributeDefaults) -> OrderedDict[str, AttributeDefinitionType]:
-    result: OrderedDict[str, AttributeDefinitionType] = OrderedDict()
+def get_attribute_definitions_dict(definitions_tokens: list[MatchObject], defaults: DbcAttributeDefaults) -> OrderedDict[str, DbcAttributeDefinitionType]:
+    result: OrderedDict[str, DbcAttributeDefinitionType] = OrderedDict()
 
-    def convert_value(definition: AttributeDefinitionType, value: AttributeValue) -> AttributeValue:
+    def convert_value(definition: DbcAttributeDefinitionType, value: DbcAttributeValue) -> DbcAttributeValue:
         if definition.type_name in ['INT', 'HEX']:
             value = to_int(value)
         elif definition.type_name == 'FLOAT':
@@ -1257,17 +1257,17 @@ def get_attribute_definitions_dict(definitions_tokens: list[MatchObject], defaul
         kind_list = dbc_assert_type(definition_tokens[1], list)
         kind: str | None = kind_list[0] if len(kind_list) > 0 else None
 
-        definition = AttributeDefinition(name=dbc_assert_type(definition_tokens[2], str),
-                                         kind=kind,
-                                         type_name=dbc_assert_type(definition_tokens[3], str))
+        definition = DbcAttributeDefinition(name=dbc_assert_type(definition_tokens[2], str),
+                                            kind=kind,
+                                            type_name=dbc_assert_type(definition_tokens[3], str))
         values = dbc_assert_type(dbc_assert_type(definition_tokens[4], list)[0], list)
 
         if len(values) > 0:
             if definition.type_name == 'ENUM':
                 definition.choices = dbc_assert_type(values, list)
             elif definition.type_name in ['INT', 'FLOAT', 'HEX']:
-                definition.minimum = typing.cast('int | float', convert_value(definition, typing.cast('AttributeValue', values[0])))
-                definition.maximum = typing.cast('int | float', convert_value(definition, typing.cast('AttributeValue', values[1])))
+                definition.minimum = typing.cast('int | float', convert_value(definition, typing.cast('DbcAttributeValue', values[0])))
+                definition.maximum = typing.cast('int | float', convert_value(definition, typing.cast('DbcAttributeValue', values[1])))
 
         if definition.name in defaults:
             definition.default_value = convert_value(definition, defaults[definition.name])  # type: ignore[assignment]
@@ -1279,10 +1279,10 @@ def get_attribute_definitions_dict(definitions_tokens: list[MatchObject], defaul
     return result
 
 
-def get_relation_definitions_dict(definitions_tokens: list[MatchObject], defaults: DbcAttributeDefaults) -> OrderedDict[str, AttributeDefinitionType]:
-    result: OrderedDict[str, AttributeDefinitionType] = OrderedDict()
+def get_relation_definitions_dict(definitions_tokens: list[MatchObject], defaults: DbcAttributeDefaults) -> OrderedDict[str, DbcAttributeDefinitionType]:
+    result: OrderedDict[str, DbcAttributeDefinitionType] = OrderedDict()
 
-    def convert_value(definition: AttributeDefinitionType, value: AttributeValue) -> AttributeValue:
+    def convert_value(definition: DbcAttributeDefinitionType, value: DbcAttributeValue) -> DbcAttributeValue:
         if definition.type_name in ['INT', 'HEX']:
             value = to_int(value)
         elif definition.type_name == 'FLOAT':
@@ -1295,9 +1295,9 @@ def get_relation_definitions_dict(definitions_tokens: list[MatchObject], default
         kind_list = dbc_assert_type(definition_tokens[1], list)
         kind: str | None = kind_list[0] if len(kind_list) > 0 else None
 
-        definition = AttributeDefinition(name=dbc_assert_type(definition_tokens[2], str),
-                                         kind=kind,
-                                         type_name=dbc_assert_type(definition_tokens[3], str))
+        definition = DbcAttributeDefinition(name=dbc_assert_type(definition_tokens[2], str),
+                                            kind=kind,
+                                            type_name=dbc_assert_type(definition_tokens[3], str))
         values = dbc_assert_type(definition_tokens[4], list)
 
         if len(values) > 0:

--- a/src/cantools/database/can/formats/dbc/dbc_specifics.py
+++ b/src/cantools/database/can/formats/dbc/dbc_specifics.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from cantools.typechecking import Choices
 
-    from .attribute import AttributeType
-    from .attribute_definition import AttributeDefinitionType
+    from .dbc_attribute import DbcAttributeType
+    from .dbc_attribute_definition import DbcAttributeDefinitionType
     from .dbc_environment_variable import DbcEnvironmentVariable
     from .dbc_loader import DbcRelationAttributes
 
@@ -17,12 +17,12 @@ class DbcSpecifics:
 
     def __init__(self,
                  *,
-                 attributes: OrderedDict[str, AttributeType] | None = None,
-                 attribute_definitions: OrderedDict[str, AttributeDefinitionType] | None = None,
+                 attributes: OrderedDict[str, DbcAttributeType] | None = None,
+                 attribute_definitions: OrderedDict[str, DbcAttributeDefinitionType] | None = None,
                  environment_variables: OrderedDict[str, DbcEnvironmentVariable] | None = None,
                  value_tables: OrderedDict[str, Choices] | None = None,
                  relation_attributes: DbcRelationAttributes | None = None,
-                 relation_attribute_definitions: OrderedDict[str, AttributeDefinitionType] | None = None) -> None:
+                 relation_attribute_definitions: OrderedDict[str, DbcAttributeDefinitionType] | None = None) -> None:
         self._attributes = attributes or OrderedDict()
         self._attribute_definitions = attribute_definitions or OrderedDict()
         self._environment_variables = environment_variables or OrderedDict()
@@ -31,7 +31,7 @@ class DbcSpecifics:
         self._relation_attribute_definitions = relation_attribute_definitions or OrderedDict()
 
     @property
-    def attributes(self) -> OrderedDict[str, AttributeType]:
+    def attributes(self) -> OrderedDict[str, DbcAttributeType]:
         """The DBC specific attributes of the parent object (database, node,
         message or signal) as a dictionary.
 
@@ -40,7 +40,7 @@ class DbcSpecifics:
         return self._attributes
 
     @property
-    def attribute_definitions(self) -> OrderedDict[str, AttributeDefinitionType]:
+    def attribute_definitions(self) -> OrderedDict[str, DbcAttributeDefinitionType]:
         """The DBC specific attribute definitions as dictionary.
 
         """
@@ -74,7 +74,7 @@ class DbcSpecifics:
         return self._relation_attributes
 
     @property
-    def relation_attribute_definitions(self) -> OrderedDict[str, AttributeDefinitionType]:
+    def relation_attribute_definitions(self) -> OrderedDict[str, DbcAttributeDefinitionType]:
         """The DBC specific attribute definitions rel as dictionary.
 
         """

--- a/src/cantools/database/can/formats/dbc/dbc_specifics.py
+++ b/src/cantools/database/can/formats/dbc/dbc_specifics.py
@@ -10,8 +10,8 @@ if TYPE_CHECKING:
 
     from .attribute import AttributeType
     from .attribute_definition import AttributeDefinitionType
+    from .dbc_environment_variable import DbcEnvironmentVariable
     from .dbc_loader import DbcRelationAttributes
-    from .environment_variable import EnvironmentVariable
 
 class DbcSpecifics:
 
@@ -19,7 +19,7 @@ class DbcSpecifics:
                  *,
                  attributes: OrderedDict[str, AttributeType] | None = None,
                  attribute_definitions: OrderedDict[str, AttributeDefinitionType] | None = None,
-                 environment_variables: OrderedDict[str, EnvironmentVariable] | None = None,
+                 environment_variables: OrderedDict[str, DbcEnvironmentVariable] | None = None,
                  value_tables: OrderedDict[str, Choices] | None = None,
                  relation_attributes: DbcRelationAttributes | None = None,
                  relation_attribute_definitions: OrderedDict[str, AttributeDefinitionType] | None = None) -> None:
@@ -57,7 +57,7 @@ class DbcSpecifics:
         return self._value_tables
 
     @property
-    def environment_variables(self) -> OrderedDict[str, EnvironmentVariable]:
+    def environment_variables(self) -> OrderedDict[str, DbcEnvironmentVariable]:
         """An ordered dictionary of all environment variables. Only valid for
         DBC specifiers on database level.
 

--- a/src/cantools/database/can/formats/dbc/dbc_writer.py
+++ b/src/cantools/database/can/formats/dbc/dbc_writer.py
@@ -18,10 +18,10 @@ from ....utils import (
 )
 from ...message import Message
 from ...signal import Signal
-from .attribute import Attribute, AttributeType
-from .attribute_definition import (
-    AttributeDefinition,
-    AttributeDefinitionType,
+from .dbc_attribute import DbcAttribute, DbcAttributeType
+from .dbc_attribute_definition import (
+    DbcAttributeDefinition,
+    DbcAttributeDefinitionType,
 )
 from .dbc_loader import (
     ATTRIBUTE_DEFINITION_VFRAMEFORMAT,
@@ -103,44 +103,44 @@ FLOAT_LENGTH_TO_SIGNAL_TYPE = {
     64: SIGNAL_TYPE_DOUBLE
 }
 
-ATTRIBUTE_DEFINITION_LONG_ENVVAR_NAME = AttributeDefinition(
+ATTRIBUTE_DEFINITION_LONG_ENVVAR_NAME = DbcAttributeDefinition(
     'SystemEnvVarLongSymbol',
     default_value='',
     kind='EV_',
     type_name='STRING')
-ATTRIBUTE_DEFINITION_LONG_NODE_NAME = AttributeDefinition(
+ATTRIBUTE_DEFINITION_LONG_NODE_NAME = DbcAttributeDefinition(
     'SystemNodeLongSymbol',
     default_value='',
     kind='BU_',
     type_name='STRING')
 
-ATTRIBUTE_DEFINITION_LONG_MESSAGE_NAME = AttributeDefinition(
+ATTRIBUTE_DEFINITION_LONG_MESSAGE_NAME = DbcAttributeDefinition(
     'SystemMessageLongSymbol',
     default_value='',
     kind='BO_',
     type_name='STRING')
 
-ATTRIBUTE_DEFINITION_LONG_SIGNAL_NAME = AttributeDefinition(
+ATTRIBUTE_DEFINITION_LONG_SIGNAL_NAME = DbcAttributeDefinition(
     'SystemSignalLongSymbol',
     default_value='',
     kind='SG_',
     type_name='STRING')
 
-ATTRIBUTE_DEFINITION_BAUDRATE = AttributeDefinition(
+ATTRIBUTE_DEFINITION_BAUDRATE = DbcAttributeDefinition(
     name='Baudrate',
     default_value=125_000,
     type_name='INT',
     minimum=0,
     maximum=10*1024*1024)
 
-ATTRIBUTE_DEFINITION_CANFD_BRS = AttributeDefinition(
+ATTRIBUTE_DEFINITION_CANFD_BRS = DbcAttributeDefinition(
     name='CANFD_BRS',
     default_value='1',
     kind='BO_',
     type_name='ENUM',
     choices=['0', '1'])
 
-ATTRIBUTE_DEFINITION_GENMSGCYCLETIME = AttributeDefinition(
+ATTRIBUTE_DEFINITION_GENMSGCYCLETIME = DbcAttributeDefinition(
     name='GenMsgCycleTime',
     default_value=0,
     kind='BO_',
@@ -148,7 +148,7 @@ ATTRIBUTE_DEFINITION_GENMSGCYCLETIME = AttributeDefinition(
     minimum=0,
     maximum=2**16-1)
 
-ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE = AttributeDefinition[float](
+ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE = DbcAttributeDefinition[float](
     name='GenSigStartValue',
     default_value=0.0,
     kind='SG_',
@@ -184,7 +184,7 @@ def get_dbc_name(name: str) -> str:
     return name
 
 
-def get_attribute_definition(database: InternalDatabase, name: str, default: AttributeDefinitionType) -> AttributeDefinitionType:
+def get_attribute_definition(database: InternalDatabase, name: str, default: DbcAttributeDefinitionType) -> DbcAttributeDefinitionType:
     if database.dbc is None:
         database.dbc = DbcSpecifics()
 
@@ -194,28 +194,28 @@ def get_attribute_definition(database: InternalDatabase, name: str, default: Att
     return database.dbc.attribute_definitions[name]
 
 
-def get_long_envvar_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
+def get_long_envvar_name_attribute_definition(database: InternalDatabase) -> DbcAttributeDefinition[str]:
     return dbc_assert_type(get_attribute_definition(database,
                                                     'SystemEnvVarLongSymbol',
-                                                    ATTRIBUTE_DEFINITION_LONG_ENVVAR_NAME), AttributeDefinition)
+                                                    ATTRIBUTE_DEFINITION_LONG_ENVVAR_NAME), DbcAttributeDefinition)
 
 
-def get_long_node_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
+def get_long_node_name_attribute_definition(database: InternalDatabase) -> DbcAttributeDefinition[str]:
     return dbc_assert_type(get_attribute_definition(database,
                                                     'SystemNodeLongSymbol',
-                                                    ATTRIBUTE_DEFINITION_LONG_NODE_NAME), AttributeDefinition)
+                                                    ATTRIBUTE_DEFINITION_LONG_NODE_NAME), DbcAttributeDefinition)
 
 
-def get_long_message_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
+def get_long_message_name_attribute_definition(database: InternalDatabase) -> DbcAttributeDefinition[str]:
     return dbc_assert_type(get_attribute_definition(database,
                                                     'SystemMessageLongSymbol',
-                                                    ATTRIBUTE_DEFINITION_LONG_MESSAGE_NAME), AttributeDefinition)
+                                                    ATTRIBUTE_DEFINITION_LONG_MESSAGE_NAME), DbcAttributeDefinition)
 
 
-def get_long_signal_name_attribute_definition(database: InternalDatabase) -> AttributeDefinition[str]:
+def get_long_signal_name_attribute_definition(database: InternalDatabase) -> DbcAttributeDefinition[str]:
     return dbc_assert_type(get_attribute_definition(database,
                                                     'SystemSignalLongSymbol',
-                                                    ATTRIBUTE_DEFINITION_LONG_SIGNAL_NAME), AttributeDefinition)
+                                                    ATTRIBUTE_DEFINITION_LONG_SIGNAL_NAME), DbcAttributeDefinition)
 
 
 def try_remove_attribute(dbc: DbcSpecifics, name: str) -> None:
@@ -277,7 +277,7 @@ def make_node_names_unique(database: InternalDatabase, shorten_long_names: bool)
         if node.dbc is None:
             node.dbc = DbcSpecifics()
 
-        node.dbc.attributes['SystemNodeLongSymbol'] = Attribute(
+        node.dbc.attributes['SystemNodeLongSymbol'] = DbcAttribute(
             long_name,
             get_long_node_name_attribute_definition(database))
         node.name = short_name
@@ -298,7 +298,7 @@ def make_message_names_unique(database: InternalDatabase, shorten_long_names: bo
         if message.dbc is None:
             message.dbc = DbcSpecifics()
 
-        message.dbc.attributes['SystemMessageLongSymbol'] = Attribute(
+        message.dbc.attributes['SystemMessageLongSymbol'] = DbcAttribute(
             long_name,
             get_long_message_name_attribute_definition(database))
         message.name = short_name
@@ -345,7 +345,7 @@ def make_signal_names_unique(database: InternalDatabase, shorten_long_names: boo
             if signal.dbc is None:
                 signal.dbc = DbcSpecifics()
 
-            signal.dbc.attributes['SystemSignalLongSymbol'] = Attribute(
+            signal.dbc.attributes['SystemSignalLongSymbol'] = DbcAttribute(
                 long_name,
                 get_long_signal_name_attribute_definition(database))
             signal.name = short_name
@@ -371,7 +371,7 @@ def make_envvar_names_unique(database: InternalDatabase, shorten_long_names: boo
         if (long_name == short_name) or not shorten_long_names:
             continue
 
-        envvar.dbc.attributes['SystemEnvVarLongSymbol'] = Attribute(
+        envvar.dbc.attributes['SystemEnvVarLongSymbol'] = DbcAttribute(
             long_name,
             get_long_envvar_name_attribute_definition(database))
         envvar.name = short_name
@@ -599,7 +599,7 @@ def _dump_attribute_definitions(database: InternalDatabase) -> list[str]:
         if 'CANFD_BRS' not in definitions:
             definitions['CANFD_BRS'] = ATTRIBUTE_DEFINITION_CANFD_BRS
 
-    def get_kind(definition: AttributeDefinitionType) -> str:
+    def get_kind(definition: DbcAttributeDefinitionType) -> str:
         return '' if definition.kind is None else definition.kind + ' '
 
     for definition in definitions.values():
@@ -708,10 +708,9 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
         if baudrate_attribute_definition is None:
             raise ParseError('Database defines a baudrate but no definition for '
                              'the corresponding attribute')
-        database.dbc.attributes['Baudrate'] = Attribute[int](
+        database.dbc.attributes['Baudrate'] = DbcAttribute[int](
             value=int(baudrate),
-            definition=typing.cast('AttributeDefinition[int]', baudrate_attribute_definition))
-
+            definition=typing.cast('DbcAttributeDefinition[int]', baudrate_attribute_definition))
 
     for attribute in database.dbc.attributes.values():
         attributes.append(('dbc', attribute, None, None, None, None))
@@ -727,7 +726,7 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
                 attributes.append(('node', attribute, node, None, None, None))
 
     for message in database.messages:
-        msg_attributes = OrderedDict[str, AttributeType]()
+        msg_attributes = OrderedDict[str, DbcAttributeType]()
         if message.dbc is not None:
             msg_attributes = deepcopy(message.dbc.attributes)
 
@@ -738,9 +737,9 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
         gen_msg_cycle_time_def = database.dbc.attribute_definitions.get('GenMsgCycleTime')
 
         if gen_msg_cycle_time_def is not None and msg_cycle_time != gen_msg_cycle_time_def.default_value:
-            msg_attributes['GenMsgCycleTime'] = Attribute(
+            msg_attributes['GenMsgCycleTime'] = DbcAttribute(
                 value=msg_cycle_time,
-                definition=dbc_assert_type(gen_msg_cycle_time_def, AttributeDefinition),
+                definition=dbc_assert_type(gen_msg_cycle_time_def, DbcAttributeDefinition),
             )
         elif 'GenMsgCycleTime' in msg_attributes:
             del msg_attributes['GenMsgCycleTime']
@@ -766,7 +765,7 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
                 v_frame_format_str in v_frame_format_def.choices
                 and v_frame_format_str != v_frame_format_def.default_value
             ):
-                msg_attributes['VFrameFormat'] = Attribute(
+                msg_attributes['VFrameFormat'] = DbcAttribute(
                     value=str(v_frame_format_def.choices.index(v_frame_format_str)),
                     definition=v_frame_format_def,
                 )
@@ -790,7 +789,7 @@ def _dump_attributes(database: InternalDatabase, sort_signals: type_sort_signals
             if signal.raw_initial is None and 'GenSigStartValue' in sig_attributes:
                 del sig_attributes['GenSigStartValue']
             elif signal.raw_initial is not None:
-                sig_attributes['GenSigStartValue'] = Attribute[float](
+                sig_attributes['GenSigStartValue'] = DbcAttribute[float](
                     value=float(signal.raw_initial),
                     definition=ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE)
 

--- a/src/cantools/database/utils.py
+++ b/src/cantools/database/utils.py
@@ -24,7 +24,7 @@ from .errors import DecodeError, EncodeError
 if TYPE_CHECKING:
     from ..database import Database
     from ..database.can.formats.dbc import (
-        AttributeType,
+        DbcAttributeType,
         DbcEnvironmentVariable,
     )
     from ..database.can.message import Message
@@ -431,11 +431,11 @@ SORT_SIGNALS_DEFAULT: Final = 'default'
 type_sort_signals = Callable[[list["Signal"]], list["Signal"]] | Literal['default'] | None
 
 type_sort_attribute = \
-    tuple[Literal['dbc'],     "AttributeType", None,   None,      None,     None] | \
-    tuple[Literal['node'],    "AttributeType", "Node", None,      None,     None] | \
-    tuple[Literal['message'], "AttributeType", None,   "Message", None,     None] | \
-    tuple[Literal['signal'],  "AttributeType", None,   "Message", "Signal", None] | \
-    tuple[Literal['envvar'],  "AttributeType", None,   None,      None,     "DbcEnvironmentVariable"]
+    tuple[Literal['dbc'],     "DbcAttributeType", None,   None,      None,     None] | \
+    tuple[Literal['node'],    "DbcAttributeType", "Node", None,      None,     None] | \
+    tuple[Literal['message'], "DbcAttributeType", None,   "Message", None,     None] | \
+    tuple[Literal['signal'],  "DbcAttributeType", None,   "Message", "Signal", None] | \
+    tuple[Literal['envvar'],  "DbcAttributeType", None,   None,      None,     "DbcEnvironmentVariable"]
 
 type_sort_attributes = Callable[[list[type_sort_attribute]], list[type_sort_attribute]] | Literal['default'] | None
 

--- a/src/cantools/database/utils.py
+++ b/src/cantools/database/utils.py
@@ -23,7 +23,10 @@ from .errors import DecodeError, EncodeError
 
 if TYPE_CHECKING:
     from ..database import Database
-    from ..database.can.formats.dbc import AttributeType, EnvironmentVariable
+    from ..database.can.formats.dbc import (
+        AttributeType,
+        DbcEnvironmentVariable,
+    )
     from ..database.can.message import Message
     from ..database.can.node import Node
     from ..database.can.signal import Signal
@@ -432,7 +435,7 @@ type_sort_attribute = \
     tuple[Literal['node'],    "AttributeType", "Node", None,      None,     None] | \
     tuple[Literal['message'], "AttributeType", None,   "Message", None,     None] | \
     tuple[Literal['signal'],  "AttributeType", None,   "Message", "Signal", None] | \
-    tuple[Literal['envvar'],  "AttributeType", None,   None,      None,     "EnvironmentVariable"]
+    tuple[Literal['envvar'],  "AttributeType", None,   None,      None,     "DbcEnvironmentVariable"]
 
 type_sort_attributes = Callable[[list[type_sort_attribute]], list[type_sort_attribute]] | Literal['default'] | None
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -7,9 +7,9 @@ import unittest
 from unittest import mock
 
 import cantools
-from cantools.database.can.formats.dbc.attribute import Attribute
-from cantools.database.can.formats.dbc.attribute_definition import (
-    AttributeDefinition,
+from cantools.database.can.formats.dbc.dbc_attribute import DbcAttribute
+from cantools.database.can.formats.dbc.dbc_attribute_definition import (
+    DbcAttributeDefinition,
 )
 from cantools.database.utils import sort_signals_by_name
 
@@ -145,12 +145,12 @@ class CanToolsConvertFullTest(unittest.TestCase):
         db = cantools.database.load_file(fn_in)
 
         # make bus CAN FD
-        bus_type_def = AttributeDefinition("BusType",
-                                           type_name="STRING",
-                                           default_value="")
+        bus_type_def = DbcAttributeDefinition("BusType",
+                                              type_name="STRING",
+                                              default_value="")
         db.dbc.attribute_definitions["BusType"] = bus_type_def
-        db.dbc.attributes["BusType"] = Attribute(value="CAN FD",
-                                                 definition=bus_type_def)
+        db.dbc.attributes["BusType"] = DbcAttribute(value="CAN FD",
+                                                    definition=bus_type_def)
 
         # make message extended and FD
         msg = db.get_message_by_name("ExampleMessage")


### PR DESCRIPTION
Analogous to the `DbcSpecifics` class, IMO this makes it clearer that these classes are DBC-specific. 

This is the final PR of the DBC cleanup series (phew!).